### PR TITLE
Fix KeyCombo Ord instance

### DIFF
--- a/src/Data/KeyCombo.purs
+++ b/src/Data/KeyCombo.purs
@@ -57,14 +57,19 @@ instance eqKeyCombo :: Eq KeyCombo where
 instance ordKeyCombo :: Ord KeyCombo where
   compare Meta Meta = EQ
   compare Meta _ = LT
+  compare _ Meta = GT
   compare Alt Alt = EQ
   compare Alt _ = EQ
+  compare _ Alt = GT
   compare Shift Shift = EQ
   compare Shift _ = LT
+  compare _ Shift = GT
   compare (Letter x) (Letter y) = compare x y
   compare (Letter _) _ = LT
+  compare _ (Letter _) = GT
   compare Enter Enter = EQ
   compare Enter _ = LT
+  compare _ Enter = GT
   compare (Combo xs) (Combo ys) = compare xs ys
 
 instance showKeyCombo :: Show KeyCombo where


### PR DESCRIPTION
Resolves #140 - this will fix the fact that the key combos are displayed with the letters in somewhat random places depending on the browser at the moment.