### PR TITLE
Make query paths relative to notebook

### DIFF
--- a/src/Controller/Notebook/Cell/Query.purs
+++ b/src/Controller/Notebook/Cell/Query.purs
@@ -18,7 +18,7 @@ runQuery cell = fromMaybe empty $ queryToJTable cell input <$> path <*> output
   output = cell ^? _output .. _PortResource
 
   path :: Maybe Resource
-  path = parent <<< parent <$> output
+  path = parent <$> output
 
   input :: String
   input = cell ^. _content .. _Query .. Qu._input

--- a/src/Model/Notebook/Cell.purs
+++ b/src/Model/Notebook/Cell.purs
@@ -145,7 +145,7 @@ newSearchContent :: Resource -> CellContent
 newSearchContent res = Search (Sr.initialSearchRec # Sr._input .. _file .~ Right res)
 
 newQueryContent :: Resource -> CellContent
-newQueryContent res = Query (Qu.initialQueryRec # Qu._input .~ "SELECT * FROM \"" ++ resourcePath res ++ "\"")
+newQueryContent res = Query (Qu.initialQueryRec # Qu._input .~ "SELECT * FROM \"" ++ resourceName res ++ "\"")
 
 newVisualizeContent :: CellContent
 newVisualizeContent = Visualize Vz.initialVizRec


### PR DESCRIPTION
@jdegoes As discussed in #230.

Previously they were relative to the directory the notebook was created inside, so you could `SELECT * FROM zips` for example, but that' won't work now. Is that ok?