### PR TITLE
Bidirectional connection URI updates

### DIFF
--- a/less/bootstrap-overloads.less
+++ b/less/bootstrap-overloads.less
@@ -2,6 +2,14 @@
     background-color: white;
 }
 
+.alert {
+    padding: 10px 12px;
+}
+
+.alert-dismissable {
+    padding-right: 32px;
+}
+
 .alert.alert-danger {
     margin-bottom: 0;
     margin-top: 10px;

--- a/less/dialog/mount.less
+++ b/less/dialog/mount.less
@@ -1,8 +1,17 @@
 .dialog-mount {
 
+    .form-group {
+        margin-bottom: 0;
+        +.form-group {
+            margin-top: 15px;
+        }
+    }
+
+
     label {
         line-height: 34px;
         width: 100%;
+        margin-bottom: 0;
         span {
             width: 100px;
             display: block;
@@ -16,8 +25,13 @@
         }
     }
 
-    .mount-uri label {
-        line-height: 125%;
+    .mount-uri {
+        label {
+            line-height: 125%;
+        }
+        input {
+            background: #eee;
+        }
     }
 
     .mount-host-list {
@@ -38,6 +52,9 @@
             label span {
                 visibility: hidden;
             }
+            +.mount-host {
+                margin-top: 5px;
+            }
         }
         .mount-host:first-child label span {
             visibility: visible;
@@ -52,6 +69,7 @@
         }
         th {
             width: 50%;
+            border-bottom-width: 1px;
         }
         td {
             padding: 0px;
@@ -62,10 +80,15 @@
                 width: 100%;
             }
         }
+        margin-bottom: 0;
     }
 
     .mount-props-scrollbox {
         max-height: 110px;
         overflow: auto;
+    }
+
+    .alert {
+        height: 42px;
     }
 }

--- a/src/Input/File/Mount.purs
+++ b/src/Input/File/Mount.purs
@@ -3,38 +3,52 @@ module Input.File.Mount
   , inputMount
   ) where
 
-import Data.Array (filter)
-import Data.Maybe (Maybe(..), fromMaybe, maybe)
+import Data.Array (filter, replicate)
+import Data.Char (fromCharCode)
 import Data.Either (Either(..))
+import Data.Maybe (Maybe(..), fromMaybe, maybe, isJust)
+import Data.Foldable (any)
 import Model.File.Dialog (Dialog(MountDialog))
-import Model.File.Dialog.Mount (MountDialogRec(), MountHostRec(), MountPropRec(), initialMountHost, initialMountProp)
-import Utils.ConnectionURI (parse)
+import Model.File.Dialog.Mount (MountDialogRec(), MountHostRec(), MountPropRec(), initialMountDialog, initialMountHost, initialMountProp)
+import Utils.ConnectionURI (parse, toURI)
 import qualified Data.String as Str
+import qualified Data.String.Regex as Rx
 
 data MountInput
   = ValueChanged (MountDialogRec -> MountDialogRec)
   | UpdateConnectionURI String
+  | ClearMessage
 
 inputMount :: Dialog -> MountInput -> Dialog
 inputMount (MountDialog d) (ValueChanged fn) =
   let d' = fn d
-  in MountDialog d' { hosts = (filter (not <<< isEmptyHost) d'.hosts) ++ [initialMountHost]
-                    , props = (filter (not <<< isEmptyProp) d'.props) ++ [initialMountProp]
+      hosts = (filter (not <<< isEmptyHost) d'.hosts)
+      props = (filter (not <<< isEmptyProp) d'.props)
+      connectionURI = mkURI d'.path d'.user d'.password hosts props
+  in MountDialog d' { connectionURI = connectionURI
+                    , hosts = hosts ++ [initialMountHost]
+                    , props = props ++ [initialMountProp]
                     , message = Nothing
+                    , valid = true
                     }
+inputMount (MountDialog d) (UpdateConnectionURI "") = MountDialog initialMountDialog
 inputMount (MountDialog d) (UpdateConnectionURI uri) =
   MountDialog $ case parse uri of
     Left _ -> d { connectionURI = uri
-                , message = Just "Pasted value does not appear to be a valid MongoDB connection URI"
+                , message = Just "Pasted value does not appear to be a valid connection URI"
+                , valid = false
                 }
     Right params ->
       d { connectionURI = uri
-        , name = fromMaybe "" params.name
+        , path = fromMaybe "" params.name
         , user = maybe "" (_.user) params.credentials
         , password = maybe "" (_.password) params.credentials
         , hosts = ((\host -> host { port = fromMaybe "" host.port }) <$> params.hosts) ++ [initialMountHost]
         , props = params.props ++ [initialMountProp]
+        , message = Nothing
+        , valid = true
         }
+inputMount (MountDialog d) ClearMessage = MountDialog $ d { message = Nothing }
 inputMount dialog _ = dialog
 
 isEmptyHost :: MountHostRec -> Boolean
@@ -42,3 +56,28 @@ isEmptyHost h = h.host == "" && h.port == ""
 
 isEmptyProp :: MountPropRec -> Boolean
 isEmptyProp p = p.name == "" && p.value == ""
+
+mkURI :: String -> String -> String -> Array MountHostRec -> Array MountPropRec -> String
+mkURI name user password hosts props =
+  if any isValidHost hosts
+  then toURI { name: nonEmpty name
+             , credentials: { user: _, password: _ }
+                            <$> nonEmpty user
+                            <*> nonEmpty (hidePassword password)
+             , hosts: (\h -> h { port = nonEmpty h.port }) <$> hosts
+             , props: props
+             }
+  else ""
+  where
+  isValidHost :: MountHostRec -> Boolean
+  isValidHost { host: host } = isJust $ nonEmpty host
+
+nonEmpty :: String -> Maybe String
+nonEmpty s | Rx.test rxEmpty s = Nothing
+nonEmpty s = Just s
+
+rxEmpty :: Rx.Regex
+rxEmpty = Rx.regex "^\\s*$" Rx.noFlags
+
+hidePassword :: String -> String
+hidePassword s = Str.joinWith "" $ replicate (Str.length s) (Str.fromChar $ fromCharCode 8226)

--- a/src/Model/File/Dialog/Mount.purs
+++ b/src/Model/File/Dialog/Mount.purs
@@ -13,10 +13,12 @@ type MountDialogRec =
   , name :: String
   , connectionURI :: String
   , hosts :: [MountHostRec]
+  , path :: String
   , user :: String
   , password :: String
   , props :: [MountPropRec]
   , message :: Maybe String
+  , valid :: Boolean
   }
 
 type MountHostRec =
@@ -37,6 +39,9 @@ connectionURI = lens _.connectionURI (_ { connectionURI = _ })
 
 hosts :: LensP MountDialogRec [MountHostRec]
 hosts = lens _.hosts (_ { hosts = _ })
+
+path :: LensP MountDialogRec String
+path = lens _.path (_ { path = _ })
 
 user :: LensP MountDialogRec String
 user = lens _.user (_ { user = _ })
@@ -62,10 +67,12 @@ initialMountDialog =
   , name: ""
   , connectionURI: ""
   , hosts: [initialMountHost]
+  , path: ""
   , user: ""
   , password: ""
   , props: [initialMountProp]
   , message: Nothing
+  , valid: false
   }
 
 initialMountHost :: MountHostRec
@@ -84,6 +91,7 @@ eqMountDialog :: MountDialogRec -> MountDialogRec -> Boolean
 eqMountDialog m1 m2 = m1.name == m2.name
                    && length m1.hosts == length m2.hosts
                    && and (m1.hosts `zipWith eqMountHost` m2.hosts)
+                   && m1.path == m2.path
                    && m1.user == m2.user
                    && m1.password == m2.password
                    && length m1.props == length m2.props

--- a/src/Utils/ConnectionURI.purs
+++ b/src/Utils/ConnectionURI.purs
@@ -4,6 +4,7 @@ module Utils.ConnectionURI
   , HostParams()
   , PropParams()
   , parse
+  , toURI
   ) where
 
 import Control.Alt ((<|>))
@@ -67,11 +68,12 @@ parseCredentials = lookAhead (string "@") *> ({ user: _, password: _ }
 
 parseHost :: Parser { host :: String, port :: Maybe String }
 parseHost = { host: _, port: _ }
-  <$> (joinWith "" <$> manyTill anyChar (string ":" <|> string "/" <|> (lookAhead (string ","))))
+  <$> (joinWith "" <$> manyTill anyChar (string ":" <|> (lookAhead (string "/" <|> string ","))))
   <*> (optionMaybe $ joinWith "" <$> many1 anyDigit)
 
 parseDatabaseName :: Parser String
-parseDatabaseName =
+parseDatabaseName = do
+  string "/"
   joinWith "" <$> manyTill anyChar ((string "?" *> pure unit) <|> eof)
 
 parseProp :: Parser { name :: String, value :: String }

--- a/src/View/Common.purs
+++ b/src/View/Common.purs
@@ -1,7 +1,12 @@
 module View.Common where
 
+import Data.Char (fromCharCode)
+import Data.String (fromChar)
 import qualified Halogen.HTML as H
 import qualified Halogen.HTML.Attributes as A
+import qualified Halogen.HTML.Events as E
+import qualified Halogen.HTML.Events.Handler as E
+import qualified Halogen.HTML.Events.Types as ET
 import qualified Halogen.Themes.Bootstrap3 as B
 import qualified Config as Config
 import qualified View.Css as Vc
@@ -13,7 +18,7 @@ row :: forall p i. [H.HTML p i ] -> H.HTML p i
 row = H.div [ A.classes [ B.row ] ]
 
 genericContainer :: forall p i. [A.ClassName] -> [A.ClassName] ->
-                    [H.HTML p i] -> H.HTML p i 
+                    [H.HTML p i] -> H.HTML p i
 genericContainer wrapperClasses contentClasses nodes =
   H.div [ A.classes wrapperClasses ]
   [ row [ H.div [ A.classes contentClasses ]
@@ -54,3 +59,9 @@ logo = H.div [ A.classes [ B.colXs3, Vc.navLogo ] ]
                            []
                    ]
              ]
+
+closeButton :: forall p i. (ET.Event ET.MouseEvent -> E.EventHandler i) -> H.HTML p i
+closeButton handler =
+  H.button [ A.class_ B.close
+           , E.onClick handler ]
+           [ H.span_ [ H.text (fromChar $ fromCharCode 215) ] ]


### PR DESCRIPTION
A dismissable error for unparseable connection strings is shown now too. This does change the size of the dialog, contrary to the requirement in #32, but without leaving a constant gap at the bottom I'm not sure how else we'd do this?

Resolves #32 again (hopefully once and for all!).