### PR TITLE
Fix bower dependencies to avoid conflicts

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,6 @@
 {
-  "name": "slamdata-frontend",
-  "version": "0.0.0",
-  "homepage": "https://github.com/cryogenian/slamdata-frontend",
+  "name": "slamdata",
+  "homepage": "https://github.com/slamdata/slamdata",
   "authors": [
     "Maxim Zimaliev <zimaliev@yandex.ru>"
   ],
@@ -15,20 +14,20 @@
     "tests"
   ],
   "dependencies": {
-    "purescript-monoid": "~0.1.5",
+    "purescript-monoid": "~0.2.0",
     "purescript-virtual-dom": "~0.3.0",
     "purescript-dom": "~0.1.1",
-    "purescript-maps": "~0.2.0",
-    "purescript-tuples": "~0.2.3",
+    "purescript-maps": "~0.3.2",
+    "purescript-tuples": "~0.3.0",
     "bootstrap": "~3.3.2",
-    "purescript-signal": "~2.2.0",
-    "purescript-strings": "~0.4.2",
-    "purescript-datetime": "~0.2.0",
+    "purescript-signal": "~2.2.1",
+    "purescript-strings": "~0.4.3",
+    "purescript-datetime": "~0.3.1",
     "purescript-timers": "~0.0.8",
     "purescript-mocha": "~0.0.3",
     "purescript-chai": "~0.0.3",
-    "purescript-foldable-traversable": "~0.2.1",
-    "purescript-arrays": "~0.3.1",
+    "purescript-foldable-traversable": "~0.3.0",
+    "purescript-arrays": "~0.3.3",
     "purescript-refs": "~0.1.2",
     "purescript-debug-foreign": "~0.0.4",
     "purescript-random": "~0.1.2",
@@ -37,12 +36,5 @@
     "purescript-search": "https://github.com/cryogenian/purescript-search.git",
     "purescript-minimatch": "~0.1.0",
     "purescript-simple-dom": "2edd5c04b5cd02e097cb85e99df6e38a02a6a165"
-  },
-  "resolutions": {
-    "purescript-tuples": "~0.3.0",
-    "purescript-monoid": "~0.2.0",
-    "purescript-foldable-traversable": "~0.3.0",
-    "purescript-enums": "~0.4.0",
-    "purescript-maps": "~0.3.0"
   }
 }


### PR DESCRIPTION
This might be pointless if things are changing over to `purescript-halogen` anyway.