### PR TITLE
216 view

### DIFF
--- a/src/Controller/Notebook/Cell.purs
+++ b/src/Controller/Notebook/Cell.purs
@@ -1,6 +1,7 @@
 module Controller.Notebook.Cell
   ( requestCellContent
   , runCell
+  , viewCell
   , handleRunClick
   , handleShareClick
   , isRunning
@@ -12,9 +13,9 @@ import Control.Monad.Aff.Class (liftAff)
 import Control.Monad.Eff.Class (liftEff)
 import Control.Monad.Eff.Exception (message)
 import Control.Plus (empty)
-import Controller.Notebook.Cell.Explore (runExplore)
-import Controller.Notebook.Cell.Query (runQuery)
-import Controller.Notebook.Cell.Search (runSearch)
+import Controller.Notebook.Cell.Explore (runExplore, viewExplore)
+import Controller.Notebook.Cell.Query (runQuery, viewQuery)
+import Controller.Notebook.Cell.Search (runSearch, viewSearch)
 import Controller.Notebook.Cell.Viz (runViz)
 import Controller.Notebook.Common (I())
 import Data.Date (now)
@@ -44,6 +45,16 @@ runCell cell = do
     Visualize _ -> runViz cell
     Markdown _ -> runMarkdown cell
     Query _ -> runQuery cell
+
+viewCell :: forall eff. Cell -> I eff
+viewCell cell = do
+  d <- liftEff now
+  case cell ^._content of
+    Search _ -> viewSearch (cell # _runState .~ (RunningSince d))
+    Explore _ -> viewExplore cell
+    Visualize _ -> runViz cell
+    Markdown _ -> runMarkdown cell
+    Query _ -> viewQuery cell
 
 requestCellContent :: forall eff. Cell -> I eff
 requestCellContent cell = pure $ RequestCellContent cell

--- a/src/Controller/Notebook/Cell.purs
+++ b/src/Controller/Notebook/Cell.purs
@@ -46,6 +46,7 @@ runCell cell = do
     Markdown _ -> runMarkdown cell
     Query _ -> runQuery cell
 
+
 viewCell :: forall eff. Cell -> I eff
 viewCell cell = do
   d <- liftEff now

--- a/src/Controller/Notebook/Cell/Explore.purs
+++ b/src/Controller/Notebook/Cell/Explore.purs
@@ -1,5 +1,6 @@
-module Controller.Notebook.Cell.Explore (runExplore) where
+module Controller.Notebook.Cell.Explore (runExplore, viewExplore) where
 
+import Control.Plus (empty)
 import Control.Monad.Eff.Class (liftEff)
 import Controller.Notebook.Cell.JTableContent (runJTable)
 import Controller.Notebook.Common (I())
@@ -25,3 +26,8 @@ runExplore cell = case cell ^? _input .. _PortResource of
     now' <- liftEff now
     let msg = fromMaybe "Please select a file" (cell ^? _input .. _PortInvalid)
     return $ inj $ CellResult (cell ^. _cellId) now' (Left $ NEL.singleton msg)
+
+
+viewExplore :: forall e. Cell -> I e
+viewExplore cell =
+  fromMaybe empty ((flip runJTable cell) <$> (cell ^? _input.._PortResource))

--- a/src/Controller/Notebook/Cell/JTableContent.purs
+++ b/src/Controller/Notebook/Cell/JTableContent.purs
@@ -135,3 +135,4 @@ queryToJTable cell sql inp out = do
   errorInQuery err =
     update cell (_failures .~ ["Error in query: " <> err])
       `andThen` \_ -> finish cell
+

--- a/src/Controller/Notebook/Cell/Query.purs
+++ b/src/Controller/Notebook/Cell/Query.purs
@@ -1,10 +1,10 @@
 module Controller.Notebook.Cell.Query where
 
 import Control.Plus (empty)
-import Controller.Notebook.Cell.JTableContent (queryToJTable)
+import Controller.Notebook.Cell.JTableContent (queryToJTable, runJTable)
 import Controller.Notebook.Common (I())
 import Data.Maybe (Maybe(), fromMaybe)
-import Model.Notebook.Cell (Cell(), _Query, _content, _output)
+import Model.Notebook.Cell (Cell(), _Query, _content, _output, _input)
 import Model.Notebook.Port (_PortResource)
 import Model.Resource (Resource(), parent, root)
 import Optic.Core ((^.), (..))
@@ -22,3 +22,8 @@ runQuery cell = fromMaybe empty $ queryToJTable cell input <$> path <*> output
 
   input :: String
   input = cell ^. _content .. _Query .. Qu._input
+
+
+viewQuery :: forall e. Cell -> I e
+viewQuery cell =
+  fromMaybe empty ((flip runJTable cell) <$> (cell ^? _input.._PortResource))

--- a/src/Controller/Notebook/Cell/Query.purs
+++ b/src/Controller/Notebook/Cell/Query.purs
@@ -26,4 +26,5 @@ runQuery cell = fromMaybe empty $ queryToJTable cell input <$> path <*> output
 
 viewQuery :: forall e. Cell -> I e
 viewQuery cell =
-  fromMaybe empty ((flip runJTable cell) <$> (cell ^? _input.._PortResource))
+  fromMaybe empty ((flip runJTable cell) <$> (cell ^? _output.._PortResource))
+

--- a/src/Controller/Notebook/Cell/Search.purs
+++ b/src/Controller/Notebook/Cell/Search.purs
@@ -1,5 +1,6 @@
 module Controller.Notebook.Cell.Search (
   runSearch
+  , viewSearch
   ) where
 
 import Control.Plus (empty)
@@ -83,3 +84,14 @@ runSearch cell =
   errorInPorts =
     update cell (_failures .~ ["Incorrect type of input or output"])
       `andThen` \_ -> finish cell
+
+
+viewSearch :: forall e. Cell -> I e
+viewSearch cell =
+  maybe error (flip runJTable cell) (cell ^? _input.._PortResource)
+  where
+  error :: I e
+  error =
+    update cell (_failures .~ ["Incorrect type of input"])
+      `andThen` \_ -> finish cell
+  

--- a/src/Controller/Notebook/Cell/Search.purs
+++ b/src/Controller/Notebook/Cell/Search.purs
@@ -88,7 +88,7 @@ runSearch cell =
 
 viewSearch :: forall e. Cell -> I e
 viewSearch cell =
-  maybe error (flip runJTable cell) (cell ^? _input.._PortResource)
+  maybe error (flip runJTable cell) (cell ^? _output.._PortResource)
   where
   error :: I e
   error =

--- a/src/Controller/Notebook/Cell/Viz.purs
+++ b/src/Controller/Notebook/Cell/Viz.purs
@@ -19,7 +19,7 @@ import Data.Tuple
 import Halogen.HTML.Events.Monad (andThen)
 import Input.Notebook (Input(..))
 import Model.Notebook (State(), _notebook)
-import Model.Notebook.Cell (Cell(), _content, _Visualize, _cellId, CellId(), _runState, _input, newVisualizeContent, RunState(..))
+import Model.Notebook.Cell (Cell(), _content, _Visualize, _cellId, CellId(), _runState, _input, _hasRun, newVisualizeContent, RunState(..))
 import Model.Notebook.Cell.Viz 
 import Model.Notebook.Domain
 import Model.Notebook.Port (_PortResource)
@@ -108,7 +108,7 @@ updateData cell file = do
         vRec = configure $ (vizRec # _all .~ all
                                    # _sample .~ sample
                            )
-    (update cell (_content .. _Visualize .~ vRec)) <>
+    (update cell ((_content .. _Visualize .~ vRec) .. (_hasRun .~ true))) <>
     (updateOpts (cell # _content.._Visualize .~ vRec))
 
   where

--- a/src/Driver/Notebook.purs
+++ b/src/Driver/Notebook.purs
@@ -94,7 +94,8 @@ driver ref k =
                      when (cell ^. _hasRun) do
                        if isEdit editable
                          then runEvent (\err -> log $ "Error requestCellContent in driver: " ++ show err) k $ requestCellContent cell
-                         else k (ViewCellContent cell)
+                         else do
+                         k (ViewCellContent cell)
 
          update = k <<< WithState
          cellUpdate cell = k <<< (UpdateCell (cell ^._cellId))

--- a/src/Driver/Notebook/Cell.purs
+++ b/src/Driver/Notebook/Cell.purs
@@ -27,6 +27,7 @@ driveCellContent (ViewCellContent cell) driver =
     Search _ -> view cell driver
     Explore _ -> view cell driver
     Visualize _ -> view cell driver
+    Query _ -> view cell driver
     _ -> pure unit 
 driveCellContent _ _ = return unit
 

--- a/src/Driver/Notebook/Cell.purs
+++ b/src/Driver/Notebook/Cell.purs
@@ -1,7 +1,7 @@
 module Driver.Notebook.Cell where
 
 import Control.Monad.Eff (Eff())
-import Controller.Notebook.Cell (runCell)
+import Controller.Notebook.Cell (runCell, viewCell)
 import Controller.Notebook.Common (I())
 import Data.Date (now)
 import EffectTypes (NotebookAppEff(), NotebookComponentEff())
@@ -22,6 +22,12 @@ driveCellContent (RequestCellContent cell) driver =
     Visualize _ -> runWith cell driver
     _ -> return unit
 driveCellContent (ReceiveCellContent cell) driver = runWith cell driver
+driveCellContent (ViewCellContent cell) driver =
+  case cell ^. _content of
+    Search _ -> view cell driver
+    Explore _ -> view cell driver
+    Visualize _ -> view cell driver
+    _ -> pure unit 
 driveCellContent _ _ = return unit
 
 runWith :: forall eff. Cell -> Driver Input (NotebookComponentEff eff) -> Eff (NotebookAppEff eff) Unit
@@ -29,3 +35,10 @@ runWith cell driver = do
   d <- now
   driver $ StartRunCell (cell ^. _cellId) d
   driveEvent driver $ runCell cell
+
+view :: forall eff. Cell -> Driver Input (NotebookComponentEff eff) -> Eff (NotebookAppEff eff) Unit
+view cell driver = do
+  d <- now
+  driver $ StartRunCell (cell ^. _cellId) d
+  driveEvent driver $ viewCell cell
+

--- a/src/Input/Notebook.purs
+++ b/src/Input/Notebook.purs
@@ -48,6 +48,7 @@ data Input
 
   | RequestCellContent Cell
   | ReceiveCellContent Cell
+  | ViewCellContent Cell
 
   | StartRunCell CellId Date
   | StopCell CellId


### PR DESCRIPTION
fixes #216 
fixes #173

Added special behaviour on cell with `hasRun` in view mode. They now ask their outputs and show JTables with its content. No rerun and deleting of temporary files happen --> viz cell works correct, all dependent cells work correct. 

But it make editing of markdown content have no meaning in view mode. Probably not much problems with it since we have no *play* button in published cells. 

We can remove this resume after #175 will be finished. 