### PR TITLE
Point `baseUrl` to the hosting server root.

### DIFF
--- a/src/Config.purs
+++ b/src/Config.purs
@@ -1,7 +1,7 @@
 module Config where
 
 baseUrl :: String
-baseUrl = "http://local.slamdata.com/"
+baseUrl = "/"
 
 uploadUrl :: String
 uploadUrl = baseUrl <> "upload"


### PR DESCRIPTION
That is, `/`, so that when deployed in the API server, request paths are relative to the server's root URI.

This makes SlamData work when deployed inside the API server on the build box.