### PR TITLE
Fix #340 by pruning form fields with changed value types

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "purescript-base": "~0.1.0",
     "purescript-halogen": "30e8b2c7174a1eeda73f67cc42c739ca24a1e218",
-    "purescript-markdown": "~1.7.0",
+    "purescript-markdown": "~1.7.1",
     "purescript-markdown-halogen": "~0.2.0",
     "purescript-halogen-bootstrap": "~0.2.0",
     "purescript-search": "~0.3.0",


### PR DESCRIPTION
This resolves #340; the problem, as observed by @garyb (thanks!), was that in a `SlamDataState` transition, the old version of a field was preferred to the new one even if it has a different value type.

This PR also introduces a new version of `purescript-markdown`, which now has an `Eq` instance for `TextBoxType`.