### PR TITLE
Split the build task to help reduce timeouts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,9 @@ install:
   - npm install bower gulp -g
   - npm install && bower install --force
 script:
-  - travis_wait gulp less deploy-prod
+  - gulp less
+  - travis_wait gulp deploy-prod-entries-file
+  - travis_wait gulp deploy-prod-entries-notebook
 before_deploy:
   - cp -r public slamdata
   - tar cjf slamdata.tar.bz2 slamdata


### PR DESCRIPTION
`travis_wait` should be doing this for us anyway, but appears not to work - it's supposed to print a line every minute for 20 minutes, perhaps it's an interaction with `gulp` or something.