### PR TITLE
Notebook serialization

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "gulp": "^3.8.11",
     "gulp-less": "^3.0.2",
-    "mandragora-bucket": "^0.3.1",
+    "mandragora-bucket": "^0.3.2",
     "minimatch": "^2.0.1",
     "virtual-dom": "^2.0.0",
     "zeroclipboard": "^2.2.0"

--- a/src/Api/Fs.purs
+++ b/src/Api/Fs.purs
@@ -1,30 +1,35 @@
 module Api.Fs where
 
-import Control.Monad.Aff(Aff())
+import Api.Common (succeeded, getResponse)
+import Control.Apply ((*>))
+import Control.Monad.Aff (Aff())
 import Control.Monad.Eff.Exception (error)
 import Control.Monad.Error.Class (throwError)
-import Data.Either (Either(..), either)
-import Data.Maybe
-
-import Data.Array (head)
-import Data.String (split)
-import Data.Foreign.Class (readProp, read, IsForeign)
-import Network.HTTP.Affjax.Response (Respondable, ResponseType(JSONResponse))
-import Network.HTTP.Affjax (Affjax(), AJAX(), affjax, get, put_, delete_, defaultRequest)
-import Network.HTTP.RequestHeader (RequestHeader(..))
-import Network.HTTP.Method (Method(MOVE))
+import Data.Argonaut.Core (Json())
+import Data.Argonaut.Decode (decodeJson)
 import Data.Argonaut.Parser (jsonParser)
+import Data.Array (head, findIndex)
+import Data.Either (Either(..), either)
+import Data.Foreign (Foreign())
+import Data.Foreign.Class (readProp, read, IsForeign)
+import Data.Maybe
+import Data.Path.Pathy
+import Data.String (split, length, take, joinWith)
+import Data.These (These(..), theseLeft, theseRight)
+import Model.Path
+import Network.HTTP.Affjax (Affjax(), AJAX(), affjax, get, put_, delete_, defaultRequest)
+import Network.HTTP.Affjax.Response (Respondable, ResponseType(JSONResponse))
+import Network.HTTP.Method (Method(MOVE))
+import Network.HTTP.RequestHeader (RequestHeader(..))
+import Optic.Core ((..), (.~), (^.))
 
-import Api.Common (succeeded, getResponse)
-import Model.Notebook.Domain (Notebook())
-import Model.Resource (getPath, Resource(), resourcePath, _root, AnyPath(), newNotebook, newFile, _path)
-import Data.Path.Pathy (rootDir)
-import Optic.Core ((.~))
-import Config
+import qualified Data.Maybe.Unsafe as U
+import qualified Model.Notebook.Domain as N
+import qualified Model.Resource as R
 
-newtype Listing = Listing [Resource]
+newtype Listing = Listing [R.Resource]
 
-runListing :: Listing -> [Resource]
+runListing :: Listing -> [R.Resource]
 runListing (Listing rs) = rs
 
 instance listingIsForeign :: IsForeign Listing where
@@ -34,25 +39,25 @@ instance listingRespondable :: Respondable Listing where
   responseType = JSONResponse
   fromResponse = read
 
-children :: forall e. Resource -> Aff (ajax :: AJAX | e) [Resource] 
+children :: forall e. R.Resource -> Aff (ajax :: AJAX | e) [R.Resource]
 children r = do
-  cs <- children' $ resourcePath r 
-  pure $ (_root .~ (either (const rootDir) id $ getPath r)) <$> cs 
+  cs <- children' $ R.resourcePath r
+  pure $ (R._root .~ (either (const rootDir) id $ R.getPath r)) <$> cs
+
+children' :: forall e. String -> Aff (ajax :: AJAX | e) [R.Resource]
+children' str = runListing <$> (getResponse msg $ listing str)
   where
   msg = "error getting resource children"
 
-  children' :: String -> Aff _ [Resource]
-  children' str = runListing <$> (getResponse msg $ listing str)
-
-  listing :: String -> Affjax _ Listing
-  listing str = get (Config.metadataUrl <> str)
+listing :: forall e. String -> Affjax e Listing
+listing str = get (Config.metadataUrl <> str)
 
 makeFile :: forall e. AnyPath -> String -> Aff (ajax :: AJAX | e) Unit
 makeFile ap content =
   getResponse msg $ either err go isJson
   where
-  resource :: Resource
-  resource = newFile # _path .~ ap 
+  resource :: R.Resource
+  resource = R.newFile # R._path .~ ap
 
   msg :: String
   msg = "error while creating file"
@@ -67,28 +72,85 @@ makeFile ap content =
   isJson = maybe (Left "empty file") Right firstLine >>= jsonParser
 
   go :: _ -> Aff _ _
-  go _ = put_ (Config.dataUrl <> resourcePath resource) content
+  go _ = put_ (Config.dataUrl <> R.resourcePath resource) content
 
+loadNotebook :: forall e. R.Resource -> Aff (ajax :: AJAX | e) N.Notebook
+loadNotebook res = do
+  val <- getResponse "error loading notebook" $ get (Config.dataUrl <> R.resourcePath res <> "/index")
+  case decodeJson (foreignToJson val) of
+    Left err -> throwError (error err)
+    Right notebook ->
+      let name = dropNotebookExt (R.resourceName res)
+      in pure (notebook # (N._path .~ R.resourceDir res)
+                       .. (N._name .~ That name))
 
-makeNotebook :: forall e. AnyPath -> Notebook -> Aff (ajax :: AJAX | e) Unit
-makeNotebook ap notebook =
-  getResponse msg $ put_ (Config.dataUrl <> resourcePath resource <> "/index") notebook
-  where msg = "error while creating notebook"
-        resource = newNotebook # _path .~ ap 
+-- TODO: Not this. either add to Argonaut, or make a Respondable Json instance (requires "argonaut core" - https://github.com/slamdata/purescript-affjax/issues/16#issuecomment-93565447)
+foreign import foreignToJson
+  """
+  function foreignToJson(x) {
+    return x;
+  }
+  """ :: Foreign -> Json
 
-delete :: forall e. Resource -> Aff (ajax :: AJAX | e) Unit
+-- | Saves (creating or updating) a notebook. If the notebook's `name` value is
+-- | a `This` value the name will be used as a basis for generating a new
+-- | notebook. If the `name` value is a `Both` value the notebook will be saved
+-- | and then moved. If the name is a `That` the notebook will be saved.
+saveNotebook :: forall e. N.Notebook -> Aff (ajax :: AJAX | e) N.Notebook
+saveNotebook notebook = case notebook ^. N._name of
+  That name -> save name *> pure notebook
+  This name -> do
+    let baseName = (U.fromJust $ theseLeft (notebook ^. N._name)) ++ "." ++ Config.notebookExtension
+    name <- getNewName (notebook ^. N._path) baseName
+    save name
+    pure (notebook # N._name .~ That (dropNotebookExt name))
+  Both newName oldName | newName /= oldName -> do
+    save oldName
+    alreadyExists <- exists (newName ++ "." ++ Config.notebookExtension) (notebook ^. N._path)
+    if alreadyExists
+      then throwError (error "A file already exists with the specified name")
+      else
+        let oldPath = Right $ (notebook ^. N._path) </> dir oldName <./> Config.notebookExtension
+            newPath = Right $ (notebook ^. N._path) </> dir newName <./> Config.notebookExtension
+        in move oldPath newPath *> pure (notebook # N._name .~ That newName)
+  where
+  save name =
+    let notebookPath = (notebook ^. N._path) </> dir name <./> Config.notebookExtension </> file "index"
+    in getResponse "error while saving notebook" $ put_ (Config.dataUrl <> printPath notebookPath) notebook
+
+-- | Generates a new resource name based on a directory path and a name for the
+-- | resource. If the name already exists in the path a number is appended to
+-- | the end of the name.
+getNewName :: forall e. DirPath -> String -> Aff (ajax :: AJAX | e) String
+getNewName parent name = do
+  items <- children' (printPath parent)
+  pure if exists' name items then getNewName' items 1 else name
+  where
+  getNewName' items i =
+    case split "." name of
+      [] -> ""
+      body:suffixes ->
+        let newName = joinWith "." $ (body ++ " " ++ show i):suffixes
+        in if exists' newName items then getNewName' items (i + 1) else newName
+
+exists :: forall e. String -> DirPath -> Aff (ajax :: AJAX | e) Boolean
+exists name parent = exists' name <$> children' (printPath parent)
+
+exists' :: forall e. String -> [R.Resource] -> Boolean
+exists' name items = findIndex (\r -> r ^. R._name == name) items /= -1
+
+delete :: forall e. R.Resource -> Aff (ajax :: AJAX | e) Unit
 delete resource =
-  getResponse msg $ delete_ (Config.dataUrl <> resourcePath resource)
+  getResponse msg $ delete_ (Config.dataUrl <> R.resourcePath resource)
   where msg = "can not delete"
 
-
-move :: forall e. Resource -> AnyPath -> Aff (ajax :: AJAX | e) (Either String AnyPath)
+move :: forall a e. AnyPath -> AnyPath -> Aff (ajax :: AJAX | e) AnyPath
 move src tgt = do
   result <- affjax $ defaultRequest
     { method = MOVE
-    , headers = [RequestHeader "Destination" $ resourcePath (src # _path .~ tgt) ]
-    , url = Config.dataUrl <> resourcePath src 
+    , headers = [RequestHeader "Destination" $ either printPath printPath tgt]
+    , url = Config.dataUrl <> either printPath printPath src
     }
-  pure if succeeded result.status
-       then Right tgt
-       else Left result.response
+  if succeeded result.status
+     then pure tgt
+     else throwError (error result.response)

--- a/src/App/Notebook/Ace.purs
+++ b/src/App/Notebook/Ace.purs
@@ -30,6 +30,7 @@ import Ace.Types (EditSession(), ACE(), Editor(), TextMode(..))
 import qualified Ace.Editor as Editor
 
 import Model.Notebook
+import Model.Notebook.Domain
 import Model.Notebook.Cell (CellId(), string2cellId, _cellId, _content)
 
 import Optic.Core
@@ -98,8 +99,7 @@ initialize m b d = do
     Editor.focus editor
     modifyRef m (M.insert cid session)
     Editor.onFocus editor do
-      d $ WithState (_activeCellId .~ cid)
-
+      d $ WithState (_notebook .. _activeCellId .~ cid)
 
   reinit :: Editor -> EditSession -> Eff _ Unit
   reinit editor session = do

--- a/src/Config.purs
+++ b/src/Config.purs
@@ -42,7 +42,7 @@ notebookExtension :: String
 notebookExtension = "slam"
 
 newNotebookName :: String
-newNotebookName = "Untitled Notebook." <> notebookExtension
+newNotebookName = "Untitled Notebook"
 
 newFileName :: String
 newFileName = "Untitled File"

--- a/src/Controller/File/Search.purs
+++ b/src/Controller/File/Search.purs
@@ -1,23 +1,23 @@
 module Controller.File.Search where
 
-import Data.Inject1 (inj)
 import Control.Monad.Aff (makeAff)
 import Control.Monad.Eff.Class (liftEff)
 import Control.Monad.Eff.Random (randomInt)
 import Control.Timer (timeout, clearTimeout)
 import Controller.File.Common (toInput)
 import Data.Either (Either(..))
+import Data.Inject1 (inj)
 import Data.Maybe (maybe)
+import Data.Path.Pathy
 import Driver.File.Path (updateQ, updateSalt)
 import EffectTypes (FileAppEff())
 import Halogen.HTML.Events.Monad (Event(), runEvent, async)
 import Input.File (Input(), FileInput(Loading))
 import Input.File.Search (SearchInput(..))
 import Model.File.Search (Search())
+import Model.Path (DirPath())
 import Routing.Hash (modifyHash)
 import Text.SlamSearch (mkQuery)
-import Model.Resource (DirPath())
-import Data.Path.Pathy
 
 handleSearchClear :: forall e. Boolean -> Search -> Event (FileAppEff e) Input
 handleSearchClear isSearching search = do

--- a/src/Controller/Notebook/Cell.purs
+++ b/src/Controller/Notebook/Cell.purs
@@ -1,10 +1,10 @@
-module Controller.Notebook.Cell (
-  requestCellContent
-, runCell
+module Controller.Notebook.Cell
+  ( requestCellContent
+  , runCell
   ) where
 
 import Control.Plus (empty)
-import Control.Monad.Eff.Class (liftEff) 
+import Control.Monad.Eff.Class (liftEff)
 import Optic.Core ((.~), (^.))
 import Data.Date (now)
 import Data.Either (Either(..))

--- a/src/Controller/Notebook/Cell/Search.purs
+++ b/src/Controller/Notebook/Cell/Search.purs
@@ -32,7 +32,8 @@ import Text.SlamSearch (mkQuery)
 import Input.Notebook (Input(..))
 import Controller.Notebook.Common (I(), finish, update)
 import Controller.Notebook.Cell.JTableContent (runJTable, queryToJTable)
-import Model.Resource (newFile, _path, AnyPath(), Resource())
+import Model.Path (AnyPath())
+import Model.Resource (newFile, _path, Resource())
 import Model.Notebook.Port (_PortResource)
 import Model.Notebook.Search (needFields, queryToSQL)
 import Model.Notebook.Cell (Cell(), RunState(..), _RunningSince, _runState,  _cellId, _content, _Search, _failures, _input, _output, _message)
@@ -59,14 +60,14 @@ runSearch cell =
       guard (needFields q)
       input
     flip (either errorInFields) fs \fs ->
-      let tmpl = queryToSQL fs q 
+      let tmpl = queryToSQL fs q
           sql :: Maybe String
           sql = templated <$> input <*> (pure tmpl) in
-      maybe empty (\s -> update cell (_message .~ ("Generated SQL: " <> s))) sql 
+      maybe empty (\s -> update cell (_message .~ ("Generated SQL: " <> s))) sql
       `andThen` \_ ->
       (fromMaybe errorInPorts (queryToJTable cell tmpl <$> input <*> output))
 
-      
+
 
   errorInParse :: _ -> I eff
   errorInParse _ =

--- a/src/Driver/File.purs
+++ b/src/Driver/File.purs
@@ -29,7 +29,7 @@ import Input.File.Search (SearchInput(..))
 import qualified Halogen as Hl
 import qualified Text.SlamSearch.Printer as S
 import Model.Sort (Sort(Asc))
-import Model.Path (cleanPath, hidePath)
+import Model.Path (AnyPath(), DirPath(), cleanPath, hidePath)
 import Model.File.Item (wrap)
 import Api.Fs (children)
 import Routing (matchesAff)

--- a/src/Driver/File/Path.purs
+++ b/src/Driver/File/Path.purs
@@ -14,6 +14,7 @@ import Data.Either (either)
 import Data.Maybe
 import Data.Path.Pathy
 import Driver.File.Search (searchPath)
+import Model.Path
 import Model.Resource
 import Model.Sort (Sort(..), sort2string)
 import qualified Data.String as Str

--- a/src/Input/File.purs
+++ b/src/Input/File.purs
@@ -20,6 +20,7 @@ import Model.Breadcrumb (Breadcrumb(), rootBreadcrumb)
 import Model.File (State())
 import Model.File.Dialog (Dialog())
 import Model.File.Item (Item(), sortItem)
+import Model.Path
 import Model.Resource
 import Model.Salt (Salt())
 import Model.Sort (Sort())

--- a/src/Model/Action.purs
+++ b/src/Model/Action.purs
@@ -9,12 +9,16 @@ string2action "view" = Right View
 string2action "edit" = Right Edit
 string2action _ = Left "incorrect action string"
 
+printAction :: Action -> String
+printAction View = "view"
+printAction Edit = "edit"
+
 isView :: Action -> Boolean
 isView View = true
 isView _ = false
 
 isEdit :: Action -> Boolean
-isEdit = not <<< isView 
+isEdit = not <<< isView
 
 instance resumeEq :: Eq Action where
   (==) View View = true

--- a/src/Model/File.purs
+++ b/src/Model/File.purs
@@ -8,7 +8,7 @@ import Model.Breadcrumb (Breadcrumb())
 import Model.File.Dialog (Dialog())
 import Model.File.Item (Item(), wrap)
 import Model.File.Search (Search(), initialSearch)
-import Model.Resource (DirPath())
+import Model.Path (DirPath())
 import Model.Salt (Salt(..))
 import Model.Sort (Sort(..))
 

--- a/src/Model/Notebook.purs
+++ b/src/Model/Notebook.purs
@@ -1,31 +1,22 @@
 module Model.Notebook where
 
-import Control.Timer (Timeout())
-import Data.Array ((!!), findIndex)
 import Data.Date (Date())
-import Data.Inject1 (prj, inj)
-import Data.Maybe
-import Data.Platform
-import EffectTypes (NotebookAppEff())
-import Model.Notebook.Cell (CellId(), Cell(), _cellId)
-import Model.Notebook.Menu (initialDropdowns, DropdownItem())
-import Model.Resource (Resource(), newNotebook)
-import Optic.Core (lens, LensP(), (..), (^.))
-import Optic.Index (ix)
-import Optic.Index.Types (TraversalP())
-
-import qualified Model.Notebook.Domain as D
+import Data.Maybe (Maybe(..))
+import Data.Path.Pathy
+import Data.Platform (Platform(..))
+import Model.Notebook.Domain (Notebook(), emptyNotebook)
+import Model.Notebook.Menu (DropdownItem(), initialDropdowns)
+import Model.Path
+import Optic.Core (LensP(), lens, (^.))
 
 type State =
   { dropdowns :: [DropdownItem]
-  , siblings :: [Resource]
   , loaded :: Boolean
-  , error :: String
+  , error :: Maybe String
   , editable :: Boolean
   , modalError :: String
   , addingCell :: Boolean
-  , notebook :: D.Notebook
-  , initialName :: String
+  , notebook :: Notebook
   , tickDate :: Maybe Date
   , platform :: Platform
   }
@@ -33,22 +24,10 @@ type State =
 _dropdowns :: LensP State [DropdownItem]
 _dropdowns = lens _.dropdowns _{dropdowns = _}
 
-_resource :: LensP State Resource
-_resource = _notebook .. D._resource
-
-_notebook :: LensP State D.Notebook
-_notebook = lens _.notebook _{notebook = _}
-
-_activeCellId :: LensP State CellId
-_activeCellId = _notebook .. D._activeCellId
-
-_siblings :: LensP State [Resource]
-_siblings = lens _.siblings _{siblings = _}
-
 _loaded :: LensP State Boolean
 _loaded = lens _.loaded _{loaded = _}
 
-_error :: LensP State String
+_error :: LensP State (Maybe String)
 _error = lens _.error _{error = _}
 
 _editable :: LensP State Boolean
@@ -60,16 +39,11 @@ _modalError = lens _.modalError _{modalError = _}
 _addingCell :: LensP State Boolean
 _addingCell = lens _.addingCell _{addingCell = _}
 
-_initialName :: LensP State String
-_initialName = lens _.initialName _{initialName = _}
+_notebook :: LensP State Notebook
+_notebook = lens _.notebook _{notebook = _}
 
 _tickDate :: LensP State (Maybe Date)
 _tickDate = lens _.tickDate _{tickDate = _}
-
-_activeCell :: TraversalP State Cell
-_activeCell f s = (_notebook .. D._cells .. ix activeIndex) f s
-  where activeIndex = findIndex (\cell -> cell ^. _cellId == s ^. _activeCellId)
-                      (s ^. _notebook .. D._cells)
 
 _platform :: LensP State Platform
 _platform = lens _.platform _{platform = _}
@@ -77,14 +51,12 @@ _platform = lens _.platform _{platform = _}
 initialState :: State
 initialState =
   { dropdowns: initialDropdowns
-  , siblings: []
   , loaded: false
-  , error: ""
+  , error: Nothing
   , editable: true
   , modalError: ""
   , addingCell: false
-  , notebook: D.emptyNotebook
-  , initialName: ""
+  , notebook: emptyNotebook
   , tickDate: Nothing
   , platform: Other
   }

--- a/src/Model/Notebook/Port.purs
+++ b/src/Model/Notebook/Port.purs
@@ -53,6 +53,6 @@ instance decodeJsonPort :: DecodeJson Port where
     portType <- obj .? "type"
     case portType of
       "resource" -> PortResource <$> obj .? "res"
-      "invalid" -> PortInvalid <$> obj .? "msg"
+      "invalid" -> PortInvalid <$> obj .? "message"
       "map" -> VarMap <$> obj .? "content"
       _ -> pure Closed

--- a/src/Model/Path.purs
+++ b/src/Model/Path.purs
@@ -2,8 +2,42 @@ module Model.Path where
 
 import Data.Array ()
 import Data.DOM.Simple.Encode (encodeURIComponent, decodeURIComponent)
-import Data.String (split, joinWith, trim, replace)
+import Data.Either (Either(..))
+import Data.Path.Pathy
+import Data.String (split, joinWith, trim, replace, drop, take, lastIndexOf, length)
+
 import qualified Data.String.Regex as Rgx
+
+type FilePath = AbsFile Sandboxed
+type DirPath = AbsDir Sandboxed
+type AnyPath = Either FilePath DirPath
+
+infixl 6 <./>
+(<./>) :: forall a s. Path a Dir s -> String -> Path a Dir s
+(<./>) p ext = renameDir (changeDirExt $ const ext) p
+
+changeDirExt :: (String -> String) -> DirName -> DirName
+changeDirExt f (DirName name) =
+  DirName ((if ext == "" then name else n) <> "." <> f ext)
+  where
+  idx = lastIndexOf "." name
+  n = case idx of
+    -1 -> name
+    _ -> take idx name
+  ext = case idx of
+    -1 -> ""
+    _ -> drop (idx + 1) name
+
+dropDirExt :: DirName -> DirName
+dropDirExt (DirName d) =
+  DirName $ case idx of
+    -1 -> d
+    _ -> take idx d
+  where
+  idx = lastIndexOf "." d
+
+dropNotebookExt :: String -> String
+dropNotebookExt name = take (length name - length Config.notebookExtension - 1) name
 
 decodeURIPath :: String -> String
 decodeURIPath uri =

--- a/src/Model/Resource.purs
+++ b/src/Model/Resource.purs
@@ -1,5 +1,5 @@
 module Model.Resource (
-  FilePath(), DirPath(), AnyPath(), Resource(),
+  Resource(..),
   isNotebook, isFile, isDatabase, isDirectory,
   resourceTag, getPath, getNameStr, getDir,
   setDir, renameAny, resourceName, resourceDir,
@@ -26,6 +26,7 @@ import Data.Maybe
 import Data.Path.Pathy
 import Data.Tuple
 import Model.Sort (Sort(..))
+import Model.Path
 import Optic.Core (lens, (..), (^.), (%~), (.~))
 import Optic.Prism
 import Optic.Refractor.Prism (_Right)
@@ -34,39 +35,11 @@ import Utils
 
 import qualified Data.String as S
 
-type FilePath = AbsFile Sandboxed
-type DirPath = AbsDir Sandboxed
-type AnyPath = Either FilePath DirPath
-
 data Resource
   = File FilePath
   | Notebook DirPath
   | Directory DirPath
   | Database DirPath
-
-infixl 6 <./>
-(<./>) :: forall a s. Path a Dir s -> String -> Path a Dir s
-(<./>) p ext = renameDir (changeDirExt $ const ext) p
-
-changeDirExt :: (String -> String) -> DirName -> DirName
-changeDirExt f (DirName name) =
-  DirName ((if ext == "" then name else n) <> "." <> f ext)
-  where
-  idx = S.lastIndexOf "." name
-  n = case idx of
-    -1 -> name
-    _ -> S.take idx name
-  ext = case idx of
-    -1 -> ""
-    _ -> S.drop (idx + 1) name
-
-dropDirExt :: DirName -> DirName
-dropDirExt (DirName d) =
-  DirName $ case idx of
-    -1 -> d
-    _ -> S.take idx d
-  where
-  idx = S.lastIndexOf "." d
 
 _notebookPath :: PrismP Resource DirPath
 _notebookPath = prism' Notebook $ \s -> case s of

--- a/src/View/Notebook/Cell/Search.purs
+++ b/src/View/Notebook/Cell/Search.purs
@@ -3,43 +3,43 @@ module View.Notebook.Cell.Search (
   searchOutput
   ) where
 
-import Control.Plus (empty)
 import Control.Functor (($>))
+import Control.Plus (empty)
+import Controller.Notebook.Cell (requestCellContent)
+import Controller.Notebook.Cell.Search (runSearch)
+import Input.Notebook (Input(..))
+import Model.Notebook (_notebook)
+import Model.Notebook.Cell (Cell(), RunState(..), _FileInput, _JTableContent, _content, _Search, _cellId, _runState)
+import Model.Notebook.Cell.Search (_buffer)
+import Model.Notebook.Domain (_activeCellId)
 import Optic.Core ((^.), (.~), (..))
 import Optic.Extended (TraversalP())
+import View.Common (glyph)
+import View.Notebook.Cell.FileInput (fileInput)
+import View.Notebook.Cell.JTableCell (renderJTableOutput)
+import View.Notebook.Common (HTML())
 
 import qualified Halogen.HTML as H
 import qualified Halogen.HTML.Attributes as A
 import qualified Halogen.HTML.Events as E
-import qualified Halogen.HTML.Events.Monad as E
 import qualified Halogen.HTML.Events.Forms as E
 import qualified Halogen.HTML.Events.Handler as E
+import qualified Halogen.HTML.Events.Monad as E
 import qualified Halogen.Themes.Bootstrap3 as B
-
-import Input.Notebook (Input(..))
-import Controller.Notebook.Cell (requestCellContent)
-import Controller.Notebook.Cell.Search (runSearch)
-import Model.Notebook (_activeCellId)
-import Model.Notebook.Cell (Cell(), _FileInput, _JTableContent, _content, _Search, _cellId, _runState, RunState(..))
-import Model.Notebook.Cell.Search (_buffer)
-import View.Common (glyph)
-import View.Notebook.Common (HTML())
-import View.Notebook.Cell.JTableCell (renderJTableOutput)
-import View.Notebook.Cell.FileInput (fileInput)
 import qualified View.Css as Vc
 
 searchEditor :: forall e. Cell -> HTML e
 searchEditor cell =
   H.div
-  [ A.classes [ Vc.exploreCellEditor ] ] $ 
+  [ A.classes [ Vc.exploreCellEditor ] ] $
   (fileInput (_content .. _FileInput) cell) <>
   [ H.div [ A.classes [ Vc.fileListField, B.inputGroup ] ]
-    [ H.input 
+    [ H.input
       [ A.value (cell ^. _lens)
       , A.classes [ B.formControl, Vc.searchCellInput ]
       , A.placeholder "Input search string"
       , E.onInput (E.input updateBuffer)
-      , E.onFocus (E.input_ $ WithState (_activeCellId .~ (cell ^. _cellId)))
+      , E.onFocus (E.input_ $ WithState (_notebook .. _activeCellId .~ (cell ^. _cellId)))
       ] [ ]
     , H.img [ E.onClick (E.input_ $ updateBuffer "")
             , A.class_ Vc.searchClear
@@ -56,7 +56,7 @@ searchEditor cell =
     ]
   ]
   where
-  updateBuffer :: String -> Input 
+  updateBuffer :: String -> Input
   updateBuffer v = UpdateCell (cell ^. _cellId) (_lens .~ v)
 
 _lens :: TraversalP Cell String

--- a/src/View/Notebook/Common.purs
+++ b/src/View/Notebook/Common.purs
@@ -1,20 +1,20 @@
-module View.Notebook.Common (HTML(), dataCellId, dataCellType, dataEChartsId) where
+module View.Notebook.Common where
 
-import Input.Notebook (Input())
+import Controller.Notebook (I())
 import EffectTypes (NotebookAppEff())
+import Halogen.HTML.Attributes (Attr(), attr, attributeName)
 import Halogen.HTML.Events.Monad (Event())
-import qualified Halogen.HTML as H
-import qualified Halogen.HTML.Attributes as A
+import Input.Notebook (Input())
 import Model.Notebook.Cell (CellContent(), cellContentType)
+import qualified Halogen.HTML as H
 
-type HTML e = H.HTML (Event (NotebookAppEff e) Input)
+type HTML e = H.HTML (I e)
 
+dataCellId :: forall i. Number -> Attr i
+dataCellId = attr (attributeName "data-cell-id")
 
-dataCellId :: forall i. Number -> A.Attr i
-dataCellId = A.attr (A.attributeName "data-cell-id")
+dataCellType :: forall i. CellContent -> Attr i
+dataCellType = attr (attributeName "data-cell-type") <<< cellContentType
 
-dataCellType :: forall i. CellContent -> A.Attr i
-dataCellType = A.attr (A.attributeName "data-cell-type") <<< cellContentType
-
-dataEChartsId :: forall i. String -> A.Attr i
-dataEChartsId = A.attr (A.attributeName "data-echarts-id") 
+dataEChartsId :: forall i. String -> Attr i
+dataEChartsId = attr (attributeName "data-echarts-id")


### PR DESCRIPTION
Notebooks created by exploring files don't work now, but everything else is done. I'll figure that out if we're happy with this approach (for now at least).

[This](https://github.com/slamdata/slamdata/compare/93-notebook-serialization?expand=1#diff-6e8be3f6e060590a815a0d8efa0f64fdR87) specifically is what I wanted thoughts on - basically I've wrapped every event from the cells in something which triggers a re-save of the notebook. It does exactly what we want, but probably fires a bit too much right now (for instance, for every directory read when expanding a file dropdown).

Without something like this, we'll have to manually save the notebook when performing actions in the cells, which also means passing the whole notebook through to the controller for the cells, which seems like a not-great idea if we're trying to make them componenty.

I guess another option would be to create a new `Input` for cells, which wraps messages in a constructor that distinguishes between UI-only `Input`s, and `Input`s that should trigger a notebook re-save, and then `saveOnCellUpdate` can switch based on that.