### PR TITLE
Notebook autosaving

### DIFF
--- a/src/Driver/Notebook.purs
+++ b/src/Driver/Notebook.purs
@@ -1,13 +1,13 @@
 module Driver.Notebook where
 
-import Api.Fs (loadNotebook)
-import Control.Monad (when)
-import Control.Monad.Aff (runAff, attempt)
+import Api.Fs (loadNotebook, saveNotebook)
+import Control.Monad (when, unless)
+import Control.Monad.Aff (Aff(), runAff, attempt)
 import Control.Monad.Eff (Eff())
-import Control.Monad.Eff.Exception (message)
-import Control.Monad.Eff.Ref (RefVal(), readRef)
+import Control.Monad.Eff.Exception (Error(), message)
+import Control.Monad.Eff.Ref (RefVal(), readRef, modifyRef, writeRef)
 import Control.Plus (empty)
-import Control.Timer (interval)
+import Control.Timer (Timeout(), timeout, clearTimeout, interval)
 import Controller.Notebook (handleMenuSignal)
 import Controller.Notebook.Cell.Explore (runExplore)
 import Controller.Notebook.Common (run)
@@ -18,26 +18,28 @@ import Data.DOM.Simple.Types (DOMEvent())
 import Data.DOM.Simple.Window (globalWindow, document)
 import Data.Either (Either(..))
 import Data.Inject1 (inj)
-import Data.Maybe (Maybe(..))
+import Data.Maybe (Maybe(..), isJust)
 import Data.Tuple (Tuple(..), fst)
-import Data.These (theseLeft)
+import Data.These (theseRight, theseLeft)
 import Driver.Notebook.Routing (Routes(..), routing)
 import EffectTypes (NotebookComponentEff(), NotebookAppEff())
 import Halogen (Driver())
 import Halogen.HTML.Events.Monad (runEvent, andThen)
 import Input.Notebook (Input(..))
-import Model.Action (isEdit)
+import Model.Action (Action(Edit), isEdit)
 import Model.Notebook
 import Model.Notebook.Cell (CellContent(..), _cellId)
 import Model.Notebook.Cell.Explore (initialExploreRec, _input)
 import Model.Notebook.Cell.FileInput
-import Model.Notebook.Domain (addCell, emptyNotebook, _activeCellId, _path, _name)
+import Model.Notebook.Domain (addCell, emptyNotebook, _activeCellId, _path, _name, notebookURL)
 import Model.Notebook.Menu
 import Model.Path (decodeURIPath, dropNotebookExt)
 import Model.Resource (resourceName, resourceDir)
 import Optic.Core ((.~), (^.), (..), (?~))
 import Routing (matches')
-import Utils (log)
+import Utils (log, setLocation)
+
+import qualified Data.Maybe.Unsafe as U
 
 tickDriver :: forall e. Driver Input (NotebookComponentEff e)
                      -> Eff (NotebookAppEff e) Unit
@@ -58,17 +60,17 @@ driver ref k =
             oldName = theseLeft (oldNotebook ^. _name)
             nameChanged = oldName /= Nothing && oldName /= Just name
         when (pathChanged || nameChanged) do
-          flip (runAff (const $ pure unit)) (attempt $ loadNotebook res) \result -> do
+          runAff' (loadNotebook res) \result -> do
             update $ (_loaded .~ true)
                   .. (_editable .~ isEdit editable)
             update case result of
               Left err -> _error ?~ message err
               Right nb -> _notebook .~ nb
         handleShortcuts ref k
-      ExploreRoute res ->
+      ExploreRoute res -> do
         let newNotebook = emptyNotebook # _path .~ resourceDir res
             newCell = Explore (initialExploreRec # _input .. _file .~ Right res)
-        in case addCell newCell newNotebook of
+        case addCell newCell newNotebook of
           Tuple notebook cell -> do
             update $ (_editable .~ true)
                   .. (_loaded .~ true)
@@ -76,6 +78,7 @@ driver ref k =
                   .. (_notebook .~ notebook)
             runEvent (\_ -> log "Error in runExplore in driver") k $
               run cell `andThen` \_ -> runExplore cell
+        handleShortcuts ref k
       _ -> update (_error ?~ "Incorrect path")
    where update = k <<< WithState
 
@@ -104,3 +107,41 @@ handleShortcuts ref k =
       13 | meta -> handle $ inj $ EvaluateCell
       _ -> pure empty
     runEvent (\_ -> log "Error in handleShortcuts") k event
+
+notebookAutosave :: forall e. RefVal State
+                           -> RefVal Timeout
+                           -> Input
+                           -> Driver Input (NotebookComponentEff e)
+                           -> Eff (NotebookAppEff e) Unit
+notebookAutosave refState refTimer input k = do
+  state <- readRef refState
+  let notebook = state ^. _notebook
+      hasBeenSaved = isJust $ theseRight (notebook ^. _name)
+      save = do
+        t <- readRef refTimer
+        clearTimeout t
+        t' <- timeout 1000 $ runAff' (saveNotebook notebook) \result -> do
+          case result of
+            Left err -> k $ WithState (_error ?~ message err)
+            Right nb -> do
+              let setName = _notebook .. _name .~ (nb ^. _name)
+              k $ WithState setName
+              -- This crime is to update the state so that when NotebookRoute is
+              -- triggered in the router, the state will have the saved-name for
+              -- the notebook, which will prevent it from re-loading it. We need
+              -- to do this now because the stateRef is updated in postRender,
+              -- but changing the URL happens immediately.
+              modifyRef refState setName
+              unless hasBeenSaved $ setLocation $ U.fromJust $ notebookURL nb Edit
+        writeRef refTimer t'
+  case input of
+    AddCell _ -> save
+    InsertCell _ _ -> save
+    UpdateCell _ _ | hasBeenSaved -> save
+    CellResult _ _ _ | hasBeenSaved -> save
+    TrashCell _ | hasBeenSaved -> save
+    _ -> pure unit
+
+
+runAff' :: forall e a. Aff e a -> (Either Error a -> Eff e Unit) -> Eff e Unit
+runAff' aff f = runAff (const $ pure unit) f (attempt aff)

--- a/src/Model/Notebook/Port.purs
+++ b/src/Model/Notebook/Port.purs
@@ -33,7 +33,9 @@ _VarMap = prism' VarMap $ \p -> case p of
   _ -> Nothing
 
 instance encodeJsonPort :: EncodeJson Port where
-  encodeJson Closed = jsonEmptyObject
+  encodeJson Closed
+    =  "type" := "closed"
+    ~> jsonEmptyObject
   encodeJson (PortResource res)
     =  "type" := "resource"
     ~> "res" := encodeJson res

--- a/src/View/Notebook.purs
+++ b/src/View/Notebook.purs
@@ -98,14 +98,9 @@ body state =
 
 
 cells :: forall e. State -> [HTML e]
-cells state = ((saveOnCellUpdate state) <$>) <$> [ H.div [ A.classes [ Vc.notebookContent ] ]
-                ((state ^. _notebook .. _cells) >>= cell state) ]
-
-saveOnCellUpdate :: forall e. State -> I e -> I e
-saveOnCellUpdate state e = e
-  -- `E.andThen` \_ -> do
-  -- liftAff (saveNotebook (state ^. _notebook))
-  -- empty
+cells state = [ H.div [ A.classes [ Vc.notebookContent ] ]
+                      $ (state ^. _notebook .. _cells) >>= cell state
+              ]
 
 margined :: forall e. [HTML e] -> [HTML e] -> HTML e
 margined l r = row [ H.div [ A.classes [ B.colMd2 ] ] l


### PR DESCRIPTION
This is almost it for #93, I just have two questions:

- For someone who knows about Ace (@puffnfresh?): do we have a way of _setting_ the content in the editors? I saw `createEditSession` accepts a string and assume that's one way, is there any other? I load/save the state for the cells, but currently the restored state leaves the Ace editors empty.
- For @jdegoes: when we load up a notebook, should we reload the contents of all of the jtables on load also? I'm assuming "yes", but if the notebook has several large result sets loading up when restored this will have some performance issues.