### PR TITLE
Save notebook on name change

### DIFF
--- a/src/Api/Fs.purs
+++ b/src/Api/Fs.purs
@@ -110,20 +110,25 @@ saveNotebook :: forall e. N.Notebook -> Aff (ajax :: AJAX | e) N.Notebook
 saveNotebook notebook = case notebook ^. N._name of
   That name -> save name *> pure notebook
   This name -> do
-    let baseName = (U.fromJust $ theseLeft (notebook ^. N._name)) ++ "." ++ Config.notebookExtension
-    name <- getNewName (notebook ^. N._path) baseName
+    name <- getNewName' (U.fromJust $ theseLeft (notebook ^. N._name))
     save name
     pure $ N.replacePendingPorts (notebook # N._name .~ That (dropNotebookExt name))
-  Both newName oldName | newName /= oldName -> do
+  Both newName oldName -> do
     save oldName
-    alreadyExists <- exists (newName ++ "." ++ Config.notebookExtension) (notebook ^. N._path)
-    if alreadyExists
-      then throwError (error "A file already exists with the specified name")
-      else
+    if newName /= oldName
+      then do
+        newName' <- getNewName' newName
         let oldPath = (notebook ^. N._path) </> dir oldName <./> Config.notebookExtension
-            newPath = Right $ (notebook ^. N._path) </> dir newName <./> Config.notebookExtension
-        in move (R.Directory oldPath) newPath *> pure (notebook # N._name .~ That newName)
+            newPath = Right $ (notebook ^. N._path) </> dir newName' <./> Config.notebookExtension
+        move (R.Directory oldPath) newPath
+        pure (notebook # N._name .~ That (dropNotebookExt newName'))
+      else pure notebook
   where
+
+  getNewName' :: String -> Aff (ajax :: AJAX | e) String
+  getNewName' name =
+    let baseName = name ++ "." ++ Config.notebookExtension
+    in getNewName (notebook ^. N._path) baseName
 
   save :: String -> Aff (ajax :: AJAX | e) Unit
   save name =

--- a/src/View/Notebook.purs
+++ b/src/View/Notebook.purs
@@ -160,11 +160,11 @@ menuItem state {name: name, message: mbMessage, lvl: lvl, shortcut: shortcut} =
 name :: forall e. State -> HTML e
 name state =
   H.div [ A.classes [Vc.notebookName] ]
-        [ H.form [ E.onSubmit (\_ -> E.preventDefault $> handleSubmitName state) ]
-                 [ H.input [ A.id_ Config.notebookNameEditorId
-                           , E.onInput (pure <<< handleNameInput)
-                           , A.value (these id id (\n _ -> n) $ state ^. _notebook .. _name)
-                           ]
-                           []
-                 ]
+        [ H.form_ [ H.input [ A.id_ Config.notebookNameEditorId
+                            , E.onInput (pure <<< handleNameInput)
+                            , E.onChange (\_ -> pure $ handleSubmitName state)
+                            , A.value (these id id (\n _ -> n) $ state ^. _notebook .. _name)
+                            ]
+                            []
+                  ]
         ]


### PR DESCRIPTION
Resolves #244.

This also now always appends a number if attempting to save a notebook with the same name as another. As a bonus, changing the behaviour to this will also resolve #243 and resolve #228. I'm really not sure about the underlying cause of those two, but as now we never reject filenames there will be no error.