### PR TITLE
Show error when directory creation fails

### DIFF
--- a/src/Controller/File.purs
+++ b/src/Controller/File.purs
@@ -105,7 +105,7 @@ handleCreateFolder state = do
     added <- liftAff $ attempt $ API.makeFile (inj hiddenFile) Nothing "{}"
     toInput (ItemRemove dirItem) `andThen` \_ ->
       case added of
-        Left _ -> empty
+        Left err -> showError ("There was a problem creating the directory: " ++ message err)
         Right _ -> toInput $ ItemAdd $ Item $ R.Directory dirPath
 
 handleHiddenFiles :: forall e a. Boolean -> Event (FileAppEff e) Input


### PR DESCRIPTION
This prevents the current silent failure and "Untitled Folder flicker" when attempting to make directories as the mount level (where they should actually be databases, see slamdata/slamengine#760). It's another modal :disappointed: but that's all we have right now.