### PR TITLE
Fix cutoff top of view page

### DIFF
--- a/less/main.less
+++ b/less/main.less
@@ -34,7 +34,6 @@ body {
 }
 
 .notebook-view-hack {
-    margin-top: -111px;
     .cell-controls, .cell-input, .cell-output-label {
         display: none;
     }


### PR DESCRIPTION
Oops, I lied. This is the last one, but it's pretty critical. After fixing the smaller-screen layout, the view notebook page was cutting off the top of the view.