### PR TITLE
work on #25

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,6 +6,7 @@
     </title>
     <script type="text/javascript" src="./concated.js"></script>
     <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.2/css/bootstrap.min.css">
+    <link rel="stylesheet" href="./main.css"> 
   </head>
   <body style="padding-top: 70px;">
   </body>

--- a/public/main.css
+++ b/public/main.css
@@ -1,0 +1,19 @@
+.search-input {
+    width: 100%;
+}
+
+.search-input.input-group span.input-group-btn {
+    width: 34px;
+}
+
+.breadcrumb {
+    background-color: white;
+}
+
+.results.list-group .list-group-item {
+    border-right: none;
+    border-left: none;
+    border-radius: 0;
+    padding-top: 14px;
+    padding-bottom: 14px;
+}

--- a/src/Controller/Driver.purs
+++ b/src/Controller/Driver.purs
@@ -61,9 +61,7 @@ routing = bothRoute <|> oneRoute <|> index
   where bothRoute = SortAndQ <$> sort <*> query
         oneRoute = Sort <$> sort
         index = pure Index
-        sort = R.lit "sort" *>
-               ((R.lit "asc" *> pure Ms.Asc) <|> (R.lit "desc" *> pure Ms.Desc))
-
+        sort = R.eitherMatch (Ms.string2sort <$> R.param "sort")
         query = R.eitherMatch (S.mkQuery <<< U.decodeURIComponent <$> R.param "q")
 
 -- | Stream of routes 
@@ -173,7 +171,7 @@ searchPath query =
 --        Setters
 ----------------------------------------------------------------------
 sortRgx :: Rgx.Regex
-sortRgx = Rgx.regex "(sort/)([^/]*)" Rgx.noFlags
+sortRgx = Rgx.regex "(sort=)([^/&]*)" Rgx.noFlags
 
 qRgx :: Rgx.Regex
 qRgx = Rgx.regex "(q=)([^/&]*)" Rgx.noFlags
@@ -190,7 +188,7 @@ updateQ q =
 
 
 setSort :: Ms.Sort -> String
-setSort sort = "sort/" <> Ms.sort2string sort <> "/?q="
+setSort sort = "?sort=" <> Ms.sort2string sort <> "&q="
 
 -- | extract path from full hash
 getPath :: String -> String

--- a/src/Controller/Input.purs
+++ b/src/Controller/Input.purs
@@ -32,7 +32,9 @@ inner state input =
     M.SearchValidation v ->
       state{search = state.search{valid = v}}
     M.SearchSet s ->
-      state{search = state.search{value = s}}
+      if state.search.value == "" then 
+        state{search = state.search{value = s}}
+        else state
     M.SearchTimeout t ->
       state{search = state.search{timeout = Just t}}
     M.ItemHover ix h ->

--- a/src/Model/Item.purs
+++ b/src/Model/Item.purs
@@ -76,7 +76,7 @@ type Breadcrumb = {
 
 rootBreadcrumb :: Breadcrumb
 rootBreadcrumb = {
-  name: "root",
+  name: "Home",
   link: "/"
   }
 

--- a/src/Model/Sort.purs
+++ b/src/Model/Sort.purs
@@ -1,6 +1,8 @@
 -- | Sort direction
 module Model.Sort where
 
+import Data.Either
+
 data Sort = Asc | Desc
 
 -- | revese sort
@@ -11,6 +13,11 @@ notSort _ = Asc
 sort2string :: Sort -> String
 sort2string Asc = "asc"
 sort2string Desc = "desc"
+
+string2sort :: String -> Either String Sort
+string2sort "asc" = Right Asc
+string2sort "desc" = Right Desc
+string2sort _ = Left "incorrect sort string"
 
 instance eqSort :: Eq Sort where
   (==) Asc Asc = true

--- a/src/Utils/Halide.purs
+++ b/src/Utils/Halide.purs
@@ -35,3 +35,4 @@ target' (T.DataTarget i) = [ A.href "#",
 
 targetLink :: forall a b. b -> [A.Attr (Either a b)]
 targetLink b = target' $ (T.DataTarget <<< Right $ b)
+

--- a/src/View/Css.purs
+++ b/src/View/Css.purs
@@ -1,0 +1,9 @@
+module View.Css where
+
+import Halogen.HTML.Attributes (className, ClassName())
+
+searchInput :: ClassName
+searchInput = className "search-input"
+
+results :: ClassName
+results = className "results"


### PR DESCRIPTION
* `path` label removed
* width of search increased
* breadcrumb background is white now
* removed chevron-right in breadcrumbs
* renamed `root` -> `Home`
* changed links to icons (with `title` attributed for tooltip, adding bootstrap tooltip need slamdata/purescript-halogen#63)
* removed left and right borders from results
* search bar now not drop user caret position 
* `/sort/asc/?q=foo` -> `?sort=asc&q=foo`