### PR TITLE
Phantom (pending) file/folder display tweaks

### DIFF
--- a/less/main.less
+++ b/less/main.less
@@ -77,6 +77,19 @@ button:focus {
 }
 .item-toolbar {
     padding-right: 0px;
+    display: none;
+}
+
+.list-group-item:hover .item-toolbar, .item-toolbar.selected {
+    display: block;
+}
+
+.list-group-item.phantom {
+    color: #999;
+    img {
+        width: 16px;
+        margin-right: 18px;
+    }
 }
 
 .item-content {

--- a/src/Driver/File/Path.purs
+++ b/src/Driver/File/Path.purs
@@ -1,6 +1,5 @@
 module Driver.File.Path
-  ( extractDir
-  , updateSort
+  ( updateSort
   , updateQ
   , updateSalt
   , setSort
@@ -51,10 +50,6 @@ updateSalt salt old =
 
 setSort :: Sort -> String
 setSort sort = "?sort=" <> sort2string sort <> "&q=&salt="
-
-extractDir :: String -> DirPath
-extractDir hash =
-  maybe rootDir (rootDir </>) (parseAbsDir (getPath' hash) >>= sandbox rootDir)
 
 getPath' :: String -> String
 getPath' hash =

--- a/src/Input/File/Item.purs
+++ b/src/Input/File/Item.purs
@@ -11,7 +11,6 @@ import Model.Sort (Sort())
 data ItemInput
   = ItemAdd Item
   | ItemRemove Item
-  | ItemHover Number Boolean
   | ItemSelect Number Boolean
   | Resort
   | Clear
@@ -24,9 +23,6 @@ inputItem sort searching items input = case input of
 
   ItemRemove item ->
     resort sort searching $ filter (\x -> not $ x.resource == item.resource) items
-
-  ItemHover ix h ->
-    modify (flip _ { hovered = _ }) items ix
 
   ItemSelect ix h ->
     modify (flip _ { selected = _ }) items ix

--- a/src/Model/File/Item.purs
+++ b/src/Model/File/Item.purs
@@ -2,12 +2,11 @@ module Model.File.Item where
 
 import Model.Resource
 import Model.Sort
-import Optic.Core 
+import Optic.Core
 
 type Item =
   { selected :: Boolean
-  , hovered :: Boolean
-  , phantom :: Boolean 
+  , phantom :: Boolean
   , resource :: Resource
   }
 
@@ -18,7 +17,6 @@ _resource = lens _.resource (_{resource = _})
 wrap :: Resource -> Item
 wrap r =
   { selected: false
-  , hovered: false
   , phantom: false
   , resource: r}
 
@@ -33,7 +31,7 @@ initNotebook = wrap newNotebook
 
 sortItem :: Boolean -> Sort -> Item -> Item -> Ordering
 sortItem isSearching sort a b =
-    sortResource (sortProjection isSearching) sort a.resource b.resource 
+    sortResource (sortProjection isSearching) sort a.resource b.resource
     where
     sortProjection true = resourcePath
     sortProjection _ = resourceName

--- a/src/View/Css.purs
+++ b/src/View/Css.purs
@@ -2,6 +2,12 @@ module View.Css where
 
 import Halogen.HTML.Attributes (className, ClassName())
 
+selected :: ClassName
+selected = className "selected"
+
+phantom :: ClassName
+phantom = className "phantom"
+
 searchInput :: ClassName
 searchInput = className "search-input"
 

--- a/src/View/File/Item.purs
+++ b/src/View/File/Item.purs
@@ -34,42 +34,53 @@ items state =
         $ zipWith (item state) (0..length state.items) state.items
 
 item :: forall e. State -> Number -> Item -> H.HTML (I e)
-item state ix item =
-  H.div [ A.classes ([B.listGroupItem] ++
-                     (if item.selected
-                      then [B.listGroupItemInfo]
-                      else []) ++
-                     (if hiddenTopLevel item.resource
-                      then if state.showHiddenFiles
-                           then [Vc.itemHidden]
-                           else [B.hidden]
-                      else []))
-        , E.onMouseOver (E.input_ $ inj $ ItemHover ix true)
-        , E.onClick (E.input_ $ inj $ ItemSelect ix true)
-        , E.onDoubleClick (\_ -> pure $ openItem item state.sort state.salt)
-        ]
-        [ H.div [ A.class_ B.row ]
-          [ H.div [ A.classes [B.colXs9, Vc.itemContent]]
-            [ H.a
-              [ A.href $ itemURL state.sort state.salt Edit item ]
-              [ H.span_ [ H.i [ iconClasses item ] []
+item state ix item
+  | item.phantom =
+    H.div [ A.classes [B.listGroupItem, Vc.phantom] ]
+          [ H.div [ A.class_ B.row ]
+            [ H.div [ A.classes [B.colXs9, Vc.itemContent]]
+              [ H.span_ [ H.img [ A.src "img/spin.svg" ] [ ]
                         , H.text $ (if state.searching
                                     then resourcePath
                                     else resourceName) item.resource
                         ]
               ]
             ]
-          , H.div [ A.classes [B.colXs3, Vc.itemToolbar] ]
-            [ H.ul [ A.classes ([B.listInline, B.pullRight] ++
-                                if not $ item.hovered || item.selected
-                                then [B.hidden]
-                                else [])
-                   , CSS.style (marginBottom $ px 0)
-                   ]
-              (showToolbar item state)
+          ]
+  | otherwise =
+    H.div [ A.classes ([B.listGroupItem] ++
+                       (if item.selected
+                        then [B.listGroupItemInfo]
+                        else []) ++
+                       (if hiddenTopLevel item.resource
+                        then if state.showHiddenFiles
+                             then [Vc.itemHidden]
+                             else [B.hidden]
+                        else []))
+          , E.onClick (E.input_ $ inj $ ItemSelect ix true)
+          , E.onDoubleClick (\_ -> pure $ openItem item state.sort state.salt)
+          ]
+          [ H.div [ A.class_ B.row ]
+            [ H.div [ A.classes [B.colXs9, Vc.itemContent]]
+              [ H.a
+                [ A.href $ itemURL state.sort state.salt Edit item ]
+                [ H.span_ [ H.i [ iconClasses item ] []
+                          , H.text $ (if state.searching
+                                      then resourcePath
+                                      else resourceName) item.resource
+                          ]
+                ]
+              ]
+            , H.div [ A.classes $ [B.colXs3, Vc.itemToolbar] ++ if item.selected
+                                                                then [Vc.selected]
+                                                                else [] ]
+              [ H.ul [ A.classes ([B.listInline, B.pullRight])
+                     , CSS.style (marginBottom $ px 0)
+                     ]
+                (showToolbar item state)
+              ]
             ]
           ]
-        ]
 
 iconClasses :: forall e. Item -> A.Attr (I e)
 iconClasses item = A.classes [B.glyphicon, Vc.itemIcon, iconClass item.resource]


### PR DESCRIPTION
Show as tinted, use spinner icon, don’t show actions for phantom items.

Also de-duplicated and removed some code that is now unnecessary.