### PR TITLE
Notebook menu component

### DIFF
--- a/src/Api/Fs.purs
+++ b/src/Api/Fs.purs
@@ -17,7 +17,7 @@ import Network.HTTP.RequestHeader (RequestHeader(..))
 import Network.HTTP.Method (Method(MOVE))
 import Data.Argonaut.Parser (jsonParser)
 
-import Model.Notebook (Notebook())
+import Model.Notebook.Domain (Notebook())
 import Model.Resource
 import Config
 import Data.Path.Pathy

--- a/src/App/Notebook/Ace.purs
+++ b/src/App/Notebook/Ace.purs
@@ -1,15 +1,18 @@
-module App.Notebook.Ace (acePostRender, ref) where
+module App.Notebook.Ace (acePostRender, ref, AceKnot()) where
 
 import Input.Notebook (Input(..))
 
 import Control.Bind ((>=>))
 import Control.Monad (when)
 import Control.Monad.Eff (Eff())
-import Control.Monad.Eff.Ref (Ref(), RefVal(), readRef, newRef, writeRef)
+import Control.Monad.Eff.Ref (Ref(), RefVal(), readRef, newRef, modifyRef)
 import Data.Foldable (for_)
 
+import Data.Tuple
 import Data.Either (either)
-import Data.Maybe (isNothing, maybe)
+import Data.Maybe (maybe, Maybe(..))
+
+
 import qualified Data.Map as M
 
 import DOM
@@ -20,50 +23,79 @@ import Halogen
 
 import Ace
 import Ace.EditSession (getValue, setMode)
-import Ace.Types (EditSession(), EAce(), Editor())
-import Model.Notebook (CellId(), string2cellId)
-
+import Ace.Selection (getRange)
+import Ace.Types (EditSession(), EAce(), Editor(), TextMode())
 import qualified Ace.Editor as Editor
 
-modeByCellTag :: String -> String
+import Model.Notebook.Cell (CellId(), string2cellId)
+
+import Optic.Core
+import Optic.Refractor.Lens 
+
+type AceKnot = Tuple CellId (M.Map CellId EditSession)
+
+foreign import markdownMode """
+  var markdownMode = "/ace/mode/markdown";
+""" :: TextMode
+foreign import plainTextMode """
+  var plainTextMode = "ace/mode/plain_text";
+""" :: TextMode
+
+modeByCellTag :: String -> TextMode
 modeByCellTag tag = case tag of
-  "markdown" -> "ace/mode/markdown"
-  _ -> "ace/mode/plain_text"
+  "markdown" -> markdownMode
+  _ -> plainTextMode
 
 
-initialize :: forall eff. RefVal (M.Map CellId EditSession) -> HTMLElement ->
+dataCellId :: String
+dataCellId = "data-cell-id"
+
+dataCellType :: String
+dataCellType = "data-cell-type"
+
+initialize :: forall eff. RefVal AceKnot -> HTMLElement ->
               Driver Input (ace :: EAce | eff) -> 
               Eff (HalogenEffects (ace :: EAce | eff)) Unit
 initialize m b d = do
   els <- getElementsByClassName "ace-container" b
-  m' <- readRef m
+  Tuple _ mr <- readRef m 
   for_ els \el -> do
-    cellId <- string2cellId <$> getAttribute "data-cell-id" el
+    cellId <- string2cellId <$> getAttribute dataCellId el
     flip (either (const $ pure unit)) cellId \cid -> do
-      when (isNothing $ M.lookup cid m') $ do
-        mode <- modeByCellTag <$> getAttribute "data-cell-type" el
-        editor <- Ace.editNode el ace
-        session <- Editor.getSession editor
-        setMode mode session
-        -- Chrome theme does useful highlighting of Markdown syntax.
-        Editor.setTheme "ace/theme/chrome" editor
+      mode <- modeByCellTag <$> getAttribute dataCellType el
+      editor <- Ace.editNode el ace
+      Editor.setTheme "ace/theme/chrome" editor
+      maybe (initialize' mode editor cid) (reinit editor) $ M.lookup cid mr 
+  where
+  initialize' :: _ -> _ -> CellId -> Eff _ Unit
+  initialize' mode editor cid = do
+    session <- createEditSession "" mode ace
+    Editor.focus editor
+    modifyRef m $ \x -> x # _2 %~ M.insert cid session
+    Editor.onFocus editor do
+      modifyRef m $ \x -> x # _1 .~ cid 
+      d $ SetActiveCell cid
 
-        writeRef m $ M.insert cid session m'
-        Editor.onFocus editor (d $ SetActiveCell cid)
+  reinit :: Editor -> EditSession -> Eff _ Unit
+  reinit editor session = do
+    Editor.setSession session editor
 
-handleInput :: forall eff. RefVal (M.Map CellId EditSession) -> Input ->
+
+handleInput :: forall eff. RefVal AceKnot -> Input ->
                Driver Input (ace :: EAce | eff) -> Eff (HalogenEffects (ace :: EAce | eff)) Unit
 handleInput m (RunCell cellId) d = do
-  m' <- readRef m
+  Tuple _ m' <- readRef m
   maybe (return unit) (getValue >=> d <<< AceContent cellId) $
     M.lookup cellId m'
+handleInput m (TrashCell cellId) _ = do
+  modifyRef m $ (\x -> x # _2 %~ M.delete cellId)
 handleInput _ _ _ = return unit
 
-acePostRender :: forall eff. RefVal (M.Map CellId EditSession) -> Input ->
+acePostRender :: forall eff. RefVal AceKnot -> Input ->
                  HTMLElement -> Driver Input (ace :: EAce | eff) -> Eff (HalogenEffects (ace :: EAce | eff)) Unit
 acePostRender m i b d = do
   initialize m b d
   handleInput m i d
 
-ref :: forall e.  Eff (ref :: Ref | e) (RefVal (M.Map CellId EditSession)) 
-ref = newRef M.empty
+ref :: forall e.  Eff (ref :: Ref | e) (RefVal AceKnot) 
+ref = newRef (Tuple 0 M.empty)

--- a/src/Controller/File.purs
+++ b/src/Controller/File.purs
@@ -32,7 +32,7 @@ import Model.File.Dialog.Mount (initialMountDialog)
 import Model.File.Dialog.Rename (initialRenameDialog)
 import Model.File.Item
 import Model.Resource (pathL, nameL, resourcePath)
-import Model.Notebook (emptyNotebook)
+import Model.Notebook.Domain (emptyNotebook)
 import Model.Sort (Sort())
 import Routing.Hash (getHash, modifyHash)
 import Utils (clearValue, select)

--- a/src/Controller/Notebook.purs
+++ b/src/Controller/Notebook.purs
@@ -12,12 +12,12 @@ import Control.Monad.Aff.Class
 import Control.Monad.Aff (attempt)
 import Model.Notebook.Menu (
   MenuNotebookSignal(..),
-  MenuEditSignal(..),
   MenuInsertSignal(..),
   MenuCellSignal(..),
   MenuHelpSignal(..),
   MenuSignal(..))
-import Model.Notebook (State(), CellType(..))
+import Model.Notebook (State(), activeCellId)
+import Model.Notebook.Cell (CellType(..))
 import Input.Notebook (Input(..))
 import Data.Inject1 (prj)
 import Debug.Foreign -- mark for grep -nr to not remove. mocking handlers
@@ -73,22 +73,18 @@ handleMenuNotebook signal = do
       >>= setLocation homeHash
   empty
 
-handleMenuCell :: forall e. MenuCellSignal -> I e
-handleMenuCell signal = do
-  liftEff $ fprint signal
-  empty
+handleMenuCell :: forall e. State -> MenuCellSignal -> I e
+handleMenuCell state signal =
+  case signal of
+    EvaluateCell -> pure $ RunCell (state ^. activeCellId)
+    DeleteCell -> pure $ TrashCell (state ^. activeCellId)
+    _ -> empty
 
 handleMenuInsert :: forall e. MenuInsertSignal -> I e
 handleMenuInsert ExploreInsert = pure $ AddCell Explore
 handleMenuInsert MarkdownInsert = pure $ AddCell Markdown
 handleMenuInsert QueryInsert = pure $ AddCell Query
 handleMenuInsert SearchInsert = pure $ AddCell Search
-
-handleMenuEdit :: forall e. MenuEditSignal -> I e
-handleMenuEdit signal = do
-  liftEff $ fprint signal
-  empty
-
 
 
 handleMenuHelp :: forall e. MenuHelpSignal -> I e
@@ -109,16 +105,14 @@ handleMenuHelp RequestSupportHelp = do
   empty
   
 
-handleMenuSignal :: forall e. MenuSignal -> I e
-handleMenuSignal signal =
+handleMenuSignal :: forall e. State -> MenuSignal -> I e
+handleMenuSignal state signal =
   maybe empty id $
   (handleMenuNotebook <$> prj signal)
   <|>
-  (handleMenuEdit <$> prj signal)
-  <|>
   (handleMenuInsert <$> prj signal)
   <|>
-  (handleMenuCell <$> prj signal)
+  (handleMenuCell state <$> prj signal)
   <|>
   (handleMenuHelp <$> prj signal)
 

--- a/src/Driver/Notebook/Routing.purs
+++ b/src/Driver/Notebook/Routing.purs
@@ -10,11 +10,12 @@ import Data.Path.Pathy ((</>), rootDir, dir, file)
 import Data.String (indexOf, length)
 import Data.Tuple (Tuple(..))
 import Model.Action (Action(..), string2action)
-import Model.Notebook (CellId(), string2cellId)
+import Model.Notebook.Cell (CellId(), string2cellId)
 import Model.Resource (Resource(), newNotebook, setPath, notebookPath)
 import Optic.Core ((.~))
 import Routing.Match (Match(), list, eitherMatch)
 import Routing.Match.Class (lit, str)
+
 
 data Routes
   = CellRoute Resource CellId Action

--- a/src/Entries/Notebook.purs
+++ b/src/Entries/Notebook.purs
@@ -8,9 +8,6 @@ import EffectTypes (NotebookAppEff())
 import Halogen (runUIWith)
 import Utils (onLoad, mountUI)
 import Ace.Types (EAce())
-
---import qualified Data.StrMap as M
---import qualified Data.Map as M
 import qualified Driver.Notebook as D
 
 
@@ -20,4 +17,4 @@ main = onLoad $ void $ do
   m <- ref
   Tuple node driver <- runUIWith app (acePostRender m)
   mountUI node
-  D.driver driver
+  D.driver m driver

--- a/src/Model/Notebook.purs
+++ b/src/Model/Notebook.purs
@@ -1,27 +1,14 @@
 module Model.Notebook where
 
-import Data.Either
 import Data.Maybe
-import Data.Foreign (toForeign)
-import Data.Foreign.Class (read)
 import Data.Inject1 (prj, inj)
-import Data.Bifunctor (lmap)
-import Halogen.HTML.Events.Monad (Event())
-import Optic.Core (lens, LensP())
 import Control.Timer (Timeout())
+import Optic.Core (lens, LensP())
 import EffectTypes (NotebookAppEff())
 import Model.Notebook.Menu (initialDropdowns, DropdownItem())
-
-import Data.Argonaut.Combinators
-import qualified Data.Argonaut.Core as Ac
-import qualified Data.Argonaut.Decode as Ad
-import qualified Data.Argonaut.Encode as Ae
-import qualified Data.Argonaut.Printer as Ap
-import qualified Network.HTTP.Affjax.Request as Ar
-import qualified Data.StrMap as M
+import Model.Notebook.Cell (CellId())
+import Model.Notebook.Domain (emptyNotebook, Notebook(), activeCellIdL)
 import Model.Resource (Resource(), newNotebook)
-import Global
-
 
 type State =
   { dropdowns :: [DropdownItem]
@@ -35,8 +22,6 @@ type State =
   , modalError :: String
   , addingCell :: Boolean
   , notebook :: Notebook
-  , nextCellId :: CellId
-  , activeCellId :: CellId 
   }
 
 dropdowns :: LensP State [DropdownItem]
@@ -45,8 +30,8 @@ dropdowns = lens _.dropdowns _{dropdowns = _}
 notebook :: LensP State Notebook
 notebook = lens _.notebook _{notebook = _}
 
-nextCellId :: LensP State Number
-nextCellId = lens _.nextCellId _{nextCellId = _}
+activeCellId :: LensP State CellId
+activeCellId = notebook <<< activeCellIdL
 
 initialState :: State
 initialState =
@@ -61,94 +46,5 @@ initialState =
   , modalError: ""
   , addingCell: false
   , notebook: emptyNotebook
-  , nextCellId: 0
-  , activeCellId: 0
   }
 
-type CellId = Number
-
-string2cellId :: String -> Either String CellId
-string2cellId str =
-  if isNaN int then Left "incorrect cell id" else Right int
-  where int = readFloat str 
-
-
-data CellType
-  = Evaluate
-  | Explore
-  | Search
-  | Query
-  | Visualize
-  | Markdown
-
-celltype2str :: CellType -> String
-celltype2str Evaluate = "evaluate"
-celltype2str Explore = "explore"
-celltype2str Search = "search"
-celltype2str Query = "query"
-celltype2str Visualize = "visualize"
-celltype2str Markdown = "markdown"
-
--- input and output are ports for cells i.e data uri,
--- content is cell content i.e. markdown
-newtype Cell = Cell {
-  cellId :: CellId,
-  input :: String,
-  output :: String,
-  content :: String,
-  cellType :: CellType,
-  metadata :: String,
-  hiddenEditor :: Boolean,
-  isRunning :: Boolean
-  }
-
-newCell :: CellId -> CellType -> Cell
-newCell cellId cellType =
-  Cell { cellId: cellId
-       , input: ""
-       , output: ""
-       , content: ""
-       , cellType: cellType
-       , metadata: ""
-       , hiddenEditor: false
-       , isRunning: false
-       }
-
-newtype Notebook = Notebook {
-  metadata :: String,
-  cells :: [Cell]
-  }
-
-emptyNotebook :: Notebook
-emptyNotebook = Notebook
-  { metadata: ""
-  , cells: [] }
-
-notebookLens :: LensP Notebook _
-notebookLens = lens (\(Notebook obj) -> obj) (const Notebook)
-
-notebookCells :: LensP Notebook [Cell]
-notebookCells = notebookLens <<< lens _.cells (_ { cells = _ })
-
-instance cellTypeEncode :: Ae.EncodeJson CellType where
-  encodeJson = Ac.fromString <<< celltype2str 
-
-instance cellEncode :: Ae.EncodeJson Cell where
-  encodeJson (Cell cell)
-    =  "input" := cell.input
-    ~> "output" := cell.output
-    ~> "cellType" := cell.cellType
-    ~> "metadata" := cell.metadata
-    ~> Ac.jsonEmptyObject
-
-instance notebookEncode :: Ae.EncodeJson Notebook where
-  encodeJson (Notebook {metadata: metadata, cells: cells})
-    =  "metadata" := metadata
-    ~> "cells" := cells
-    ~> Ac.jsonEmptyObject
-
-
-instance notebookRequestable :: Ar.Requestable Notebook where
-  toRequest notebook =
-    let str = Ap.printJson (Ae.encodeJson notebook) :: String
-    in Ar.toRequest str

--- a/src/Model/Notebook/Cell.purs
+++ b/src/Model/Notebook/Cell.purs
@@ -1,0 +1,78 @@
+module Model.Notebook.Cell where
+
+import Data.Either
+import Global
+import Model.Notebook.Port
+import Data.Argonaut.Combinators
+import qualified Data.Argonaut.Core as Ac
+import qualified Data.Argonaut.Encode as Ae
+
+
+type CellId = Number
+
+string2cellId :: String -> Either String CellId
+string2cellId str =
+  if isNaN int then Left "incorrect cell id" else Right int
+  where int = readFloat str
+
+
+data CellType
+  = Evaluate
+  | Explore
+  | Search
+  | Query
+  | Visualize
+  | Markdown
+
+celltype2str :: CellType -> String
+celltype2str Evaluate = "evaluate"
+celltype2str Explore = "explore"
+celltype2str Search = "search"
+celltype2str Query = "query"
+celltype2str Visualize = "visualize"
+celltype2str Markdown = "markdown"
+
+
+-- input and output are ports for cells i.e data uri,
+-- content is cell content i.e. markdown
+newtype Cell = 
+  Cell { cellId :: CellId
+       , input :: Port
+       , output :: Port
+       , content :: String
+       , cellType :: CellType
+       , metadata :: String
+       , hiddenEditor :: Boolean
+       , isRunning :: Boolean
+       }
+
+newCell :: CellId -> CellType -> Cell
+newCell cellId cellType =
+  Cell { cellId: cellId
+       , input: Closed 
+       , output: Closed
+       , content: ""
+       , cellType: cellType
+       , metadata: ""
+       , hiddenEditor: false
+       , isRunning: false
+       }
+
+instance cellEq :: Eq Cell where
+  (==) (Cell c) (Cell c') =
+    c.cellId == c'.cellId
+  (/=) a b = not $ a == b
+
+instance cellOrd :: Ord Cell where
+  compare (Cell c) (Cell c') = compare c.cellId c'.cellId
+
+instance cellTypeEncode :: Ae.EncodeJson CellType where
+  encodeJson = Ac.fromString <<< celltype2str 
+
+instance cellEncode :: Ae.EncodeJson Cell where
+  encodeJson (Cell cell)
+    =  "input" := cell.input
+    ~> "output" := cell.output
+    ~> "cellType" := cell.cellType
+    ~> "metadata" := cell.metadata
+    ~> Ac.jsonEmptyObject

--- a/src/Model/Notebook/Domain.purs
+++ b/src/Model/Notebook/Domain.purs
@@ -1,0 +1,88 @@
+module Model.Notebook.Domain where
+
+import Data.Array (length, sort, reverse, head)
+import Data.Tuple
+import Data.Maybe
+import Data.Map 
+import Data.Argonaut.Combinators
+import qualified Data.Argonaut.Core as Ac
+import qualified Data.Argonaut.Decode as Ad
+import qualified Data.Argonaut.Encode as Ae
+import qualified Data.Argonaut.Printer as Ap
+import qualified Network.HTTP.Affjax.Request as Ar
+
+import Optic.Core (lens, LensP())
+import Model.Notebook.Cell
+
+-- We have no any cells that have more than one
+-- dependency right now. And have no ui to make
+-- cell that has more than one deps.  
+type Dependencies = Map CellId CellId
+
+deps :: CellId -> Dependencies -> [CellId]
+deps cid ds = deps' cid ds []
+  where
+  deps' cid ds agg =
+    case lookup cid ds of
+      Nothing -> agg
+      Just a -> deps' a ds (a : agg)
+
+
+type NotebookRec =
+  { metadata :: String
+  , cells :: [Cell]
+  , dependencies :: Dependencies
+  , activeCellId :: CellId
+  }
+
+newtype Notebook = Notebook NotebookRec 
+
+
+notebookRecL :: LensP Notebook NotebookRec
+notebookRecL = lens (\(Notebook r) -> r) (\_ r -> Notebook r)
+
+activeCellIdRecL :: LensP NotebookRec CellId
+activeCellIdRecL = lens _.activeCellId _{activeCellId = _}
+
+activeCellIdL :: LensP Notebook CellId
+activeCellIdL = notebookRecL <<< activeCellIdRecL
+
+emptyNotebook :: Notebook
+emptyNotebook = Notebook
+  { metadata: ""
+  , cells: []
+  , dependencies: empty
+  , activeCellId: 0
+  }
+
+addCell :: CellType -> Maybe CellId -> Notebook -> Tuple Notebook Cell 
+addCell cellType mbCellId (Notebook n) = Tuple notebook cell
+  where 
+  newId = maybe 0 (+ 1) $ head $ reverse $ sort $ (\(Cell x) -> x.cellId) <$> n.cells
+  cell = newCell newId cellType
+  newDeps = maybe n.dependencies (\x -> insert newId x n.dependencies) mbCellId 
+  notebook = Notebook $ n { cells = cell : n.cells
+                          , dependencies = newDeps
+                          , activeCellId = newId
+                          }
+  
+
+
+notebookLens :: LensP Notebook _
+notebookLens = lens (\(Notebook obj) -> obj) (const Notebook)
+
+notebookCells :: LensP Notebook [Cell]
+notebookCells = notebookLens <<< lens _.cells (_ { cells = _ })
+
+
+instance notebookEncode :: Ae.EncodeJson Notebook where
+  encodeJson (Notebook {metadata: metadata, cells: cells})
+    =  "metadata" := metadata
+    ~> "cells" := cells
+    ~> Ac.jsonEmptyObject
+
+
+instance notebookRequestable :: Ar.Requestable Notebook where
+  toRequest notebook =
+    let str = Ap.printJson (Ae.encodeJson notebook) :: String
+    in Ar.toRequest str

--- a/src/Model/Notebook/Menu.purs
+++ b/src/Model/Notebook/Menu.purs
@@ -10,11 +10,6 @@ data MenuNotebookSignal
   | DeleteNotebook
   | PublishNotebook
 
-data MenuEditSignal
-  = CopyEdit
-  | PasteEdit
-  | CutEdit
-
 data MenuInsertSignal
   = ExploreInsert
   | MarkdownInsert
@@ -34,10 +29,9 @@ data MenuHelpSignal
   | RequestSupportHelp
 
 type MenuSignal = Either MenuNotebookSignal
-                 (Either MenuEditSignal
                   (Either MenuInsertSignal
                    (Either MenuCellSignal
-                    MenuHelpSignal)))
+                    MenuHelpSignal))
 
 
 
@@ -69,18 +63,6 @@ initialDropdowns =
         , lvl: fromNumber 0}
       ]
     }
-  , { visible: false
-    , name: "Edit"
-    , children:
-      [ { name: "Copy (Cmd + C)"
-        , message: Just $ inj CopyEdit
-        , lvl: fromNumber 0 }
-      , { name: "Cut (Cmd + X)"
-        , message: Just $ inj CutEdit
-        , lvl: fromNumber 0 }
-      , { name: "Paste (Cmd + V)"
-        , message: Just $ inj PasteEdit
-        , lvl: fromNumber 0 }]}
   , { visible: false
     , name: "Insert"
     , children:

--- a/src/Model/Notebook/Port.purs
+++ b/src/Model/Notebook/Port.purs
@@ -1,0 +1,27 @@
+module Model.Notebook.Port where
+
+import Model.Resource
+import Data.StrMap
+import Data.Argonaut.Combinators
+import qualified Data.Argonaut.Core as Ac
+import qualified Data.Argonaut.Encode as Ae
+
+
+type VarMapValue = String 
+
+data Port
+  = Closed
+  | PortResource Resource
+  | VarMap (StrMap VarMapValue)
+    
+    
+instance portEncode :: Ae.EncodeJson Port where
+  encodeJson Closed = Ac.jsonEmptyObject
+  encodeJson (PortResource res) =
+    "type" := "resource"
+    ~> "path" := resourcePath res
+    ~> Ac.jsonEmptyObject
+  encodeJson (VarMap map) =
+    "type" := "map"
+    ~> "content" := map
+    ~> Ac.jsonEmptyObject


### PR DESCRIPTION
fixes #19 
* fixes reinstalls of ace editors: ace editors were mounted to particular element, and doesn't reinstalls after removing of cell from notebook because node has not been changed, but modified. 
* Splitted `Model.Notebook` to smaller modules.
* removed `nextCellId` added `activeCellId` and make adding of cells managed by notebook. 
* initial work on cell ports and dependencies. 