### PR TITLE
Download dialog

### DIFF
--- a/less/dialog/download.less
+++ b/less/dialog/download.less
@@ -1,0 +1,141 @@
+.dialog-download {
+
+    .form-group {
+        margin-bottom: 0;
+        +.form-group {
+            margin-top: 15px;
+        }
+    }
+
+    input[type=radio] {
+        margin-right: 10px;
+    }
+
+    label {
+        line-height: 34px;
+        width: 100%;
+        margin-bottom: 0;
+        input, select {
+            font-weight: normal;
+        }
+        > span:first-child {
+            width: 100px;
+            display: block;
+            float: left;
+        }
+        input.form-control {
+            width: ~"calc(100% - 100px)";
+        }
+        select.form-control {
+            width: auto;
+        }
+    }
+
+    .download-source {
+        label input.form-control {
+           width: ~"calc(100% - 100px - 33px)";
+           float: left;
+        }
+        ul.file-list-group {
+            width: 468px;
+            left: 115px;
+            margin-top: -5px;
+        }
+    }
+
+    .download-target {
+        label {
+            position: relative;
+        }
+        input {
+            background: transparent;
+        }
+
+        .download-target-box {
+            position: absolute;
+            top: 0px;
+            left: 113px;
+            font-weight: normal;
+            span:nth-child(1) {
+                color: transparent;
+            }
+            span:nth-child(2) {
+                opacity: 0.5;
+            }
+        }
+    }
+
+    .download-csv-delimiters {
+        list-style: none;
+        padding: 0;
+        margin-top: 10px;
+        li {
+            float: left;
+            display: block;
+            width: 50%;
+            margin: 5px 0;
+            span {
+                width: 50%;
+            }
+            input {
+                width: 4em;
+            }
+        }
+    }
+
+    .download-array-mode {
+        > label {
+            width: 25%;
+            float: left;
+        }
+        ul {
+            list-style: none;
+            padding: 0;
+            float: left;
+            width: 75%;
+
+            li {
+                label {
+                    cursor: pointer;
+                    display: inline;
+                }
+                display: block;
+                input.form-control {
+                    margin-left: 10px;
+                    width: 4em;
+                    display: inline-block;
+                }
+            }
+        }
+    }
+
+    .download-json-options {
+        margin-top: 15px;
+        > div > label {
+            width: 25%;
+            float: left;
+        }
+        ul {
+            list-style: none;
+            padding: 0;
+            width: 75%;
+            float: left;
+            margin-bottom: 0px;
+            li {
+                label {
+                    cursor: pointer;
+                    display: inline;
+                }
+                float: left;
+                width: 50%;
+            }
+            li:first-child {
+                width: 45%;
+            }
+        }
+    }
+
+    .alert {
+        height: 42px;
+    }
+}

--- a/less/main.less
+++ b/less/main.less
@@ -231,6 +231,11 @@ ol.breadcrumb {
         margin-top: 8px;
         margin-bottom: 0;
     }
+    button i {
+        padding-left: 10px;
+        font-size: 16px;
+        line-height: 40px;
+    }
 }
 
 .toolbar-menu button, .item-toolbar button {
@@ -238,10 +243,6 @@ ol.breadcrumb {
     border: 0;
     padding: 0;
     color: #337ab7;
-
-    i.btn-lg.glyphicon {
-        padding-right: 0 !important;
-    }
 
     &:hover {
         color: #23527c
@@ -570,3 +571,4 @@ div.viz-cell-editor {
 @import "dialog/mount";
 @import "dialog/rename";
 @import "dialog/embed";
+@import "dialog/download";

--- a/src/Api/Common.purs
+++ b/src/Api/Common.purs
@@ -1,11 +1,16 @@
 module Api.Common where
 
-import Control.Monad.Error.Class (throwError)
-import Control.Monad.Eff.Exception (error)
 import Control.Monad.Aff (Aff())
-import Network.HTTP.StatusCode (StatusCode(..))
-import Network.HTTP.Affjax (Affjax(), AJAX())
+import Control.Monad.Eff.Exception (error)
+import Control.Monad.Error.Class (throwError)
+import Data.Argonaut.Combinators ((~>), (:=))
+import Data.Argonaut.Core (Json(), JAssoc(), jsonEmptyObject)
 import Data.Int (fromNumber, toNumber)
+import Data.Foldable (foldl)
+import Network.HTTP.Affjax (Affjax(), AJAX())
+import Network.HTTP.MimeType (MimeType(..), mimeTypeToString)
+import Network.HTTP.RequestHeader (RequestHeader(..))
+import Network.HTTP.StatusCode (StatusCode(..))
 
 successStatus :: StatusCode
 successStatus = StatusCode $ fromNumber 200
@@ -15,9 +20,16 @@ succeeded (StatusCode int) =
   200 <= code && code < 300
   where code = toNumber int
 
-getResponse :: forall a e. String -> Affjax e a -> Aff (ajax :: AJAX | e) a 
-getResponse msg affjax = do 
+getResponse :: forall a e. String -> Affjax e a -> Aff (ajax :: AJAX | e) a
+getResponse msg affjax = do
   res <- affjax
   if not $ succeeded res.status
     then throwError $ error msg
     else pure res.response
+
+reqHeadersToJSON :: [RequestHeader] -> Json
+reqHeadersToJSON = foldl go jsonEmptyObject
+  where
+  go obj (Accept mime) = "Accept" := mimeTypeToString mime ~> obj
+  go obj (ContentType mime) = "Content-Type" := mimeTypeToString mime ~> obj
+  go obj (RequestHeader k v) = k := v ~> obj

--- a/src/Controller/File/Common.purs
+++ b/src/Controller/File/Common.purs
@@ -5,7 +5,6 @@ import Data.Inject1 (Inject1, inj)
 import Data.Maybe (Maybe(), maybe)
 import Data.Path.Pathy (printPath)
 import EffectTypes (FileAppEff())
-import Halogen.HTML.Events.Monad (Event())
 import Input.File (Input(), FileInput(..))
 import Model.File (_dialog)
 import Model.File.Dialog (Dialog(..))
@@ -14,6 +13,10 @@ import Model.File.Sort (Sort(), sort2string)
 import Model.Path (DirPath())
 import Optic.Core ((?~))
 
+import qualified Halogen.HTML.Events.Monad as E
+
+type Event e = E.Event (FileAppEff e) Input
+
 -- | Lifts an input value into an applicative and injects it into the right
 -- | place in an Either.
 toInput :: forall m a b. (Applicative m, Inject1 a b) => a -> m b
@@ -21,7 +24,7 @@ toInput = pure <<< inj
 
 -- | Shows an error in a modal dialog.
 -- | TODO: remove the need for this with unobtrusive errors #284
-showError :: forall e. String -> Event (FileAppEff e) Input
+showError :: forall e. String -> Event e
 showError msg = toInput $ WithState (_dialog ?~ ErrorDialog msg)
 
 -- | Create a URL for the file browser using the specified values.

--- a/src/Controller/File/Dialog/Download.purs
+++ b/src/Controller/File/Dialog/Download.purs
@@ -1,0 +1,67 @@
+module Controller.File.Dialog.Download where
+
+import Control.Plus (empty)
+import Control.Monad.Eff.Class (liftEff)
+import Controller.File.Common (Event(), toInput)
+import Data.Array (findIndex)
+import Data.DOM.Simple.Types (HTMLElement())
+import Data.DOM.Simple.Element (getAttribute)
+import Data.Either (Either(..), either, isLeft)
+import Data.Maybe (Maybe(..), maybe)
+import Data.String (indexOf)
+import Input.File (FileInput(..))
+import Model.File (State(), _dialog)
+import Model.File.Dialog (_DownloadDialog)
+import Model.File.Dialog.Download
+import Model.Path (parseAnyPath)
+import Model.Resource (Resource(..), getPath, resourceName)
+import Optic.Core ((..), (^.), (.~), (?~), (%~))
+import Optic.Refractor.Prism (_Just)
+import Utils (newTab)
+
+import qualified Data.Either.Unsafe as U
+
+handleSourceInput :: forall e. String -> Event e
+handleSourceInput s = toInput' $ _source .~ maybe (Left s) (Right <<< either File Directory) (parseAnyPath s)
+
+handleSourceClicked :: forall e. Resource -> Event e
+handleSourceClicked r = toInput' $ (_showSourcesList .~ false)
+                                .. (_targetName .~ Right (resourceName r))
+                                .. (_source .~ Right r)
+
+handleToggleList :: forall e. Event e
+handleToggleList = toInput' $ _showSourcesList %~ not
+
+handleTargetNameChange :: forall e. String -> Event e
+handleTargetNameChange s = toInput' $ _targetName .~ (if indexOf "/" s > -1 then Left else Right) s
+
+handleCompressToggle :: forall e. Event e
+handleCompressToggle = toInput' $ _compress %~ not
+
+handleChangeOutput :: forall e. OutputType -> Event e
+handleChangeOutput ty = toInput' $ _options %~ case ty of
+  CSV -> Left <<< either id (const initialCSVOptions)
+  JSON -> Right <<< either (const initialJSONOptions) id
+
+handleOptionChange :: forall e. (Either CSVOptions JSONOptions -> Either CSVOptions JSONOptions) -> Event e
+handleOptionChange f = toInput' $ _options %~ f
+
+handleDownloadClick :: forall e. HTMLElement -> Event e
+handleDownloadClick el = do
+  liftEff $ getAttribute "href" el >>= newTab
+  empty
+
+toInput' :: forall e. (DownloadDialogRec -> DownloadDialogRec) -> Event e
+toInput' f = toInput $ WithState $ _dialog .. _Just .. _DownloadDialog %~ validate <<< f
+
+validate :: DownloadDialogRec -> DownloadDialogRec
+validate rec
+  | isLeft (rec ^. _source) = rec # _error ?~ "Please enter a valid source path to download"
+  | not $ checkExists (U.fromRight $ rec ^. _source) (rec ^. _sources) = rec # _error ?~ "The source resource does not exist"
+  | isLeft (rec ^. _targetName) = rec # _error ?~ "Please enter a valid target filename"
+  | otherwise = rec # _error .~ Nothing
+
+checkExists :: Resource -> [Resource] -> Boolean
+checkExists r rs =
+  let path = getPath r
+  in findIndex (\r' -> getPath r' == path) rs /= -1

--- a/src/Controller/File/Item.purs
+++ b/src/Controller/File/Item.purs
@@ -4,21 +4,22 @@ import Api.Fs (delete, children, mountInfo)
 import Control.Monad.Aff.Class (liftAff)
 import Control.Monad.Eff.Class (liftEff)
 import Control.Plus (empty)
-import Controller.Common (getDirectories)
-import Controller.File.Common (toInput, showError, browseURL)
+import Controller.Common (getDirectories, getChildren)
+import Controller.File.Common (Event(), toInput, showError, browseURL)
+import Data.Array (sort)
 import Data.Either (Either(..), either)
 import Data.Inject1 (Inject1, inj)
 import Data.Maybe (Maybe(..))
 import Data.Path.Pathy (rootDir, printPath)
 import Data.URI (runParseAbsoluteURI)
-import EffectTypes (FileAppEff())
-import Halogen.HTML.Events.Monad (Event(), async, andThen)
-import Input.File (Input(), FileInput(..))
+import Halogen.HTML.Events.Monad (async, andThen)
+import Input.File (FileInput(..))
 import Input.File.Item (ItemInput(..))
 import Input.File.Rename (RenameInput(..))
 import Model.Action
 import Model.File (_dialog)
-import Model.File.Dialog (Dialog(..))
+import Model.File.Dialog (Dialog(..), _DownloadDialog)
+import Model.File.Dialog.Download (initialDownloadDialog, _sources)
 import Model.File.Dialog.Mount
 import Model.File.Dialog.Rename (initialRenameDialog, _siblings)
 import Model.File.Item (Item(..), itemResource)
@@ -26,30 +27,31 @@ import Model.File.Salt (Salt())
 import Model.File.Sort (Sort())
 import Model.Path (encodeURIPath)
 import Model.Resource (Resource(..), resourceName, resourceDir, parent, root, getPath)
-import Optic.Core ((?~), (.~))
+import Optic.Core ((..), (?~), (.~), (++~), (%~))
+import Optic.Refractor.Prism (_Just)
 import Utils (locationString, setLocation)
 
-handleDeleteItem :: forall e. Item -> Event (FileAppEff e) Input
+handleDeleteItem :: forall e. Item -> Event e
 handleDeleteItem (PhantomItem _) = empty
 handleDeleteItem item = do
   liftAff $ delete (itemResource item)
   toInput $ ItemRemove item
 
-handleMoveItem :: forall e. Item -> Event (FileAppEff e) Input
+handleMoveItem :: forall e. Item -> Event e
 handleMoveItem (PhantomItem _) = empty
 handleMoveItem item = do
   let res = itemResource item
   ss <- liftAff $ children $ parent res
   let dialog = RenameDialog $ (initialRenameDialog res # _siblings .~ ss)
-  (toInput $ WithState (_dialog ?~ dialog))
+  showDialog dialog
     `andThen` \_ -> getDirectories (toInput <<< AddDirs) root
 
-handleShare :: forall e. Sort -> Salt -> Item -> Event (FileAppEff e) Input
+handleShare :: forall e. Sort -> Salt -> Item -> Event e
 handleShare _ _ (PhantomItem _) = empty
 handleShare sort salt item = do
   loc <- liftEff locationString
   let url = loc ++ "/" ++ itemURL sort salt View item
-  toInput $ WithState $ _dialog ?~ ShareDialog url
+  showDialog $ ShareDialog url
 
 itemURL :: Sort -> Salt -> Action -> Item -> String
 itemURL sort salt act item = case itemResource item of
@@ -58,13 +60,17 @@ itemURL sort salt act item = case itemResource item of
   Directory path -> browseURL Nothing sort salt path
   Database path -> browseURL Nothing sort salt path
 
-openItem :: forall e. Item -> Sort -> Salt -> Event (FileAppEff e) Input
+openItem :: forall e. Item -> Sort -> Salt -> Event e
 openItem (PhantomItem _) _ _ = empty
 openItem item sort salt = do
   liftEff $ setLocation $ itemURL sort salt Edit item
   empty
 
-handleConfigure :: forall e. Resource -> Event (FileAppEff e) Input
+handleConfigureItem :: forall e. Item -> Event e
+handleConfigureItem (PhantomItem _) = empty
+handleConfigureItem item = handleConfigure $ itemResource item
+
+handleConfigure :: forall e. Resource -> Event e
 handleConfigure res@(Database _) = do
   x <- liftAff $ mountInfo res
   case runParseAbsoluteURI x of
@@ -75,6 +81,16 @@ handleConfigure res@(Database _) = do
                                          , parent = resourceDir res
                                          , valid = true
                                          }
-      in toInput $ WithState (_dialog ?~ MountDialog rec)
+      in showDialog $ MountDialog rec
 handleConfigure _ = empty
 
+handleDownloadItem :: forall e. Item -> Event e
+handleDownloadItem (PhantomItem _) = empty
+handleDownloadItem item =
+  showDialog (DownloadDialog $ initialDownloadDialog $ itemResource item)
+    `andThen` \_ -> getChildren (const true) (\rs -> toInput $ WithState $ (lens %~ sort) .. (lens ++~ rs)) root
+  where
+  lens = _dialog .. _Just .. _DownloadDialog .. _sources
+
+showDialog :: forall e. Dialog -> Event e
+showDialog = toInput <<< WithState <<< (_dialog ?~)

--- a/src/Controller/File/Search.purs
+++ b/src/Controller/File/Search.purs
@@ -4,14 +4,13 @@ import Control.Monad.Aff (makeAff)
 import Control.Monad.Eff.Class (liftEff)
 import Control.Plus (empty)
 import Control.Timer (timeout, clearTimeout)
-import Controller.File.Common (toInput, browseURL)
+import Controller.File.Common (Event(), toInput, browseURL)
 import Data.Either (Either(..))
 import Data.Inject1 (inj)
 import Data.These (theseLeft, theseRight, thisOrBoth)
 import Data.Maybe (Maybe(..), maybe)
-import EffectTypes (FileAppEff())
-import Halogen.HTML.Events.Monad (Event(), runEvent, async, andThen)
-import Input.File (Input(), FileInput(..))
+import Halogen.HTML.Events.Monad (runEvent, async, andThen)
+import Input.File (FileInput(..))
 import Model.File (State(), _sort, _path, _search)
 import Model.File.Salt (newSalt)
 import Model.File.Search (_loading, _value, _timeout, _valid)
@@ -19,13 +18,13 @@ import Optic.Core ((..), (.~), (^.), (%~), (?~))
 import Text.SlamSearch (mkQuery)
 import Utils (setLocation)
 
-handleSearchClear :: forall e. State -> Event (FileAppEff e) Input
+handleSearchClear :: forall e. State -> Event e
 handleSearchClear state = do
   salt <- liftEff newSalt
   liftEff $ setLocation $ browseURL Nothing (state ^. _sort) salt (state ^. _path)
   empty
 
-handleSearchChange :: forall e. State -> String -> Event (FileAppEff e) Input
+handleSearchChange :: forall e. State -> String -> Event e
 handleSearchChange state value = do
   liftEff $ maybe (pure unit) clearTimeout (state ^. _search .. _timeout)
   let updateValue = _search .. _value %~ (thisOrBoth value <<< theseRight)
@@ -36,7 +35,7 @@ handleSearchChange state value = do
           handleSearchSubmit (updateValue state)
       k $ inj $ WithState (_search .. _timeout ?~ tim)
 
-handleSearchSubmit :: forall e. State -> Event (FileAppEff e) Input
+handleSearchSubmit :: forall e. State -> Event e
 handleSearchSubmit state = do
   salt <- liftEff newSalt
   case theseLeft (state ^. _search .. _value) of

--- a/src/Model/File/Dialog.purs
+++ b/src/Model/File/Dialog.purs
@@ -1,10 +1,29 @@
 module Model.File.Dialog where
 
-import Model.File.Dialog.Mount
-import Model.File.Dialog.Rename
+import Data.Maybe (Maybe(..))
+import Model.File.Dialog.Download (DownloadDialogRec())
+import Model.File.Dialog.Mount (MountDialogRec())
+import Model.File.Dialog.Rename (RenameDialogRec())
+import Optic.Core (prism', PrismP())
 
 data Dialog
   = RenameDialog RenameDialogRec
   | MountDialog MountDialogRec
   | ShareDialog String
   | ErrorDialog String
+  | DownloadDialog DownloadDialogRec
+
+_RenameDialog :: PrismP Dialog RenameDialogRec
+_RenameDialog = prism' RenameDialog $ \s -> case s of
+  RenameDialog r -> Just r
+  _ -> Nothing
+
+_MountDialog :: PrismP Dialog MountDialogRec
+_MountDialog = prism' MountDialog $ \s -> case s of
+  MountDialog r -> Just r
+  _ -> Nothing
+
+_DownloadDialog :: PrismP Dialog DownloadDialogRec
+_DownloadDialog = prism' DownloadDialog $ \s -> case s of
+  DownloadDialog r -> Just r
+  _ -> Nothing

--- a/src/Model/File/Dialog/Download.purs
+++ b/src/Model/File/Dialog/Download.purs
@@ -1,0 +1,161 @@
+module Model.File.Dialog.Download where
+
+import Data.Either (Either(..))
+import Data.Maybe (Maybe(..))
+import Data.Path.Pathy (rootDir)
+import Model.Resource (Resource(..), resourceFileName)
+import Optic.Core (LensP(), (^.), lens)
+import Optic.Extended (TraversalP())
+import Network.HTTP.MimeType (MimeType(..))
+import Network.HTTP.RequestHeader (RequestHeader(..))
+
+import qualified Data.String.Regex as Rx
+
+data OutputType = CSV | JSON
+
+newtype DownloadDialogRec = DownloadDialogRec
+  { source :: Either String Resource
+  , sources :: [Resource]
+  , showSourcesList :: Boolean
+  , targetName :: Either String String
+  , compress :: Boolean
+  , options :: Either CSVOptions JSONOptions
+  , error :: Maybe String
+  }
+
+initialDownloadDialog :: Resource -> DownloadDialogRec
+initialDownloadDialog res = DownloadDialogRec
+  { source: Right res
+  , sources: [Database rootDir]
+  , showSourcesList: false
+  , targetName: let name = resourceFileName res
+                in Right $ if name == "" then "archive" else name
+  , compress: false
+  , options: Left initialCSVOptions
+  , error: Nothing
+  }
+
+_DownloadDialogRec :: LensP DownloadDialogRec _
+_DownloadDialogRec = lens (\(DownloadDialogRec obj) -> obj) (const DownloadDialogRec)
+
+_source :: LensP DownloadDialogRec (Either String Resource)
+_source = _DownloadDialogRec <<< lens _.source (_ { source = _ })
+
+_sources :: LensP DownloadDialogRec [Resource]
+_sources = _DownloadDialogRec <<< lens _.sources (_ { sources = _ })
+
+_showSourcesList :: LensP DownloadDialogRec Boolean
+_showSourcesList = _DownloadDialogRec <<< lens _.showSourcesList (_ { showSourcesList = _ })
+
+_targetName :: LensP DownloadDialogRec (Either String String)
+_targetName = _DownloadDialogRec <<< lens _.targetName (_ { targetName = _ })
+
+_compress :: LensP DownloadDialogRec Boolean
+_compress = _DownloadDialogRec <<< lens _.compress (_ { compress = _ })
+
+_options :: LensP DownloadDialogRec (Either CSVOptions JSONOptions)
+_options = _DownloadDialogRec <<< lens _.options (_ { options = _ })
+
+_error :: LensP DownloadDialogRec (Maybe String)
+_error = _DownloadDialogRec <<< lens _.error (_ { error = _ })
+
+newtype CSVOptions = CSVOptions
+  { colDelimiter :: String
+  , rowDelimiter :: String
+  , quoteChar :: String
+  , escapeChar :: String
+  , arrays :: ArrayMode
+  }
+
+initialCSVOptions :: CSVOptions
+initialCSVOptions = CSVOptions
+  { colDelimiter: ","
+  , rowDelimiter: "\\n"
+  , quoteChar: "\""
+  , escapeChar: "\""
+  , arrays: Flatten
+  }
+
+_CSVOptions :: LensP CSVOptions _
+_CSVOptions = lens (\(CSVOptions obj) -> obj) (const CSVOptions)
+
+_colDelimiter :: LensP CSVOptions String
+_colDelimiter = _CSVOptions <<< lens _.colDelimiter (_ { colDelimiter = _ })
+
+_rowDelimiter :: LensP CSVOptions String
+_rowDelimiter = _CSVOptions <<< lens _.rowDelimiter (_ { rowDelimiter = _ })
+
+_quoteChar :: LensP CSVOptions String
+_quoteChar = _CSVOptions <<< lens _.quoteChar (_ { quoteChar = _ })
+
+_escapeChar :: LensP CSVOptions String
+_escapeChar = _CSVOptions <<< lens _.escapeChar (_ { escapeChar = _ })
+
+_arrays :: LensP CSVOptions ArrayMode
+_arrays = _CSVOptions <<< lens _.arrays (_ { arrays = _ })
+
+newtype JSONOptions = JSONOptions
+  { multivalues :: MultiValueMode
+  , precision :: PrecisionMode
+  }
+
+initialJSONOptions :: JSONOptions
+initialJSONOptions = JSONOptions
+  { multivalues: ArrayWrapped
+  , precision: Readable
+  }
+
+_JSONOptions :: LensP JSONOptions _
+_JSONOptions = lens (\(JSONOptions obj) -> obj) (const JSONOptions)
+
+_multivalues :: LensP JSONOptions MultiValueMode
+_multivalues = _JSONOptions <<< lens _.multivalues (_ { multivalues = _ })
+
+_precision :: LensP JSONOptions PrecisionMode
+_precision = _JSONOptions <<< lens _.precision (_ { precision = _ })
+
+data ArrayMode = Flatten | Separate String
+
+separateValue :: ArrayMode -> Maybe String
+separateValue (Separate s) = Just s
+separateValue _ = Nothing
+
+data MultiValueMode = ArrayWrapped | LineDelimited
+data PrecisionMode = Readable | Precise
+
+instance eqMultiValueMode :: Eq MultiValueMode where
+  (==) ArrayWrapped ArrayWrapped = true
+  (==) LineDelimited LineDelimited = true
+  (==) _ _ = false
+  (/=) x y = not (x == y)
+
+instance eqPrecisionMode :: Eq PrecisionMode where
+  (==) Readable Readable = true
+  (==) Precise Precise = true
+  (==) _ _ = false
+  (/=) x y = not (x == y)
+
+toHeaders :: DownloadDialogRec -> [RequestHeader]
+toHeaders rec = encHeader (rec ^. _compress) ++ [Accept $ MimeType $ mimeType (rec ^. _options)]
+  where
+
+  encHeader :: Boolean -> [RequestHeader]
+  encHeader true = [RequestHeader "Accept-Encoding" "gzip"]
+  encHeader false = []
+
+  mimeType :: Either CSVOptions JSONOptions -> String
+  mimeType (Left (CSVOptions opts)) =
+    "text/csv;columnDelimiter=" ++ esc opts.colDelimiter
+         ++ "&rowDelimiter=" ++ esc opts.rowDelimiter
+         ++ "&quoteChar=" ++ esc opts.quoteChar
+         ++ "&escapeChar=" ++ esc opts.escapeChar
+  mimeType (Right (JSONOptions opts)) =
+    let suffix = if opts.precision == Precise then ";mode=precise" else ""
+        subtype = if opts.multivalues == ArrayWrapped then "json" else "ldjson"
+    in "application/" ++ subtype ++ suffix
+
+  esc :: String -> String
+  esc s = "\"" ++ Rx.replace (grx "\"") "\\\"" s ++ "\""
+    where
+    grx :: String -> Rx.Regex
+    grx pat = Rx.regex pat Rx.noFlags { global = true }

--- a/src/Model/Path.purs
+++ b/src/Model/Path.purs
@@ -1,6 +1,9 @@
 module Model.Path where
 
+import Control.Alt ((<|>))
+import Control.Bind ((=<<))
 import Data.Array ()
+import Data.Maybe (Maybe(..))
 import Data.DOM.Simple.Encode (encodeURIComponent, decodeURIComponent)
 import Data.Either (Either(..))
 import Data.Path.Pathy
@@ -22,6 +25,9 @@ infixl 6 <./>
 phantomNotebookPath :: DirPath
 phantomNotebookPath = rootDir </> dir "phantom" <./> notebookExtension
 
+parseAnyPath :: String -> Maybe AnyPath
+parseAnyPath s = Left <<< (rootDir </>) <$> (sandbox rootDir =<< parseAbsFile s)
+             <|> Right <<< (rootDir </>) <$> (sandbox rootDir =<< parseAbsDir s)
 
 changeDirExt :: (String -> String) -> DirName -> DirName
 changeDirExt f (DirName name) =

--- a/src/View/Css.purs
+++ b/src/View/Css.purs
@@ -86,6 +86,9 @@ fileListGroup = className "file-list-group"
 notebookNav :: ClassName
 notebookNav = className "notebook-nav"
 
+dialogDownload :: ClassName
+dialogDownload = className "dialog-download"
+
 dialogMount :: ClassName
 dialogMount = className "dialog-mount"
 
@@ -226,3 +229,21 @@ aggregation = className "aggregation"
 
 embedBox :: ClassName
 embedBox = className "embed-box"
+
+downloadSource :: ClassName
+downloadSource = className "download-source"
+
+downloadTarget :: ClassName
+downloadTarget = className "download-target"
+
+downloadTargetBox :: ClassName
+downloadTargetBox = className "download-target-box"
+
+downloadCSVDelimiters :: ClassName
+downloadCSVDelimiters = className "download-csv-delimiters"
+
+downloadArrayMode :: ClassName
+downloadArrayMode = className "download-array-mode"
+
+downloadJSONOptions :: ClassName
+downloadJSONOptions = className "download-json-options"

--- a/src/View/File.purs
+++ b/src/View/File.purs
@@ -13,7 +13,7 @@ import Optic.Core ((..), (^.))
 import View.Common (glyph)
 import View.Common (navbar, icon, logo, content, row)
 import View.File.Breadcrumb (breadcrumbs)
-import View.File.Common (I())
+import View.File.Common (HTML())
 import View.File.Item (items)
 import View.File.Modal (modal)
 import View.File.Search (search)
@@ -31,7 +31,7 @@ import qualified Halogen.Themes.Bootstrap3 as B
 import qualified Utils as U
 import qualified View.Css as Vc
 
-view :: forall e. State -> H.HTML (I e)
+view :: forall e. State -> HTML e
 view state =
   H.div_ [ navbar [ H.div [ A.classes [Vc.header, B.clearfix] ]
                           [ icon B.glyphiconFolderOpen Config.homeHash
@@ -48,7 +48,7 @@ view state =
          , modal state
          ]
 
-sorting :: forall e. State -> H.HTML (I e)
+sorting :: forall e. State -> HTML e
 sorting state =
   H.div [ A.classes [B.colXs4, Vc.toolbarSort] ]
         [ H.a [ A.href (browseURL (theseRight $ state ^. _search .. _value) (notSort (state ^. _sort)) (state ^. _salt) (state ^. _path)) ]

--- a/src/View/File/Common.purs
+++ b/src/View/File/Common.purs
@@ -1,19 +1,15 @@
 module View.File.Common where
 
 import Control.Alternative (Alternative)
-import Input.File (Input())
-import EffectTypes (FileAppEff ())
+import Controller.File.Common (Event())
+
 import qualified Halogen.HTML as H
 import qualified Halogen.HTML.Attributes as A
 import qualified Halogen.HTML.Events as E
 import qualified Halogen.HTML.Events.Monad as E
-import qualified Halogen.HTML.Events.Monad as E
 import qualified Halogen.Themes.Bootstrap3 as B
-import qualified View.Css as Vc
 
-type I e = E.Event (FileAppEff e) Input
-
-type HTML e = H.HTML (I e)
+type HTML e = H.HTML (Event e)
 
 toolItem :: forall a m i. (Alternative m) => [A.ClassName] -> a -> (a -> m i) -> String -> A.ClassName -> H.HTML (m i)
 toolItem classes actionArg action title icon =

--- a/src/View/File/Item.purs
+++ b/src/View/File/Item.purs
@@ -1,5 +1,6 @@
 module View.File.Item (items) where
 
+import Controller.File.Common (Event())
 import Controller.File.Item
 import Css.Geometry
 import Css.Size (px)
@@ -11,7 +12,7 @@ import Model.Action (Action(..))
 import Model.File
 import Model.File.Item
 import Model.Resource (Resource(..), resourcePath, resourceName, isFile, isDatabase, isNotebook, hiddenTopLevel)
-import View.File.Common (HTML(), I(), toolItem)
+import View.File.Common (HTML(), toolItem)
 import Optic.Core ((^.))
 
 import qualified Halogen.HTML as H
@@ -81,7 +82,7 @@ item state ix item =
   itemName | isSearching state = resourcePath <<< itemResource
            | otherwise = resourceName <<< itemResource
 
-iconClasses :: forall e. Item -> A.Attr (I e)
+iconClasses :: forall i. Item -> A.Attr i
 iconClasses item = A.classes [B.glyphicon, Vc.itemIcon, iconClass $ itemResource item]
   where
   iconClass :: Resource -> A.ClassName
@@ -94,13 +95,14 @@ showToolbar :: forall e. Item -> State -> [HTML e]
 showToolbar item state =
   let r = itemResource item
       conf = if isDatabase r
-             then [toolItem' (handleConfigure <<< itemResource) "configure" B.glyphiconWrench]
+             then [toolItem' handleConfigureItem "configure" B.glyphiconWrench]
              else []
   in conf <> [ toolItem' handleMoveItem "move/rename" B.glyphiconMove
+             , toolItem' handleDownloadItem "download" B.glyphiconDownloadAlt
              , toolItem' handleDeleteItem "remove" B.glyphiconTrash
              ] ++ if isFile r || isNotebook r
                   then [toolItem' (handleShare (state ^. _sort) (state ^. _salt)) "share" B.glyphiconShare]
                   else []
   where
-  toolItem' :: forall e. (Item -> I e) -> String -> A.ClassName -> HTML e
+  toolItem' :: forall e. (Item -> Event e) -> String -> A.ClassName -> HTML e
   toolItem' f = toolItem [] item f

--- a/src/View/File/Modal.purs
+++ b/src/View/File/Modal.purs
@@ -9,6 +9,7 @@ import Model.File (State(), _dialog)
 import Model.File.Dialog (Dialog(..))
 import Optic.Core ((.~), (^.))
 import View.File.Common (HTML())
+import View.File.Modal.DownloadDialog (downloadDialog)
 import View.File.Modal.ErrorDialog (errorDialog)
 import View.File.Modal.MountDialog (mountDialog)
 import View.File.Modal.RenameDialog (renameDialog)
@@ -40,3 +41,4 @@ dialogContent (ShareDialog url) = shareDialog url
 dialogContent (RenameDialog dialog) = renameDialog dialog
 dialogContent (MountDialog dialog) = mountDialog dialog
 dialogContent (ErrorDialog msg) = errorDialog msg
+dialogContent (DownloadDialog dialog) = downloadDialog dialog

--- a/src/View/File/Modal/DownloadDialog.purs
+++ b/src/View/File/Modal/DownloadDialog.purs
@@ -1,0 +1,243 @@
+module View.File.Modal.DownloadDialog (downloadDialog) where
+
+import Api.Common (reqHeadersToJSON)
+import Control.Functor (($>))
+import Controller.File.Dialog.Download
+import Data.DOM.Simple.Encode (encodeURIComponent)
+import Data.Either (either, isLeft, isRight)
+import Data.Inject1 (inj)
+import Data.Maybe (Maybe(..), isJust, isNothing, maybe, fromMaybe)
+import Input.File (FileInput(..))
+import Model.File (_dialog)
+import Model.File.Dialog.Download
+import Model.Resource (Resource(), resourcePath, resourceFileName, isHidden, isFile)
+import Optic.Core (LensP(), (..), (^.), (.~), set)
+import Optic.Refractor.Prism (_Left, _Right)
+import View.Common (closeButton, fadeWhen)
+import View.File.Common (HTML())
+import View.Modal.Common (header, body, footer, h4, nonSubmit)
+
+import qualified Halogen.HTML as H
+import qualified Halogen.HTML.Attributes as A
+import qualified Halogen.HTML.Events as E
+import qualified Halogen.HTML.Events.Forms as E
+import qualified Halogen.HTML.Events.Handler as E
+import qualified Halogen.HTML.Events.Monad as E
+import qualified Halogen.Themes.Bootstrap3 as B
+import qualified View.Css as VC
+
+downloadDialog :: forall e. DownloadDialogRec -> [HTML e]
+downloadDialog state =
+  [ header $ h4 "Download"
+  , body [ H.form [ A.class_ VC.dialogDownload
+                  , nonSubmit
+                  ]
+                  [ resField
+                  , fldName
+                  , chkCompress
+                  , options
+                  , message (state ^. _error)
+                  ]
+         ]
+  , footer [ btnCancel
+           , btnDownload
+           ]
+  ]
+
+  where
+
+  resField :: HTML e
+  resField =
+    let value = either id resourcePath $ state ^. _source
+    in H.div [ A.classes [B.formGroup, VC.downloadSource, B.clearfix] ]
+             [ H.label_ [ H.span_ [ H.text "Source" ]
+                        , H.input [ A.classes [B.formControl]
+                                  , E.onInput (pure <<< handleSourceInput)
+                                  , A.value value
+                                  ]
+                                  []
+                        , H.span [ A.classes [B.inputGroupBtn] ]
+                                 [ H.button [ A.classes [B.btn, B.btnDefault]
+                                            , E.onClick (\_ -> E.stopPropagation $> handleToggleList)
+                                            ]
+                                            [ H.span [ A.classes [B.caret] ] [] ]
+                                 ]
+                        ]
+             , H.ul [ A.classes $ [B.listGroup, VC.fileListGroup, B.fade] <> fadeWhen (not $ state ^. _showSourcesList) ]
+                    $ resItem <$> state ^. _sources
+             ]
+
+  resItem :: Resource -> HTML e
+  resItem res =
+    H.button [ A.classes ([B.listGroupItem] <> (if isHidden res
+                                                then [VC.itemHidden]
+                                                else []))
+             , E.onClick (\_ -> pure $ handleSourceClicked res)
+             ]
+             [ H.text (resourcePath res) ]
+
+  fldName :: HTML e
+  fldName =
+    let value = either id id $ state ^. _targetName
+        ext | compressed = ".zip"
+            | isLeft (state ^. _options) = ".csv"
+            | otherwise = ".json"
+    in  H.div [ A.classes [B.formGroup, VC.downloadTarget] ]
+              [ H.label_ [ H.span_ [ H.text "Target name" ]
+                         , H.input [ A.classes [B.formControl]
+                                   , A.value value
+                                   , E.onInput (pure <<< handleTargetNameChange)
+                                   ]
+                                   []
+                         , H.div [ A.class_ VC.downloadTargetBox ]
+                                 [ H.span_ [ H.text value ]
+                                 , H.span_ [ H.text ext ]
+                                 ]
+                         ]
+              ]
+
+  chkCompress :: HTML e
+  chkCompress =
+    H.div [ A.class_ B.formGroup ]
+          [ H.label_ [ H.span_ [ H.text "Compress" ]
+                     , H.input [ A.type_ "checkbox"
+                               , A.enabled (not compressed)
+                               , A.checked compressed
+                               , E.onChange (\_ -> pure $ handleCompressToggle)
+                               ]
+                               []
+                     ]
+          ]
+
+  compressed :: Boolean
+  compressed = either (const false) (not <<< isFile) (state ^. _source) || state ^. _compress
+
+  options :: HTML e
+  options =
+    let opts = state ^. _options
+        active = [ A.class_ B.active ]
+    in H.div [ A.class_ B.formGroup ]
+             [ H.ul [ A.classes [B.nav, B.navTabs] ]
+                    [ H.li (if isLeft opts then active else [])
+                           [ H.a [ E.onClick (\_ -> pure $ handleChangeOutput CSV) ]
+                                 [ H.text "CSV" ]
+                           ]
+                    , H.li (if isRight opts then active else [])
+                           [ H.a [ E.onClick (\_ -> pure $ handleChangeOutput JSON) ]
+                                 [ H.text "JSON" ]
+                           ]
+                    ]
+             , either optionsCSV optionsJSON opts
+             ]
+
+  message :: forall e. Maybe String -> HTML e
+  message msg =
+    H.div [ A.classes $ [B.alert, B.alertDanger, B.alertDismissable] ++ fadeWhen (isNothing msg) ]
+          $ maybe [] (pure <<< H.text) msg
+
+  btnCancel :: forall e. HTML e
+  btnCancel =
+    H.button [ A.classes [B.btn]
+             , E.onClick (E.input_ $ inj $ WithState (_dialog .~ Nothing))
+             ]
+             [ H.text "Cancel" ]
+
+  btnDownload :: forall e. HTML e
+  btnDownload =
+    let headers = encodeURIComponent $ show $ reqHeadersToJSON $ toHeaders state
+        url = Config.dataUrl ++ either (const "#") resourcePath (state ^. _source) ++ "?request-headers=" ++ headers
+        disabled = isJust $ state ^. _error
+    in H.a [ A.classes $ [B.btn, B.btnPrimary] ++ if disabled then [B.disabled] else []
+           , A.disabled disabled
+           , A.href url
+           , E.onClick (\ev -> E.preventDefault $> handleDownloadClick ev.target)
+           ]
+           [ H.text "Download" ]
+
+optionsCSV :: forall e. CSVOptions -> HTML e
+optionsCSV opts =
+  H.div_ [ H.ul [ A.classes [VC.downloadCSVDelimiters, B.clearfix] ]
+                [ field _rowDelimiter "Row delimiter"
+                , field _colDelimiter "Column delimiter"
+                , field _quoteChar "Quote character"
+                , field _escapeChar "Quote escape"
+                ]
+         ]
+  where
+
+  field :: LensP CSVOptions String -> String -> HTML e
+  field lens label =
+    H.li_ [ H.label_ [ H.span_ [ H.text label ]
+                     , H.input [ A.class_ B.formControl
+                               , A.value (opts ^. lens)
+                               , E.onInput (pure <<< handleOptionChange <<< set (_Left .. lens))
+                               ] []
+                     ]
+          ]
+
+  -- TODO: this is unused currently, awaiting a feature in slamengine
+  arrays :: HTML e
+  arrays =
+    let sepVal = separateValue $ opts ^. _arrays
+        isFlatMode = isNothing sepVal
+    in H.div [ A.classes [B.clearfix, VC.downloadArrayMode] ]
+             [ H.label_ [ H.text "Array flattening" ]
+             , H.ul_ [ H.li_ [ H.label_ [ H.input [ A.type_ "radio"
+                                                  , A.name "arraymode"
+                                                  , A.checked isFlatMode
+                                                  , E.onChange (\_ -> pure $ handleOptionChange $ _Left .. _arrays .~ Flatten)
+                                                  ] []
+                                        , H.text "Flatten into columns"
+                                        ]
+                             ]
+                     , H.li_ [ H.label_ [ H.input [ A.type_ "radio"
+                                                  , A.name "arraymode"
+                                                  , A.checked (not isFlatMode)
+                                                  , E.onChange (\_ -> pure $ handleOptionChange $ _Left .. _arrays .~ Separate "|")
+                                                  ] []
+                                        , H.text "Separate elements with: "
+                                        , H.input [ A.class_ B.formControl
+                                                  , A.enabled (not isFlatMode)
+                                                  , A.value (fromMaybe "" sepVal)
+                                                  , E.onInput (pure <<< handleOptionChange <<< set (_Left .. _arrays) <<< Separate)
+                                                  ]
+                                                  []
+                                        ]
+                             ]
+                     ]
+             ]
+
+optionsJSON :: forall e. JSONOptions -> HTML e
+optionsJSON opts = H.div [ A.class_ VC.downloadJSONOptions ]
+                         [ multivalues, precision ]
+  where
+
+  multivalues :: HTML e
+  multivalues =
+    H.div [ A.class_ B.clearfix ]
+          [ H.label_ [ H.text "Multiple values" ]
+          , H.ul [ A.class_ B.clearfix ]
+                 [ radio "multivalues" _multivalues ArrayWrapped "Wrap values in array"
+                 , radio "multivalues" _multivalues LineDelimited "Separate values by newlines"
+                 ]
+          ]
+
+  precision :: HTML e
+  precision =
+    H.div [ A.class_ B.clearfix ]
+          [ H.label_ [ H.text "Precision" ]
+          , H.ul_ [ radio "precision" _precision Readable "Readable"
+                  , radio "precision" _precision Precise  "Encode all types"
+                  ]
+          ]
+
+  radio :: forall a. (Eq a) => String -> LensP JSONOptions a -> a -> String -> HTML e
+  radio grp lens value label =
+     H.li_ [ H.label_ [ H.input [ A.type_ "radio"
+                                , A.name grp
+                                , A.checked (opts ^. lens == value)
+                                , E.onChange (\_ -> pure $ handleOptionChange (_Right .. lens .~ value))
+                                ] []
+                      , H.text label
+                      ]
+           ]

--- a/src/View/File/Modal/RenameDialog.purs
+++ b/src/View/File/Modal/RenameDialog.purs
@@ -1,7 +1,7 @@
 module View.File.Modal.RenameDialog (renameDialog) where
 
 import Control.Functor (($>))
-import Controller.File.Rename
+import Controller.File.Dialog.Rename
 import Data.Inject1 (inj)
 import Data.Maybe (Maybe(..), isNothing, isJust, maybe)
 import Input.File (FileInput(..))

--- a/src/View/File/Toolbar.purs
+++ b/src/View/File/Toolbar.purs
@@ -2,10 +2,12 @@ module View.File.Toolbar (toolbar) where
 
 import Controller.File
 import Controller.File.Item
+import Controller.File.Common (Event())
 import Data.Path.Pathy
 import Model.File
+import Model.File.Item (Item(..))
 import Model.Resource (Resource(..))
-import View.File.Common (I(), toolItem)
+import View.File.Common (HTML(), toolItem)
 import Optic.Core ((^.))
 
 import qualified Halogen.HTML as H
@@ -14,25 +16,40 @@ import qualified Halogen.HTML.Events as E
 import qualified Halogen.Themes.Bootstrap3 as B
 import qualified View.Css as Vc
 
-toolbar :: forall e. State -> H.HTML (I e)
+toolbar :: forall e. State -> HTML e
 toolbar state =
   H.div [ A.classes [B.colXs5, Vc.toolbarMenu] ]
         [ H.ul [ A.classes [B.listInline, B.pullRight] ]
-               $ [showHide] ++ mount ++ [folder, file, notebook]
+               $ [showHide] ++ download ++ mount ++ [folder, file, notebook]
         ]
 
   where
 
-  showHide :: H.HTML (I e)
+  showHide :: HTML e
   showHide =
     if state ^. _showHiddenFiles
-    then toolItem [B.btnLg] false handleHiddenFiles "hide hidden files" B.glyphiconEyeClose
-    else toolItem [B.btnLg] true handleHiddenFiles "show hidden files" B.glyphiconEyeOpen
+    then toolItem [] false handleHiddenFiles "hide hidden files" B.glyphiconEyeClose
+    else toolItem [] true handleHiddenFiles "show hidden files" B.glyphiconEyeOpen
 
-  file :: H.HTML (I e)
+  download :: [HTML e]
+  download =
+    if state ^. _path == rootDir
+    then [toolItem [] (Item $ Directory rootDir) handleDownloadItem "download" B.glyphiconDownloadAlt]
+    else []
+
+  mount :: [HTML e]
+  mount = (if state ^. _isMount
+           then [toolItem [] (Database (state ^. _path)) handleConfigure "configure mount" B.glyphiconWrench]
+           else [])
+          ++ [toolItem' handleMountDatabase "mount database" B.glyphiconHdd]
+
+  folder :: HTML e
+  folder = toolItem' handleCreateFolder "create folder" B.glyphiconFolderClose
+
+  file :: HTML e
   file = H.li_ [ H.button [ E.onClick (\ev -> pure $ handleUploadFile ev.target) ]
                           [ H.i [ A.title "upload file"
-                                , A.classes [B.btnLg, B.glyphicon, B.glyphiconFile]
+                                , A.classes [B.glyphicon, B.glyphiconFile]
                                 ]
                                 [ H.input [ A.class_ B.hidden
                                           , A.type_ "file"
@@ -43,17 +60,8 @@ toolbar state =
                           ]
                ]
 
-  folder :: H.HTML (I e)
-  folder = toolItem' handleCreateFolder "create folder" B.glyphiconFolderClose
-
-  notebook :: H.HTML (I e)
+  notebook :: HTML e
   notebook = toolItem' handleCreateNotebook "create notebook" B.glyphiconBook
 
-  mount :: [H.HTML (I e)]
-  mount = (if state ^. _isMount
-           then [toolItem [B.btnLg] (Database (state ^. _path)) handleConfigure "configure mount" B.glyphiconWrench]
-           else [])
-          ++ [toolItem' handleMountDatabase "mount database" B.glyphiconHdd]
-
-  toolItem' :: (State -> I e) -> String -> A.ClassName -> H.HTML (I e)
-  toolItem' f = toolItem [B.btnLg] state f
+  toolItem' :: (State -> Event e) -> String -> A.ClassName -> HTML e
+  toolItem' f = toolItem [] state f


### PR DESCRIPTION
Resolves #260 

Although it doesn't quite, as nothing happens yet :smile: 

There are two problems - one is slamengine isn't ready yet I think: slamdata/slamengine#763, but the other is to do with how we are actually going to deliver this to the user. You cannot force a download with any kind of AJAX trickery, so I don't really know where to go from here.

We could perhaps have an invisible iframe with a form in which we make the request, but in order for the browser to treat this as a file download the response will need the `Content-Disposition: attachment` header to force this and to set the target filename, which is not something we'd want to do for `GET /data/fs/...` requests in the general case. Perhaps the header could be set when a query parameter for a target filename is specified?

/cc @mossprescott for thoughts on the API to support this.