### PR TITLE
Make URLs relative

### DIFF
--- a/src/Config.purs
+++ b/src/Config.purs
@@ -1,7 +1,7 @@
 module Config where
 
 baseUrl :: String
-baseUrl = "/"
+baseUrl = ""
 
 uploadUrl :: String
 uploadUrl = baseUrl <> "upload"
@@ -22,7 +22,7 @@ searchTimeout :: Number
 searchTimeout = 500
 
 slamDataHome :: String
-slamDataHome = baseUrl
+slamDataHome = baseUrl <> "index.html"
 
 userEnabled :: Boolean
 userEnabled = false


### PR DESCRIPTION
@jdegoes This will (hopefully) fix our Safari issue, and nothing has broken when testing locally.

It might be better to do this in the long run anyway, as it means it doesn't matter where the app is hosted - at `/` or an _n_-deep directory, it's all the same. The only disadvantage I can see is things might be a bit trickier if we change the front-end file structure to something more irregular later.