### PR TITLE
Fix hotkeys using a global state ref

### DIFF
--- a/src/Controller/Notebook.purs
+++ b/src/Controller/Notebook.purs
@@ -83,7 +83,9 @@ handleMenuNotebook signal = do
 handleMenuCell :: forall e. State -> MenuCellSignal -> I e
 handleMenuCell state signal =
   case signal of
-    EvaluateCell -> maybe empty requestCellContent (state ^? _activeCell)
+    EvaluateCell ->
+      let activeCell = state ^? _activeCell
+      in maybe empty requestCellContent activeCell
     DeleteCell -> pure $ TrashCell (state ^. _activeCellId)
     _ -> empty
 


### PR DESCRIPTION
We had inconsistent state previously. Let's just unify how we treat
notebook state.

We're now doing work twice, which sucks but it seems like a
consequence of the black box nature of Halogen state.