### PR TITLE
Notebook routing 

### DIFF
--- a/MODULES.md
+++ b/MODULES.md
@@ -1,15 +1,5 @@
 # Module Documentation
 
-## Module App
-
-#### `app`
-
-``` purescript
-app :: forall e. Hl.UI M.Input Void M.Request (ajax :: Af.Ajax, file :: Uf.ReadFile, timer :: Tm.Timer | e)
-```
-
-
-
 ## Module Config
 
 #### `uploadUrl`
@@ -79,73 +69,6 @@ notebookExtension :: String
 
 ``` purescript
 newNotebookName :: String
-```
-
-
-
-## Module Main
-
-
-## Module Model
-
-
-Input, output messages and state
-
-#### `Input`
-
-``` purescript
-data Input
-  = Sorting Sort
-  | ItemsUpdate [Item] Sort
-  | ItemHover Number Boolean
-  | ItemSelect Number Boolean
-  | ItemAdd Item
-  | SearchValidation Boolean
-  | SearchSet String
-  | SearchTimeout Timeout
-  | SearchNextValue String
-  | SetPath String
-  | Resort 
-  | Remove Item
-```
-
-Input messages 
-
-#### `Request`
-
-``` purescript
-data Request
-  = GoToRoute String
-  | SetSort Sort
-  | SearchChange (Maybe Timeout) String
-  | Breadcrumb Breadcrumb
-  | SearchSubmit Search
-  | Open Item
-  | Delete Item
-  | Share Item
-  | Move Item
-  | Configure Item
-  | CreateNotebook State
-  | MountDatabase State
-  | CreateFolder State
-  | UploadFile Node State
-  | FileListChanged Node State
-```
-
-Request Messages 
-
-#### `State`
-
-``` purescript
-type State = { path :: String, breadcrumbs :: [Breadcrumb], items :: [Item], sort :: Sort, search :: Search }
-```
-
-Application state
-
-#### `initialState`
-
-``` purescript
-initialState :: State
 ```
 
 
@@ -227,16 +150,6 @@ trimQuotes :: String -> String
 
 
 
-## Module View
-
-#### `view`
-
-``` purescript
-view :: forall u node. (H.HTMLRepr node) => M.State -> node u (Either M.Input M.Request)
-```
-
-
-
 ## Module Api.Fs
 
 
@@ -292,7 +205,50 @@ deleteItem :: forall e. Mi.Item -> Aff.Aff (ajax :: Af.Ajax | e) Unit
 
 
 
-## Module Controller.Driver
+## Module App.File
+
+#### `app`
+
+``` purescript
+app :: forall e. Hl.UI M.Input Void M.Request (ajax :: Af.Ajax, file :: Uf.ReadFile, timer :: Tm.Timer | e)
+```
+
+
+
+## Module App.Notebook
+
+#### `app`
+
+``` purescript
+app :: forall e. H.UI M.Input Void M.Request e
+```
+
+
+
+## Module Controller.File
+
+
+File component main handler 
+
+#### `handler`
+
+``` purescript
+handler :: forall e. M.Request -> Aff.Aff (Hl.HalogenEffects (ajax :: Af.Ajax, file :: Uf.ReadFile, timer :: Tm.Timer | e)) M.Input
+```
+
+
+
+## Module Controller.Notebook
+
+#### `handler`
+
+``` purescript
+handler :: forall e. M.Request -> Aff (H.HalogenEffects e) M.Input
+```
+
+
+
+## Module Driver.File
 
 
 Module handles outer messages to `halogen` application
@@ -360,10 +316,41 @@ addToPath :: String -> String -> String
 Add to _path_ value in path-labeled predicate 
 
 
-## Module Controller.Input
+## Module Driver.Notebook
+
+#### `Routes`
+
+``` purescript
+data Routes
+  = Cell M.Path M.CellId Resume
+  | Notebook M.Path Resume
+```
 
 
-state update function 
+#### `routing`
+
+``` purescript
+routing :: R.Match Routes
+```
+
+
+#### `driver`
+
+``` purescript
+driver :: forall e. H.Driver M.Input e -> Eff (H.HalogenEffects e) Unit
+```
+
+
+## Module Entries.File
+
+
+## Module Entries.Notebook
+
+
+## Module Input.File
+
+
+file component state update function 
 
 #### `inner`
 
@@ -373,15 +360,76 @@ inner :: M.State -> M.Input -> M.State
 
 
 
-## Module Controller.Request
+## Module Input.Notebook
 
-
-Main app handler
-
-#### `handler`
+#### `updateState`
 
 ``` purescript
-handler :: forall e. M.Request -> Aff.Aff (Hl.HalogenEffects (ajax :: Af.Ajax, file :: Uf.ReadFile, timer :: Tm.Timer | e)) M.Input
+updateState :: M.State -> M.Input -> M.State
+```
+
+
+
+## Module Model.File
+
+
+Input, output messages and state for file component
+
+#### `Input`
+
+``` purescript
+data Input
+  = Sorting Sort
+  | ItemsUpdate [Item] Sort
+  | ItemHover Number Boolean
+  | ItemSelect Number Boolean
+  | ItemAdd Item
+  | SearchValidation Boolean
+  | SearchSet String
+  | SearchTimeout Timeout
+  | SearchNextValue String
+  | SetPath String
+  | Resort 
+  | Remove Item
+```
+
+Input messages 
+
+#### `Request`
+
+``` purescript
+data Request
+  = GoToRoute String
+  | SetSort Sort
+  | SearchChange (Maybe Timeout) String
+  | Breadcrumb Breadcrumb
+  | SearchSubmit Search
+  | Open Item
+  | Delete Item
+  | Share Item
+  | Move Item
+  | Configure Item
+  | CreateNotebook State
+  | MountDatabase State
+  | CreateFolder State
+  | UploadFile Node State
+  | FileListChanged Node State
+```
+
+Request Messages 
+
+#### `State`
+
+``` purescript
+type State = { path :: String, breadcrumbs :: [Breadcrumb], items :: [Item], sort :: Sort, search :: Search }
+```
+
+Application state
+
+#### `initialState`
+
+``` purescript
+initialState :: State
 ```
 
 
@@ -492,6 +540,69 @@ initialSearch :: Search
 
 ## Module Model.Notebook
 
+#### `Input`
+
+``` purescript
+data Input
+  = ViewNotebook String (List CellState)
+  | EditNotebook String (List CellState)
+  | ViewCell CellState
+  | EditCell CellState
+```
+
+
+#### `Request`
+
+``` purescript
+data Request
+  = Request 
+```
+
+
+#### `State`
+
+``` purescript
+data State
+  = OneCellView Resume CellState
+  | NotebookView Resume String (List CellState)
+```
+
+
+#### `CellState`
+
+``` purescript
+type CellState = { id :: String }
+```
+
+
+#### `initialCell`
+
+``` purescript
+initialCell :: CellState
+```
+
+
+#### `initialState`
+
+``` purescript
+initialState :: State
+```
+
+
+#### `CellId`
+
+``` purescript
+type CellId = String
+```
+
+
+#### `string2cellId`
+
+``` purescript
+string2cellId :: String -> Either String CellId
+```
+
+
 #### `CellType`
 
 ``` purescript
@@ -557,6 +668,38 @@ instance notebookRequestable :: Ar.Requestable Notebook
 
 
 
+## Module Model.Path
+
+#### `Path`
+
+``` purescript
+data Path
+  = Path (List String) String
+```
+
+
+#### `path2str`
+
+``` purescript
+path2str :: Path -> String
+```
+
+
+#### `decodeURIPath`
+
+``` purescript
+decodeURIPath :: String -> String
+```
+
+
+#### `encodeURIPath`
+
+``` purescript
+encodeURIPath :: String -> String
+```
+
+
+
 ## Module Model.Resource
 
 
@@ -598,6 +741,32 @@ Now only `IsForeign`. After switching to `purescript-affjax`
 will be `EncodeJson`
 
 
+## Module Model.Resume
+
+#### `Resume`
+
+``` purescript
+data Resume
+  = View 
+  | Edit 
+```
+
+
+#### `string2resume`
+
+``` purescript
+string2resume :: String -> Either String Resume
+```
+
+
+#### `resumeEq`
+
+``` purescript
+instance resumeEq :: Eq Resume
+```
+
+
+
 ## Module Model.Sort
 
 
@@ -624,6 +793,13 @@ revese sort
 
 ``` purescript
 sort2string :: Sort -> String
+```
+
+
+#### `string2sort`
+
+``` purescript
+string2sort :: String -> Either String Sort
 ```
 
 
@@ -731,6 +907,78 @@ request :: forall e i r. r -> EventHandler (Either i r)
 
 ``` purescript
 targetLink :: forall a b. b -> [A.Attr (Either a b)]
+```
+
+
+
+## Module View.Css
+
+#### `searchInput`
+
+``` purescript
+searchInput :: ClassName
+```
+
+
+#### `results`
+
+``` purescript
+results :: ClassName
+```
+
+
+#### `logo`
+
+``` purescript
+logo :: ClassName
+```
+
+
+#### `navCont`
+
+``` purescript
+navCont :: ClassName
+```
+
+
+#### `navIcon`
+
+``` purescript
+navIcon :: ClassName
+```
+
+
+#### `navLogo`
+
+``` purescript
+navLogo :: ClassName
+```
+
+
+#### `search`
+
+``` purescript
+search :: ClassName
+```
+
+
+
+## Module View.File
+
+#### `view`
+
+``` purescript
+view :: forall u node. (H.HTMLRepr node) => M.State -> node u (Either M.Input M.Request)
+```
+
+
+
+## Module View.Notebook
+
+#### `view`
+
+``` purescript
+view :: forall u node. (Ht.HTMLRepr node) => M.State -> node u (Either M.Input M.Request)
 ```
 
 

--- a/bower.json
+++ b/bower.json
@@ -32,8 +32,9 @@
     "purescript-minimatch": "~0.1.0",
     "purescript-affjax": "https://github.com/slamdata/purescript-affjax.git#310c8b51aaeb8544d41369ce2d1cd281ffa173e6",
     "purescript-argonaut": "https://github.com/cryogenian/purescript-argonaut.git#master",
-    "purescript-routing": "https://github.com/slamdata/purescript-routing.git#aaa82cc6f504d979a5f69d41ea50bf9a9e21d5f8",
     "purescript-lists": "~0.6.0",
-    "purescript-integers": "~0.0.1"
+    "purescript-integers": "~0.0.1",
+    "purescript-routing": "https://github.com/cryogenian/purescript-routing.git#master",
+    "purescript-lazy": "~0.3.1"
   }
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,29 +3,17 @@ var mandragora = require("mandragora-bucket/index.js"),
     less = require("gulp-less");
 
 
-mandragora(gulp, {
-    paths: {
-        bower: [
-            "bower_components/purescript-*/src/**/*.purs",
-            "bower_components/purescript-*/purescript-*/src/**/*.purs"
-        ],
-        test: ["test/**/*.purs"],
-        src: ["src/**/*.purs"]
+mandragora.config.entries = {
+    "Entries.File": {
+        "name": "file",
+        "dir": "public"
     },
-    entries: {
-        "Entries.File": {
-            "name": "file",
-            "dir": "public"
-        },
-        "Entries.Notebook": {
-            "name": "notebook",
-            "dir": "public"
-        }
-    },
-    docs: "MODULES.md",
-    tmpDir: "dist"
-});
-
+    "Entries.Notebook": {
+        "name": "notebook",
+        "dir": "public"
+    }
+};
+mandragora(gulp);
 
 gulp.task("less", function() {
     return gulp.src(["less/main.less"])

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "gulp": "^3.8.11",
     "gulp-less": "^3.0.2",
-    "mandragora-bucket": "^0.2.1",
+    "mandragora-bucket": "^0.2.3",
     "minimatch": "^2.0.1",
     "virtual-dom": "^2.0.0"
   }

--- a/public/index.html
+++ b/public/index.html
@@ -6,7 +6,9 @@
     </title>
     <script type="text/javascript" src="./file.js"></script>
     <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.2/css/bootstrap.min.css">
-    <link rel="stylesheet" href="./main.css"> 
+    
+    <link rel="stylesheet" href="./main.css">
+
   </head>
   <body>
   </body>

--- a/public/notebook.html
+++ b/public/notebook.html
@@ -6,7 +6,12 @@
     </title>
     <script type="text/javascript" src="./notebook.js"></script>
     <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.2/css/bootstrap.min.css">
-    <link rel="stylesheet" href="./main.css"> 
+    <link rel="stylesheet" href="./main.css">
+        <style>
+      body {
+      padding-left: 40px;
+      }
+    </style>
   </head>
   <body style="padding-top: 70px;">
   </body>

--- a/src/Api/Fs.purs
+++ b/src/Api/Fs.purs
@@ -27,7 +27,7 @@ import qualified Network.HTTP.Affjax as Af
 import qualified Network.HTTP.StatusCode as Sc
 
 import qualified Config as Config
-import qualified Model as M
+import qualified Model.File as M
 import qualified Model.Item as Mi
 import qualified Model.Resource as Mr
 import qualified Model.Notebook as Mn

--- a/src/App/File.purs
+++ b/src/App/File.purs
@@ -1,11 +1,11 @@
-module App where
+module App.File where
 
 import Data.Void
 import qualified Utils.File as Uf
-import qualified Model as M
-import qualified View as V
-import qualified Controller.Input as Ci
-import qualified Controller.Request as Cr
+import qualified Model.File as M
+import qualified View.File as V
+import qualified Input.File as Ci
+import qualified Controller.File as Cr
 import qualified Control.Timer as Tm
 import qualified Halogen as Hl
 import qualified Halogen.Signal as HS

--- a/src/App/Notebook.purs
+++ b/src/App/Notebook.purs
@@ -1,0 +1,19 @@
+module App.Notebook where
+
+import Data.Void
+import Control.Monad.Eff 
+import qualified Halogen as H
+import qualified Halogen.Signal as Hs
+
+import qualified View.Notebook as V
+import qualified Model.Notebook as M
+import qualified Controller.Notebook as C
+import qualified Input.Notebook as I
+
+app :: forall e. H.UI M.Input Void M.Request e
+app = {
+  view: V.view <$> Hs.stateful M.initialState I.updateState,
+  handler: C.handler,
+  renderer: H.defaultRenderer
+  }
+       

--- a/src/Config.purs
+++ b/src/Config.purs
@@ -10,7 +10,7 @@ dataUrl :: String
 dataUrl = "/data/fs/"
 
 notebookUrl :: String
-notebookUrl = "/notebook/"
+notebookUrl = "/notebook.html"
 
 
 searchTimeout :: Number

--- a/src/Controller/File.purs
+++ b/src/Controller/File.purs
@@ -1,5 +1,5 @@
--- | Main app handler
-module Controller.Request where
+-- | File component main handler 
+module Controller.File where
 
 import Control.Monad.Eff
 import Control.Monad.Eff.Class
@@ -24,10 +24,10 @@ import qualified Text.SlamSearch as S
 import qualified Routing.Hash as Rh
 import qualified Data.String as Str
 import qualified Data.DOM.Simple.Element as El
-import qualified Controller.Driver as Cd 
+import qualified Driver.File as Cd 
 import qualified Network.HTTP.Affjax as Af
 
-import qualified Model as M
+import qualified Model.File as M
 import qualified Model.Item as Mi
 import qualified Model.Notebook as Mn
 import qualified Model.Resource as Mr
@@ -160,7 +160,8 @@ handler r =
         -- open notebook or file
         open item isNew = U.newTab $ foldl (<>) ""
                           ([Config.notebookUrl,
-                            "#", Mi.itemPath item] <>
+                            "#", Mi.itemPath item,
+                            "/edit"] <>
                              if isNew then 
                              ["/?q=", U.encodeURIComponent ("select * from ...")]
                            else [])
@@ -182,4 +183,6 @@ handler r =
                             state.items /= -1 
                          then getNewName' name (i + 1)
                          else newName 
+
+
 

--- a/src/Controller/Notebook.purs
+++ b/src/Controller/Notebook.purs
@@ -1,0 +1,9 @@
+module Controller.Notebook where
+
+import Control.Monad.Aff
+import Data.List
+import qualified Halogen as H
+import qualified Model.Notebook as M
+
+handler :: forall e. M.Request -> Aff (H.HalogenEffects e) M.Input
+handler r = pure $ M.ViewNotebook "" Nil

--- a/src/Driver/File.purs
+++ b/src/Driver/File.purs
@@ -1,6 +1,6 @@
 -- | Module handles outer messages to `halogen` application
 -- | Mostly consists of routing functions 
-module Controller.Driver (
+module Driver.File (
   outside,
   getPath,
   searchPath,
@@ -36,7 +36,7 @@ import qualified Text.SlamSearch.Types as S
 import qualified Text.SlamSearch.Printer as S
 import qualified Data.Minimatch as MM
 import qualified Control.Monad.Aff as Aff
-import qualified Model as M
+import qualified Model.File as M
 import qualified Model.Item as Mi
 import qualified Model.Sort as Ms
 import qualified Model.Resource as Mr

--- a/src/Driver/Notebook.purs
+++ b/src/Driver/Notebook.purs
@@ -1,0 +1,62 @@
+module Driver.Notebook where
+
+import Data.Either
+import Data.List
+import Control.Alt
+import Control.Apply
+import Control.Monad.Eff
+import Model.Resume
+
+import qualified Utils as U
+import qualified Data.String as Str
+import qualified Data.String.Regex as Rgx
+import qualified Halogen as H
+import qualified Routing as R
+import qualified Routing.Match as R
+import qualified Routing.Match.Class as R
+import qualified Routing.Hash as R
+import qualified Model.Notebook as M
+import qualified Model.Path as M
+
+data Routes 
+  = Cell M.Path M.CellId Resume
+  | Notebook M.Path Resume 
+
+routing :: R.Match Routes
+routing = Cell <$> notebook <*> (R.lit "cells" *> cellId) <*> resume
+          <|>
+          Notebook <$> notebook <*> resume
+  where notebook = M.Path <$> (oneSlash *> (R.list notName)) <*> name
+        oneSlash = R.lit ""
+        notebookName input =
+          if Str.indexOf ".slam" input == -1 then
+            Left input
+          else Right input
+        pathPart input =
+          if input == "" || Str.indexOf ".slam" input /= -1 then
+            Left "incorrect path part"
+          else Right input 
+               
+        name = R.eitherMatch (notebookName <$> R.str)
+        notName = R.eitherMatch (pathPart <$> R.str)
+
+        resume = (R.eitherMatch (string2resume <$> R.str)) <|> pure View
+        cellId = R.eitherMatch (M.string2cellId <$> R.str)
+
+-- Mock
+driver :: forall e. H.Driver M.Input e -> Eff (H.HalogenEffects e) Unit
+driver k =
+  R.matches' M.decodeURIPath routing \old new -> do
+    case new of 
+      Cell path id View -> k $ M.ViewCell (cell path id)
+      Cell path id Edit -> k $ M.EditCell (cell path id)
+      Notebook path View -> k $ M.ViewNotebook (M.path2str path) (cells path)
+      Notebook path Edit -> k $ M.EditNotebook (M.path2str path) (cells path)
+                            
+  where cell path id = {id: M.path2str path <> ":" <> id}
+        cells path =
+          (Cons (cell path "3")
+           (Cons (cell path "4")
+            Nil))
+
+

--- a/src/Entries/File.purs
+++ b/src/Entries/File.purs
@@ -3,8 +3,8 @@ module Entries.File where
 import Utils
 import Data.Tuple
 import qualified Halogen as Hl
-import qualified App as App
-import qualified Controller.Driver as Cd
+import qualified App.File as App
+import qualified Driver.File as D
 import Control.Monad.Aff
 import Control.Monad.Aff.Queue
 import Control.Monad.Eff.Class
@@ -15,4 +15,4 @@ main = onLoad $ void $ do
   Tuple node driver <- Hl.runUI App.app
   body <- bodyNode
   append body (convertToElement node)
-  Cd.outside driver
+  D.outside driver

--- a/src/Entries/Notebook.purs
+++ b/src/Entries/Notebook.purs
@@ -1,7 +1,15 @@
 module Entries.Notebook where
 
 import Debug.Trace
+import Utils
+import Data.Tuple
+import qualified Halogen as Hl
+import qualified App.Notebook as App
+import qualified Driver.Notebook as D
 
-main =
-  print "Notebook"
+main = onLoad $ void $ do
+  Tuple node driver <- Hl.runUI App.app
+  body <- bodyNode
+  append body (convertToElement node)
+  D.driver driver
        

--- a/src/Input/File.purs
+++ b/src/Input/File.purs
@@ -1,14 +1,16 @@
--- | state update function 
-module Controller.Input where
+-- | file component state update function 
+module Input.File where
 
 import Data.Maybe
+import Data.Either
 import Data.Foldable
-import qualified Model as M
+import Text.SlamSearch.Printer (strQuery)
+import Text.SlamSearch (mkQuery)
+import qualified Model.File as M
 import qualified Model.Item as M
 import qualified Data.Array as A
 import qualified Data.String as Str
 import qualified Data.List as L
-import Debug.Foreign
 
 inner :: M.State -> M.Input -> M.State
 inner state input =
@@ -33,7 +35,8 @@ inner state input =
     M.SearchValidation v ->
       state{search = state.search{valid = v}}
     M.SearchSet s ->
-      if state.search.nextValue /= s then
+      let nq = either (const "") id (strQuery <$> mkQuery state.search.nextValue)
+      in if nq /= s then
         state{search = state.search{value = s}}
         else state
     M.SearchTimeout t ->

--- a/src/Input/Notebook.purs
+++ b/src/Input/Notebook.purs
@@ -1,0 +1,14 @@
+module Input.Notebook where
+
+import qualified Model.Notebook as M
+import Model.Resume
+
+updateState :: M.State -> M.Input -> M.State
+updateState state input =
+  case input of
+    M.ViewNotebook id cs -> M.NotebookView View id cs
+    M.EditNotebook id cs -> M.NotebookView Edit id cs
+    M.ViewCell c -> M.OneCellView View c
+    M.EditCell c -> M.OneCellView Edit c
+
+

--- a/src/Model/File.purs
+++ b/src/Model/File.purs
@@ -1,5 +1,5 @@
--- | Input, output messages and state
-module Model where
+-- | Input, output messages and state for file component
+module Model.File where
 
 import Control.Timer (Timeout())
 import Data.Maybe

--- a/src/Model/Item.purs
+++ b/src/Model/Item.purs
@@ -5,12 +5,13 @@ import Control.Timer (Timeout())
 import Data.Foreign
 import Data.Foreign.Class
 import qualified Data.String.Regex as Rgx
+import qualified Data.String as Str
 import qualified Network.HTTP.Affjax.Request as Ar
 import Utils (trimQuotes)
 
 import Model.Sort
 import Model.Resource
-
+import Model.Path
 
 -- | Item in list
 
@@ -24,8 +25,13 @@ type Item = {
   }
 
 itemPath :: Item -> String
-itemPath item =
-  trimQuotes item.root <> trimQuotes item.name
+itemPath item = encodeURIPath $
+                leadingSlash $ 
+                trimQuotes item.root <> trimQuotes item.name
+  where leadingSlash input =
+          if Str.indexOf "/" input == 0 then
+            input
+            else "/" <> input 
 
 -- | link to upper directory
 up :: String

--- a/src/Model/Notebook.purs
+++ b/src/Model/Notebook.purs
@@ -1,5 +1,9 @@
 module Model.Notebook where
 
+import Data.Either
+import Data.List
+import qualified Data.String as Str
+
 import Data.Argonaut.Combinators
 import qualified Data.Argonaut.Core as Ac 
 import qualified Data.Argonaut.Decode as Ad
@@ -7,6 +11,36 @@ import qualified Data.Argonaut.Encode as Ae
 import qualified Data.Argonaut.Printer as Ap
 import qualified Network.HTTP.Affjax.Request as Ar
 
+
+import Model.Resume
+
+data Input
+  = ViewNotebook String (List CellState)
+  | EditNotebook String (List CellState)
+  | ViewCell CellState
+  | EditCell CellState
+    
+data Request = Request
+
+data State
+  = OneCellView Resume CellState
+  | NotebookView Resume String (List CellState)
+
+
+type CellState = {id :: String}
+
+initialCell :: CellState
+initialCell = {id: ""}
+
+initialState :: State
+initialState = NotebookView View "" Nil
+
+type CellId = String
+
+
+string2cellId :: String -> Either String CellId
+string2cellId "" = Left "incorrect cellid"
+string2cellId a = Right a 
 
 data CellType
   = Evaluate

--- a/src/Model/Path.purs
+++ b/src/Model/Path.purs
@@ -1,0 +1,26 @@
+module Model.Path where
+
+import Data.List
+import Utils (encodeURIComponent, decodeURIComponent)
+import qualified Data.String as Str
+import qualified Data.String.Regex as Rgx
+
+data Path = Path (List String) String
+
+path2str :: Path -> String
+path2str (Path lst name) =
+  "/" <> (Str.joinWith "/" $ toArray lst) <> "/" <> name
+
+
+decodeURIPath :: String -> String
+decodeURIPath uri =
+  decodeURIComponent $
+  Rgx.replace (Rgx.regex "\\+" Rgx.noFlags{global=true}) " " uri
+
+encodeURIPath :: String -> String
+encodeURIPath path =
+  Str.joinWith "/" $
+  Str.joinWith "+" <$>
+  (encodeURIComponent <$>) <$>
+  Str.split " " <$>
+  Str.split "/" path

--- a/src/Model/Resume.purs
+++ b/src/Model/Resume.purs
@@ -1,0 +1,16 @@
+module Model.Resume where
+
+import Data.Either
+
+data Resume = View | Edit
+
+string2resume :: String -> Either String Resume
+string2resume "view" = Right View
+string2resume "edit" = Right Edit
+string2resume _ = Left "incorrect resume string"
+
+instance resumeEq :: Eq Resume where
+  (==) View View = true
+  (==) Edit Edit = true
+  (==) _ _ = false
+  (/=) a b = not $ a == b

--- a/src/Utils.purs
+++ b/src/Utils.purs
@@ -13,6 +13,7 @@ import Data.DOM.Simple.Types (HTMLElement(), DOMEvent())
 import Data.DOM.Simple.Document (body)
 import Data.DOM.Simple.Window (globalWindow, document)
 import Data.DOM.Simple.Events (addUIEventListener, UIEventType(..))
+import qualified Data.String as Str
 import qualified Data.String.Regex as Rgx
 
 -- I think that we will be able to switch from `purescript-simple-dom`
@@ -77,3 +78,6 @@ trimQuotes :: String -> String
 trimQuotes input = Rgx.replace start "" $ Rgx.replace end "" input
   where start = Rgx.regex "^\"" Rgx.noFlags
         end = Rgx.regex "\"$" Rgx.noFlags
+
+
+

--- a/src/View/File.purs
+++ b/src/View/File.purs
@@ -1,11 +1,11 @@
-module View (view) where
+module View.File (view) where
 
 import Data.Either
 import Data.Tuple
 import Data.Monoid (mempty)
 import Data.Array
 import Utils.Halide (back, request, targetLink)
-import qualified Model as M
+import qualified Model.File as M
 import qualified Model.Item as M
 import qualified Model.Sort as Ms
 import qualified Model.Resource as Mr

--- a/src/View/Notebook.purs
+++ b/src/View/Notebook.purs
@@ -1,0 +1,32 @@
+module View.Notebook (view) where
+
+import Data.Either
+import Data.List
+
+import qualified Halogen.HTML as Ht
+import qualified Model.Notebook as M
+import qualified Model.Resume as M
+
+view :: forall u node. (Ht.HTMLRepr node) => M.State ->
+        node u (Either M.Input M.Request)
+view state =
+  case state of
+    M.OneCellView resume cellState -> viewCell resume cellState
+    M.NotebookView resume id cells ->
+      Ht.div_ $
+      [Ht.p_ [Ht.text $ "notebook path: " <> id],
+       Ht.p_ [Ht.text $ "cells in notebook: "]] <>
+      (toArray (viewCell resume <$> cells))
+
+
+viewCell :: forall u node. (Ht.HTMLRepr node) => M.Resume -> M.CellState ->
+            node u (Either M.Input M.Request)
+viewCell resume state =
+  Ht.div_ $ 
+  editField resume <> 
+  [Ht.pre_ [Ht.text state.id]]
+  
+  where editField resume =
+          if resume == M.Edit then
+            [Ht.p_ [Ht.text "cell means to be editable"]]
+          else []


### PR DESCRIPTION
fixes #9 

This pr is only for routing, notebook and cell views and states mocked. 
To show that `view/edit` switches state there are string at top of cell view. 
To show that path is gotten correctly there is path string in cell and notebook views. 

I've deployed this build to http://slamdata.cryogenian.ru 

Because of mocks you can go to any path like 
* `notebook.html#/foo/bar/baz/quux.slam/view` 
* `notebook.html#/foo/bar/baz/quux.slam/edit`
* `notebook.html#/foo/bar/baz/quux.slam/cells/any+string/view`
* `notebook.html#/foo/bar/baz/quux.slam/cells/any+string/edit`