### PR TITLE
Specify correct repo when encrypting API token.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_deploy:
 deploy:
   provider: releases
   api-key:
-    secure: "VeEwQn8CDYPdHtNX3Sx88EvBCuYti6w1ciuDvUrhFf87iSAZS5D5yXwN/kXcTVZ9jtQdIG3u/8KisNZCdtGSkUaHU4FNJgMSGFl6kqSEx4/Tu87xu8Crpq/SgGTwI1OUKBVg720XycE1ii5GwjcESSBELDH0unPFVpVoCpqDWwg="
+    secure: "TitL0gINR0xhcMdNBSFKulH7VlS+q1bAkmkWe5H5drTGesqFQprmnoHxPM8Sstfr0DGrAsSKweN/SsUpmVpK8fUE3AcK9kNqt9HXIXr2UotYa1f3jqQKc4+KRXOOf4qjEdUwYRYYMUayR4psA/mijm3WxoVG/jrOjRZAkal/NAY="
   file: slamdata.tar.bz2
   skip_cleanup: true
   on:


### PR DESCRIPTION
This is take three. Wouldn’t be surprised if there were a take four coming up. Doesn’t seem to be well documented beyond the very basic case (and actually, that wasn’t either, come to think of it).