### PR TITLE
Publish markdown fields

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -37,7 +37,7 @@
     "purescript-lens": "^0.7.0",
     "purescript-lists": "^0.6.0",
     "purescript-maps": "^0.3.3",
-    "purescript-markdown": "2f7d778a630917540e009d5db921e7617b513e37",
+    "purescript-markdown": "ed6dc90ff70326b0355518a6e96376abd4e2e835",
     "purescript-maybe": "^0.2.2",
     "purescript-minimatch": "^0.1.0",
     "purescript-monoid": "^0.2.0",

--- a/less/main.less
+++ b/less/main.less
@@ -486,6 +486,7 @@ ol.breadcrumb {
 }
 
 .markdown-output {
+    margin-left: 1em;
     &.fade.in {
         padding-top: 10px;
     }

--- a/src/Controller/Notebook.purs
+++ b/src/Controller/Notebook.purs
@@ -32,6 +32,7 @@ import Model.Action (Action(Edit))
 import Model.Notebook (State(), _dialog, _notebook)
 import Model.Notebook.Cell (CellContent(..))
 import Model.Notebook.Cell.Explore (initialExploreRec)
+import Model.Notebook.Cell.Markdown (initialMarkdownRec)
 import Model.Notebook.Cell.Query (initialQueryRec)
 import Model.Notebook.Cell.Search (initialSearchRec)
 import Model.Notebook.Dialog
@@ -91,7 +92,7 @@ handleMenuCell state signal =
 
 handleMenuInsert :: forall e. MenuInsertSignal -> I e
 handleMenuInsert ExploreInsert = pure $ AddCell (Explore initialExploreRec)
-handleMenuInsert MarkdownInsert = pure $ AddCell (Markdown "")
+handleMenuInsert MarkdownInsert = pure $ AddCell (Markdown initialMarkdownRec)
 handleMenuInsert QueryInsert = pure $ AddCell (Query initialQueryRec)
 handleMenuInsert SearchInsert = pure $ AddCell (Search initialSearchRec)
 

--- a/src/Input/Notebook.purs
+++ b/src/Input/Notebook.purs
@@ -20,7 +20,7 @@ import Model.Notebook.Port (Port(..), VarMapValue())
 import Optic.Core (LensP(), (..), (<>~), (%~), (+~), (.~), (^.), (?~), lens)
 import Optic.Fold ((^?))
 import Optic.Setter (mapped)
-import Text.Markdown.SlamDown.Html (FormFieldValue(..), SlamDownEvent(..), SlamDownState(..), applySlamDownEvent)
+import Text.Markdown.SlamDown.Html (FormFieldValue(..), SlamDownEvent(..), SlamDownState(..), applySlamDownEvent, emptySlamDownState)
 
 import qualified Data.Array.NonEmpty as NEL
 import qualified Data.Map as M
@@ -127,8 +127,13 @@ cellContent :: Either (NEL.NonEmpty FailureMessage) CellResultContent -> Cell ->
 cellContent = either (setFailures <<< NEL.toArray) success
   where
   success :: CellResultContent -> Cell -> Cell
-  success (AceContent content) = setFailures [ ] <<< (_content .. _AceContent .~ content)
-  success (JTableContent content) = setFailures [ ] <<< (_content .. _JTableContent .~ content)
+  success (AceContent content) =
+    setFailures [ ]
+    <<< (_content.._AceContent .~ content)
+    <<< (_content.._Markdown..Ma._state .~ emptySlamDownState)
+  success (JTableContent content) =
+    setFailures [ ]
+    <<< (_content.._JTableContent .~ content)
   success MarkdownContent = setFailures [ ]
 
 onCell :: CellId -> (Cell -> Cell) -> Cell -> Cell

--- a/src/Model/Notebook/Cell/Markdown.purs
+++ b/src/Model/Notebook/Cell/Markdown.purs
@@ -1,0 +1,51 @@
+module Model.Notebook.Cell.Markdown where
+
+import Data.Argonaut.Combinators ((~>), (:=), (.?))
+import Data.Argonaut.Core (Json(), jsonEmptyObject)
+import Data.Argonaut.Decode (DecodeJson, decodeJson)
+import Data.Argonaut.Encode (EncodeJson)
+import Data.Either (Either())
+import Optic.Core (LensP(), lens)
+import Text.Markdown.SlamDown.Html (SlamDownState(), emptySlamDownState)
+import qualified Model.Notebook.Cell.Common as C
+
+newtype MarkdownRec =
+  MarkdownRec { input :: String
+              , state :: SlamDownState
+              }
+
+encodeState :: SlamDownState -> Json
+encodeState _ = jsonEmptyObject
+
+decodeState :: Json -> Either String SlamDownState
+decodeState _ = pure emptySlamDownState
+
+instance encodeJsonMarkdownRec :: EncodeJson MarkdownRec where
+  encodeJson (MarkdownRec rec)
+    =  "input" := rec.input
+    ~> "state" := encodeState rec.state
+    ~> jsonEmptyObject
+
+instance decodeJsonMarkdownRec :: DecodeJson MarkdownRec where
+  decodeJson json = do
+    obj <- decodeJson json
+    state <- obj .? "state"
+    rec <- { input: _, state: _ }
+        <$> obj .? "input"
+        <*> decodeState state
+    return $ MarkdownRec rec
+
+initialMarkdownRec :: MarkdownRec
+initialMarkdownRec =
+  MarkdownRec { input: ""
+              , state: emptySlamDownState
+              }
+
+_MarkdownRec :: LensP MarkdownRec _
+_MarkdownRec = lens (\(MarkdownRec obj) -> obj) (const MarkdownRec)
+
+_input :: LensP MarkdownRec String
+_input = _MarkdownRec <<< C._input
+
+_state :: LensP MarkdownRec SlamDownState
+_state = _MarkdownRec <<< lens _.state _{state = _}

--- a/src/Model/Notebook/Domain.purs
+++ b/src/Model/Notebook/Domain.purs
@@ -29,7 +29,7 @@ import Data.Maybe (Maybe(..), maybe)
 import Data.Path.Pathy (rootDir, dir, file, (</>), printPath)
 import Data.These (These(..), these, theseRight)
 import Data.Tuple (Tuple(..))
-import Model.Notebook.Cell (CellContent(..), CellId(), Cell(), _cellId, _output, newCell, _input, _FileInput)
+import Model.Notebook.Cell (CellContent(..), CellId(), Cell(), _cellId, _output, newCell, _input, _parent, _FileInput)
 import Model.Notebook.Cell.FileInput (_file, fileFromString, portFromFile)
 import Model.Notebook.Port (Port(..), _PortResource)
 import Model.Action (Action(), printAction)
@@ -138,7 +138,9 @@ insertCell parent content oldNotebook@(Notebook n) = Tuple new cell
   newDeps = insert newId (parent ^. _cellId) n.dependencies
   newId = freeId oldNotebook
   cell = newCell newId (content # _FileInput .. _file .~ maybe (Left "") Right (port ^? _PortResource))
-         # (_output .~ port) .. (_input .~ (parent ^. _output))
+         # (_output .~ port)
+         ..(_input  .~ (parent ^. _output))
+         ..(_parent .~ Just (parent ^. _cellId))
   port = cellOut oldNotebook newId
 
 cellOut :: Notebook -> CellId -> Port

--- a/src/View/Notebook/Cell.purs
+++ b/src/View/Notebook/Cell.purs
@@ -193,9 +193,9 @@ cellInfo cell = case cell ^. _content of
 
 editor :: forall e. Cell -> HTML e
 editor state = case state ^. _content of
-  (Explore rec) -> exploreEditor state
-  (Search _) -> searchEditor state
-  (Visualize _) -> vizChoices state
+  Explore rec -> exploreEditor state
+  Search _ ->searchEditor state
+  Visualize _ -> vizChoices state
   _ -> aceEditor state
 
 renderOutput :: forall e. Cell -> [HTML e]
@@ -204,7 +204,7 @@ renderOutput cell =
   then []
   else case cell ^. _content of
     Explore _ -> exploreOutput cell
-    Markdown s -> markdownOutput s (cell ^. _cellId)
+    Markdown mr -> markdownOutput mr cell
     Search _ -> searchOutput cell
     Visualize _ -> vizOutput cell
     Query _ -> queryOutput cell

--- a/src/View/Notebook/Cell.purs
+++ b/src/View/Notebook/Cell.purs
@@ -31,6 +31,7 @@ import qualified Halogen.HTML.Events.Forms as E
 import qualified Halogen.HTML.Events.Handler as E
 import qualified Halogen.HTML.Events.Monad as E
 import qualified Halogen.Themes.Bootstrap3 as B
+import qualified Model.Notebook.Cell.Query as Qu
 import qualified View.Css as VC
 
 cell :: forall e. State -> Cell -> [HTML e]
@@ -92,6 +93,12 @@ cellOutputBar notebook cell =
              [ li "Query this output" (E.input_ $ InsertCell cell $ newQueryContent res) B.glyphiconHdd
              , li "Search this output" (E.input_ $ InsertCell cell $ newSearchContent res) B.glyphiconSearch
              , li "Visualize this output" (\_ -> pure $ insertViz notebook cell) B.glyphiconPicture
+             ]
+      ]
+
+    VarMap _ ->
+      [ H.ul [ A.classes [VC.nextCellList] ]
+             [ li "Query using fields" (E.input_ $ InsertCell cell $ Query Qu.initialQueryRec) B.glyphiconHdd
              ]
       ]
 

--- a/src/View/Notebook/Cell/Markdown.purs
+++ b/src/View/Notebook/Cell/Markdown.purs
@@ -1,11 +1,14 @@
 module View.Notebook.Cell.Markdown (markdownOutput) where
 
 import Data.Array (null)
-import EffectTypes (NotebookAppEff())
+import EffectTypes (NotebookAppEff()) 
 import Input.Notebook (Input(..))
-import Model.Notebook.Cell (CellId())
-import Text.Markdown.SlamDown.Html (SlamDownEvent(), renderHalogen)
+import Model.Notebook.Cell (Cell(), _cellId)
+import Model.Notebook.Cell.Markdown (MarkdownRec(), _input, _state)
+import Optic.Core ((^.))
+import Text.Markdown.SlamDown.Html (SlamDownState(), SlamDownEvent(), renderHalogen)
 import Text.Markdown.SlamDown.Parser (parseMd)
+import View.Notebook.Common (HTML())
 import View.Common (fadeWhen)
 import View.Notebook.Common (HTML())
 
@@ -14,14 +17,22 @@ import qualified Halogen.HTML.Attributes as A
 import qualified Halogen.HTML.Events.Monad as E
 import qualified View.Css as VC
 
-markdownOutput :: forall e. String -> CellId -> [HTML e]
-markdownOutput s cellId =
-  let md = renderHalogen $ parseMd s
-  in if null md
-     then []
-     else [ H.div [ A.classes ([ VC.markdownOutput ] <> (fadeWhen $ s == "")) ]
-                  $ fromSlamDownEvents $ md
-          ]
+type SlamDownHTML e = H.HTML (E.Event (NotebookAppEff e) SlamDownEvent)
+
+markdownOutput :: forall e. MarkdownRec -> Cell -> [HTML e]
+markdownOutput mr cell =
+  optionalHTML
+  <<< renderHalogen (mr ^. _state)
+  <<< parseMd
+  $ mr ^. _input
   where
-  fromSlamDownEvents :: [H.HTML (E.Event (NotebookAppEff e) SlamDownEvent)] -> [HTML e]
-  fromSlamDownEvents = ((((CellSlamDownEvent cellId) <$>) <$>) <$>)
+  optionalHTML :: [SlamDownHTML e] -> [HTML e]
+  optionalHTML md =
+    if null md
+    then [ ]
+    else [ H.div [ A.classes ([ VC.markdownOutput ] <> (fadeWhen $ (mr ^. _input) == "")) ]
+                 $ fromSlamDownEvents md
+         ]
+
+  fromSlamDownEvents :: [SlamDownHTML e] -> [HTML e]
+  fromSlamDownEvents = ((((CellSlamDownEvent $ cell ^. _cellId) <$>) <$>) <$>)


### PR DESCRIPTION
To test:

Add a Markdown cell:

```
a=_(b)
```

Run and create a query child cell via the button. Write the following query:

```sql
SELECT :a
```

Execute, you should get an error. Change the input field on the cell's output to 2 and then run the query cell again. You should get a table with the number 2.