### PR TITLE
Path fix take 2

### DIFF
--- a/src/Config.purs
+++ b/src/Config.purs
@@ -3,17 +3,20 @@ module Config where
 baseUrl :: String
 baseUrl = ""
 
+serviceBaseUrl :: String
+serviceBaseUrl = "/"
+
 uploadUrl :: String
-uploadUrl = baseUrl <> "upload"
+uploadUrl = serviceBaseUrl <> "upload"
 
 metadataUrl :: String
-metadataUrl = baseUrl <> "metadata/fs/"
+metadataUrl = serviceBaseUrl <> "metadata/fs/"
 
 dataUrl :: String
-dataUrl = baseUrl <> "data/fs/"
+dataUrl = serviceBaseUrl <> "data/fs/"
 
 queryUrl :: String
-queryUrl = baseUrl <> "query/fs/"
+queryUrl = serviceBaseUrl <> "query/fs/"
 
 notebookUrl :: String
 notebookUrl = baseUrl <> "notebook.html"


### PR DESCRIPTION
Relative URLs didn't work as then the service calls were being made to `slamdata/fs/...` etc. so this introduces a separate base path for the service calls.