### PR TITLE
CSV upload, file system error dialogs

### DIFF
--- a/less/main.less
+++ b/less/main.less
@@ -217,9 +217,21 @@ ol.breadcrumb {
     ul.list-inline {
         margin-top: 8px;
         margin-bottom: 0;
-        li a i.btn-lg.glyphicon {
-            padding-right: 0 !important;
-        }
+    }
+}
+
+.toolbar-menu button, .item-toolbar button {
+    background: none;
+    border: 0;
+    padding: 0;
+    color: #337ab7;
+
+    i.btn-lg.glyphicon {
+        padding-right: 0 !important;
+    }
+
+    &:hover {
+        color: #23527c
     }
 }
 

--- a/src/Controller/File.purs
+++ b/src/Controller/File.purs
@@ -114,8 +114,8 @@ handleCreateFolder state = do
       dir = initDirectory{phantom = true} #
             _resource.._path .~ inj dirPath
       hiddenFile = dirPath </> file (Config.folderMark)
-  added <- liftAff $ attempt $ API.makeFile (inj hiddenFile) "{}"
-  (toInput (ItemRemove dir)) `andThen` \_ -> 
+  added <- liftAff $ attempt $ API.makeFile (inj hiddenFile) Nothing "{}"
+  (toInput (ItemRemove dir)) `andThen` \_ ->
   case added of
     Left _ -> empty
     Right _ -> toInput (ItemAdd (dir{phantom = false} # _resource .. _path .~ inj dirPath))

--- a/src/Controller/File/Common.purs
+++ b/src/Controller/File/Common.purs
@@ -1,8 +1,16 @@
 module Controller.File.Common where
 
 import Data.Inject1 (Inject1, inj)
+import Data.Maybe (Maybe(..))
+import EffectTypes (FileAppEff())
+import Halogen.HTML.Events.Monad (Event())
+import Input.File
+import Model.File.Dialog
 
 -- | Lifts an input value into an applicative and injects it into the right
 -- | place in an Either.
 toInput :: forall m a b. (Applicative m, Inject1 a b) => a -> m b
 toInput = pure <<< inj
+
+showError :: forall e. String -> Event (FileAppEff e) Input
+showError = toInput <<< SetDialog <<< Just <<< ErrorDialog

--- a/src/Controller/File/Item.purs
+++ b/src/Controller/File/Item.purs
@@ -6,7 +6,7 @@ import Control.Monad.Aff.Class (liftAff)
 import Control.Monad.Eff.Class (liftEff)
 import Control.Plus (empty)
 import Controller.Common (getDirectories)
-import Controller.File.Common (toInput)
+import Controller.File.Common (toInput, showError)
 import Data.DOM.Simple.Element (getElementById)
 import Data.DOM.Simple.Encode (encodeURIComponent)
 import Data.DOM.Simple.Window (document, globalWindow)
@@ -71,7 +71,7 @@ handleConfigure :: forall e. Resource -> Event (FileAppEff e) Input
 handleConfigure res = do
   x <- liftAff $ mountInfo res
   case runParseAbsoluteURI x of
-    Left err -> empty -- TODO: show error in the unlikely event that this happens
+    Left err -> showError ("There was a problem reading the mount settings: " ++ show err)
     Right uri ->
       let rec = (mountDialogFromURI uri) { new = false
                                          , name = if getPath res == Right rootDir then "/" else resourceName res

--- a/src/Model/File/Dialog.purs
+++ b/src/Model/File/Dialog.purs
@@ -7,3 +7,4 @@ data Dialog
   = RenameDialog RenameDialogRec
   | MountDialog MountDialogRec
   | ShareDialog String
+  | ErrorDialog String

--- a/src/View/File/Common.purs
+++ b/src/View/File/Common.purs
@@ -16,10 +16,10 @@ type I e = E.Event (FileAppEff e) Input
 
 toolItem :: forall a m i. (Alternative m) => [A.ClassName] -> a -> (a -> m i) -> String -> A.ClassName -> H.HTML (m i)
 toolItem classes actionArg action title icon =
-  H.li_ [ H.a (targetLink' $ action actionArg)
-              [ H.i [ A.title title
-                    , A.classes (classes ++ [B.glyphicon, icon])
-                    ]
-                    []
-              ]
+  H.li_ [ H.button [ E.onClick (\_ -> pure $ action actionArg) ]
+                   [ H.i [ A.title title
+                         , A.classes (classes ++ [B.glyphicon, icon])
+                         ]
+                         []
+                   ]
         ]

--- a/src/View/File/Modal.purs
+++ b/src/View/File/Modal.purs
@@ -8,6 +8,7 @@ import EffectTypes (FileAppEff())
 import Input.File (Input(), FileInput(SetDialog))
 import Model.File (State())
 import Model.File.Dialog (Dialog(..))
+import View.File.Modal.ErrorDialog (errorDialog)
 import View.File.Modal.MountDialog (mountDialog)
 import View.File.Modal.RenameDialog (renameDialog)
 import View.File.Modal.ShareDialog (shareDialog)
@@ -37,3 +38,4 @@ dialogContent :: forall e. Dialog -> [H.HTML (E.Event (FileAppEff e) Input)]
 dialogContent (ShareDialog url) = shareDialog url
 dialogContent (RenameDialog dialog) = renameDialog dialog
 dialogContent (MountDialog dialog) = mountDialog dialog
+dialogContent (ErrorDialog msg) = errorDialog msg

--- a/src/View/File/Modal/ErrorDialog.purs
+++ b/src/View/File/Modal/ErrorDialog.purs
@@ -1,0 +1,28 @@
+module View.File.Modal.ErrorDialog where
+
+import Data.Inject1 (inj)
+import Data.Maybe (Maybe(..))
+import Input.File
+import Model.File
+import Optic.Core ((.~))
+import View.File.Common (I())
+import View.Modal.Common
+
+import qualified Halogen.HTML as H
+import qualified Halogen.HTML.Attributes as A
+import qualified Halogen.HTML.Events as E
+import qualified Halogen.HTML.Events.Monad as E
+import qualified Halogen.Themes.Bootstrap3 as B
+
+errorDialog :: forall e. String -> [H.HTML (I e)]
+errorDialog message =
+  [ header $ h4 "Error"
+  , body [ H.div [ A.classes [B.alert, B.alertDanger] ]
+                 [ H.text message ]
+         ]
+  , footer [ H.button [ A.classes [B.btn]
+                      , E.onClick (E.input_ $ inj $ SetDialog Nothing)
+                      ]
+                      [ H.text "Dismiss" ]
+           ]
+  ]

--- a/src/View/File/Toolbar.purs
+++ b/src/View/File/Toolbar.purs
@@ -36,19 +36,17 @@ toolbar state =
   showFiles = toolItem [B.btnLg] false handleHiddenFiles "show hidden files" B.glyphiconEyeOpen
 
   file :: H.HTML (I e)
-  file = H.li_ [ H.a [ A.href "javascript:void(0);"
-                     , E.onClick (\ev -> pure $ handleUploadFile ev.target state)
-                     ]
-                     [ H.i [ A.title "upload file"
-                           , A.classes [B.btnLg, B.glyphicon, B.glyphiconFile]
-                           ]
-                           [ H.input [ A.class_ B.hidden
-                                     , A.type_ "file"
-                                     , E.onChange (\ev -> pure $ handleFileListChanged ev.target state)
-                                     ]
-                                     []
-                           ]
-                     ]
+  file = H.li_ [ H.button [ E.onClick (\ev -> pure $ handleUploadFile ev.target) ]
+                          [ H.i [ A.title "upload file"
+                                , A.classes [B.btnLg, B.glyphicon, B.glyphiconFile]
+                                ]
+                                [ H.input [ A.class_ B.hidden
+                                          , A.type_ "file"
+                                          , E.onChange (\ev -> pure $ handleFileListChanged ev.target state)
+                                          ]
+                                          []
+                                ]
+                          ]
                ]
 
 


### PR DESCRIPTION
I think this resolves #87 at last.

Also there were a bunch of places that would fail silently previously, now an error message will be presented in a modal dialog. Most of them are exceptional failures, not things that should happen during normal interaction, so the modal may be a little more intrusive than is ideal, but since they should never be seen anyway it's probably ok.

[There is some code in here](https://github.com/slamdata/slamdata/compare/87-csv-upload?expand=1#diff-cc24a5615b3868e85a6c7b7533f1793cR64) that I've intentionally left even though it's not used now, as it will come in handy again when we do the JSON format detection.