### PR TITLE
Update markdown version and add styling

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,7 +27,7 @@
     "purescript-foldable-traversable": "^0.3.1",
     "purescript-foreign": "^0.4.2",
     "purescript-globals": "^0.1.6",
-    "purescript-halogen": "3e189cf7f4b191dc82d01b4cb9ab2f119342a6d7",
+    "purescript-halogen": "b1636e2537526963f89134c7b4fd8005c1b62e37",
     "purescript-halogen-bootstrap": "b163b1eb7200ad9af9ddd700c80872a6386ba76d",
     "purescript-index": "^0.3.0",
     "purescript-integers": "^0.1.0",
@@ -36,7 +36,7 @@
     "purescript-lens": "^0.7.0",
     "purescript-lists": "^0.6.0",
     "purescript-maps": "^0.3.3",
-    "purescript-markdown": "1.4.0",
+    "purescript-markdown-halogen": "^0.1.2",
     "purescript-maybe": "^0.2.2",
     "purescript-minimatch": "^0.1.0",
     "purescript-monoid": "^0.2.0",
@@ -60,7 +60,7 @@
   },
   "resolutions": {
     "purescript-argonaut": "^0.6.0",
-    "purescript-halogen": "3e189cf7f4b191dc82d01b4cb9ab2f119342a6d7",
+    "purescript-halogen": "b1636e2537526963f89134c7b4fd8005c1b62e37",
     "purescript-random": "573de58651264a2b04636eed8f4bf09364fbca02",
     "purescript-timers": "^0.0.9"
   }

--- a/less/main.less
+++ b/less/main.less
@@ -493,18 +493,6 @@ ol.breadcrumb {
     }
 }
 
-.markdown-output {
-    margin-left: 1em;
-    &.fade.in {
-        padding-top: 10px;
-    }
-    label {
-        select, input {
-            margin-left: 0.5em;
-        }
-    }
-}
-
 .search-cell-input {
     border-top: none;
 
@@ -589,6 +577,7 @@ div.viz-cell-editor {
 
 @import "bootstrap-overloads";
 @import "nav";
+@import "markdown-output";
 @import "dialog/mount";
 @import "dialog/rename";
 @import "dialog/embed";

--- a/less/markdown-output.less
+++ b/less/markdown-output.less
@@ -1,0 +1,62 @@
+.markdown-output {
+
+    margin-left: 1em;
+
+    &.fade.in {
+        padding-top: 10px;
+    }
+
+    span.slamdown-field {
+      > label {
+        margin-left: 1.5em;
+      }
+      > input {
+        margin-left: 0.5em;
+        margin-right: 1em;
+      }
+    }
+
+    span.slamdown-field:first-child {
+      > label {
+          margin-left: 0;
+          display: block;
+          width: calc(100px - 0.5em);
+          padding-top: 7px;
+          padding-right: 0.5em;
+          float: left;
+      }
+      input {
+        margin: 0;
+      }
+      overflow: hidden;
+    }
+
+    ul.slamdown-radios, ul.slamdown-checkboxes {
+      list-style: none;
+      padding: 7px 0 0;
+      li {
+        display: inline;
+        margin-right: 1.5em;
+        label {
+          margin-left: 0.5em;
+        }
+      }
+    }
+
+    input {
+      padding: 0 6px;
+      height: 34px;
+    }
+
+    input[type=radio], input[type=checkbox] {
+      height: auto;
+    }
+
+    select {
+      margin-top: 7px;
+    }
+
+    p {
+      overflow: hidden;
+    }
+}

--- a/src/Input/Notebook.purs
+++ b/src/Input/Notebook.purs
@@ -27,7 +27,7 @@ import Optic.Core (LensP(), (..), (<>~), (%~), (+~), (.~), (^.), (?~), lens)
 import Optic.Fold ((^?))
 import Optic.Setter (mapped)
 import Text.Markdown.SlamDown (SlamDown(..), Block(..), Expr(..), Inline(..), FormField(..))
-import Text.Markdown.SlamDown.Html (FormFieldValue(..), SlamDownEvent(..), SlamDownState(..), applySlamDownEvent, emptySlamDownState)
+import Text.Markdown.SlamDown.Html (FormFieldValue(..), SlamDownEvent(..), SlamDownState(..), applySlamDownEvent)
 import Text.Markdown.SlamDown.Parser (parseMd)
 import Utils (elem)
 
@@ -60,7 +60,7 @@ data Input
   | ReceiveCellContent Cell
   | ViewCellContent Cell
   | RefreshCell Cell
-    
+
   | StartRunCell CellId Date
   | StopCell CellId
   | CellResult CellId Date (Either (NEL.NonEmpty FailureMessage) CellResultContent)
@@ -137,10 +137,10 @@ updateState state (UpdatedOutput cid newInput) =
 
 updateState state (RefreshCell cell) =
   let requesting = state ^. _requesting
-      cid = cell ^. _cellId 
+      cid = cell ^. _cellId
   in if elem cid requesting
      then state
-     else state # _refreshing <>~ [cell ^. _cellId] 
+     else state # _refreshing <>~ [cell ^. _cellId]
 
 updateState state i = state
 
@@ -201,9 +201,9 @@ initialSlamDownOutput sf = VarMap sm
   where sm :: SM.StrMap VarMapValue
         sm = fromMaybe SM.empty <<< traverse toValue $ SM.fromList sf
         toValue :: FormField -> Maybe VarMapValue
-        toValue (TextBox _ (Literal s)) = Just s
+        toValue (TextBox _ (Just (Literal s))) = Just s
         toValue (RadioButtons (Literal s) _) = Just s
-        toValue (DropDown _ (Literal s)) = Just s
+        toValue (DropDown _ (Just (Literal s))) = Just s
         toValue (CheckBoxes _ (Literal ss)) = Nothing
         toValue _ = Nothing
 

--- a/src/Model/Notebook/Cell/Markdown.purs
+++ b/src/Model/Notebook/Cell/Markdown.purs
@@ -7,10 +7,10 @@ import Data.Argonaut.Decode (DecodeJson, decodeJson)
 import Data.Argonaut.Encode (EncodeJson, encodeJson)
 import Data.Either (Either(..))
 import Optic.Core (LensP(), lens)
-import Text.Markdown.SlamDown (TextBoxType(..))
-import Text.Markdown.SlamDown.Html (SlamDownState(..), emptySlamDownState, FormFieldValue(..))
+import Text.Markdown.SlamDown (SlamDown(..), TextBoxType(..))
+import Text.Markdown.SlamDown.Html (SlamDownState(..), initSlamDownState, FormFieldValue(..))
 import qualified Data.StrMap as M
-import qualified Data.Set as S 
+import qualified Data.Set as S
 import qualified Model.Notebook.Cell.Common as C
 
 
@@ -46,7 +46,7 @@ instance encodeEncFormField :: EncodeJson EncFormField where
   encodeJson (EncFormField (SingleValue tx str)) =
     "type" := encodeTextBox tx
     ~> "value" := str
-    ~> jsonEmptyObject 
+    ~> jsonEmptyObject
   encodeJson (EncFormField (MultipleValues ss)) = encodeJson (S.toList ss)
 
 instance decodeEncFormField :: DecodeJson EncFormField where
@@ -59,7 +59,7 @@ instance decodeEncFormField :: DecodeJson EncFormField where
         pure $ EncFormField $ SingleValue tx v)
 
 prepareToEnc :: SlamDownState -> M.StrMap EncFormField
-prepareToEnc (SlamDownState m) = EncFormField <$> m 
+prepareToEnc (SlamDownState m) = EncFormField <$> m
 
 encodeState :: SlamDownState -> Json
 encodeState = encodeJson <<< prepareToEnc
@@ -98,3 +98,7 @@ _input = _MarkdownRec <<< C._input
 
 _state :: LensP MarkdownRec SlamDownState
 _state = _MarkdownRec <<< lens _.state _{state = _}
+
+-- TODO: re-look at this, we may be able to simplify things elsewhere if we use `initSlamDownState` properly
+emptySlamDownState :: SlamDownState
+emptySlamDownState = initSlamDownState (SlamDown [])

--- a/src/View/Notebook/Cell/Markdown.purs
+++ b/src/View/Notebook/Cell/Markdown.purs
@@ -1,7 +1,7 @@
 module View.Notebook.Cell.Markdown (markdownOutput) where
 
 import Data.Array (null)
-import EffectTypes (NotebookAppEff()) 
+import EffectTypes (NotebookAppEff())
 import Input.Notebook (Input(..))
 import Model.Notebook.Cell (Cell(), _cellId)
 import Model.Notebook.Cell.Markdown (MarkdownRec(), _input, _state)
@@ -22,7 +22,7 @@ type SlamDownHTML e = H.HTML (E.Event (NotebookAppEff e) SlamDownEvent)
 markdownOutput :: forall e. MarkdownRec -> Cell -> [HTML e]
 markdownOutput mr cell =
   optionalHTML
-  <<< renderHalogen (mr ^. _state)
+  <<< renderHalogen ("slamdata-frm-" ++ show (cell ^. _cellId)) (mr ^. _state)
   <<< parseMd
   $ mr ^. _input
   where


### PR DESCRIPTION
Resolves #219, resolves #218.

`"purescript-markdown-halogen": "^0.1.2"` doesn't exit yet, it depends on slamdata/purescript-markdown-halogen#4 being merged and published as that first.

Styling of inline elements (`foo = ___ bar = ___`) still isn't wonderful - the first input will align with a left column, the following inputs appear based on the width of their labels. An alternative is to use label-width-alignment for the first label/input too, so lines with multiple inputs always ignore the "left column layout" entirely, but that has its own problems.

