### PR TITLE
Nudge delete cell icon out from under scrollbar

### DIFF
--- a/less/main.less
+++ b/less/main.less
@@ -346,6 +346,10 @@ ol.breadcrumb {
                 color: #286090;
             }
         }
+        > i {
+            margin-left: 6px;
+            opacity: 0.5;
+        }
     }
 
     .cell-failures, .cell-messages {

--- a/src/View/Notebook/Cell.purs
+++ b/src/View/Notebook/Cell.purs
@@ -85,6 +85,7 @@ controls cell =
         , H.button [ A.title "Delete cell"
                    , E.onClick $ E.input_ $ TrashCell $ cell ^. _cellId ]
                    [ glyph B.glyphiconTrash ]
+        , glyph B.glyphiconChevronLeft
         ]
 
 output :: forall e. State -> Cell -> Maybe (HTML e)
@@ -158,6 +159,7 @@ statusBar notebook hasOutput cell =
                            , H.div [ A.classes [ B.pullRight, VC.cellControls ] ]
                                    $ catMaybes [ toggleMessageButton
                                                , linkButton
+                                               , Just $ glyph B.glyphiconChevronLeft
                                                ]
                            ] ++ messages
                  ]


### PR DESCRIPTION
Resolves #301 I think - I wasn't able to find another problematic situation that prevented cells from being deleted anyway.

It looked a bit weird having just extra space to the right of the action icons, so I added a little chevron symbol to do the nudging.