### PR TITLE
Retry ajax requests (#343)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -44,7 +44,7 @@
     "purescript-control": "~0.3.0",
     "purescript-lazy": "~0.4.0",
     "purescript-globals": "~0.2.0",
-    "purescript-affjax": "~0.4.0",
+    "purescript-affjax": "~0.5.0",
     "purescript-uri": "~0.1.0-rc.1",
     "purescript-nonempty-arrays": "~0.3.0",
     "purescript-webdriver": "~0.1.0"

--- a/src/Api/Common.purs
+++ b/src/Api/Common.purs
@@ -27,17 +27,21 @@ succeeded (StatusCode int) =
   200 <= code && code < 300
   where code = int
 
+-- | A version of `affjax` with our retry policy.
+slamjax :: forall e a b. (Requestable a, Respondable b) => AffjaxRequest a -> Affjax (avar :: AVAR | e) b
+slamjax = retry Nothing affjax
+
 retryGet :: forall e a. (Respondable a) => URL -> Affjax (avar :: AVAR | e) a
-retryGet u = retry Nothing affjax $ defaultRequest { url = u }
+retryGet u = slamjax $ defaultRequest { url = u }
 
 retryDelete :: forall e a. (Respondable a) => URL -> Affjax (avar :: AVAR | e) a
-retryDelete u = retry Nothing affjax $ defaultRequest { url = u, method = DELETE }
+retryDelete u = slamjax $ defaultRequest { url = u, method = DELETE }
 
 retryPost :: forall e a b. (Requestable a, Respondable b) => URL -> a -> Affjax (avar :: AVAR | e) b
-retryPost u c = retry Nothing affjax $ defaultRequest { method = POST, url = u, content = Just c }
+retryPost u c = slamjax $ defaultRequest { method = POST, url = u, content = Just c }
 
 retryPut :: forall e a b. (Requestable a, Respondable b) => URL -> a -> Affjax (avar :: AVAR | e) b
-retryPut u c = retry Nothing affjax $ defaultRequest { method = PUT, url = u, content = Just c }
+retryPut u c = slamjax $ defaultRequest { method = PUT, url = u, content = Just c }
 
 getResponse :: forall a e. String -> Affjax e a -> Aff (ajax :: AJAX | e) a
 getResponse msg affjax = do

--- a/src/Api/Common.purs
+++ b/src/Api/Common.purs
@@ -2,13 +2,19 @@ module Api.Common where
 
 import Prelude
 import Control.Monad.Aff (Aff())
+import Control.Monad.Aff.AVar (AVAR())
 import Control.Monad.Eff.Exception (error)
 import Control.Monad.Error.Class (throwError)
 import Data.Argonaut.Combinators ((~>), (:=))
 import Data.Argonaut.Core (Json(), JAssoc(), jsonEmptyObject)
 import Data.Int (fromNumber, toNumber)
 import Data.Foldable (foldl)
-import Network.HTTP.Affjax (Affjax(), AJAX())
+import Data.Maybe (Maybe(..))
+import Network.HTTP.Affjax.Request (Requestable)
+import Network.HTTP.Affjax.Response (Respondable)
+import Network.HTTP.Affjax (Affjax(), AJAX(), URL(), AffjaxRequest(), defaultRequest, affjax, retry)
+import Network.HTTP.Method (Method(..))
+
 import Network.HTTP.MimeType (MimeType(..), mimeTypeToString)
 import Network.HTTP.RequestHeader (RequestHeader(..))
 import Network.HTTP.StatusCode (StatusCode(..))
@@ -20,6 +26,18 @@ succeeded :: StatusCode -> Boolean
 succeeded (StatusCode int) =
   200 <= code && code < 300
   where code = int
+
+retryGet :: forall e a. (Respondable a) => URL -> Affjax (avar :: AVAR | e) a
+retryGet u = retry Nothing affjax $ defaultRequest { url = u }
+
+retryDelete :: forall e a. (Respondable a) => URL -> Affjax (avar :: AVAR | e) a
+retryDelete u = retry Nothing affjax $ defaultRequest { url = u, method = DELETE }
+
+retryPost :: forall e a b. (Requestable a, Respondable b) => URL -> a -> Affjax (avar :: AVAR | e) b
+retryPost u c = retry Nothing affjax $ defaultRequest { method = POST, url = u, content = Just c }
+
+retryPut :: forall e a b. (Requestable a, Respondable b) => URL -> a -> Affjax (avar :: AVAR | e) b
+retryPut u c = retry Nothing affjax $ defaultRequest { method = PUT, url = u, content = Just c }
 
 getResponse :: forall a e. String -> Affjax e a -> Aff (ajax :: AJAX | e) a
 getResponse msg affjax = do

--- a/src/Api/Fs.purs
+++ b/src/Api/Fs.purs
@@ -1,7 +1,7 @@
 module Api.Fs where
 
 import Prelude
-import Api.Common (succeeded, getResponse, retryGet, retryDelete, retryPost, retryPut)
+import Api.Common (succeeded, getResponse, retryGet, retryDelete, retryPost, retryPut, slamjax)
 import Control.Apply ((*>))
 import Control.Bind ((>=>))
 import Control.Monad.Aff (Aff())
@@ -24,7 +24,7 @@ import Data.Tuple (Tuple(..))
 import Model.Path
 import Model.Notebook.Cell
 import Model.Notebook.Port
-import Network.HTTP.Affjax (Affjax(), AJAX(), affjax, defaultRequest, retry)
+import Network.HTTP.Affjax (Affjax(), AJAX(), affjax, defaultRequest)
 import Network.HTTP.Affjax.Response (Respondable, ResponseType(JSONResponse))
 import Network.HTTP.Method (Method(..))
 import Network.HTTP.RequestHeader (RequestHeader(..))
@@ -83,7 +83,7 @@ makeFile ap mime content =
   isJson = maybe (Left "empty file") Right firstLine >>= jsonParser
 
   go :: _ -> Aff _ _
-  go _ = retry Nothing affjax $ defaultRequest
+  go _ = slamjax $ defaultRequest
     { method = PUT
     , headers = maybe [] (pure <<< ContentType) mime
     , content = Just content
@@ -226,7 +226,7 @@ move src tgt = do
   let url = if R.isDatabase src
             then Config.mountUrl
             else Config.dataUrl
-  result <- retry Nothing affjax $ defaultRequest
+  result <- slamjax $ defaultRequest
     { method = MOVE
     , headers = [RequestHeader "Destination" $ either printPath printPath tgt]
     , url = url <> R.resourcePath src
@@ -249,7 +249,7 @@ mountInfo res = do
 
 saveMount :: forall e. R.Resource -> String -> Aff (ajax :: AJAX, avar :: AVAR | e) Unit
 saveMount res uri = do
-  result <- retry Nothing affjax $ defaultRequest
+  result <- slamjax $ defaultRequest
     { method = PUT
     , headers = [ContentType applicationJSON]
     , content = Just $ stringify { mongodb: { connectionUri: uri } }

--- a/src/Api/Fs.purs
+++ b/src/Api/Fs.purs
@@ -1,10 +1,11 @@
 module Api.Fs where
 
 import Prelude
-import Api.Common (succeeded, getResponse)
+import Api.Common (succeeded, getResponse, retryGet, retryDelete, retryPost, retryPut)
 import Control.Apply ((*>))
 import Control.Bind ((>=>))
 import Control.Monad.Aff (Aff())
+import Control.Monad.Aff.AVar (AVAR())
 import Control.Monad.Eff.Exception (error)
 import Control.Monad.Error.Class (throwError)
 import Data.Argonaut.Core (Json())
@@ -23,7 +24,7 @@ import Data.Tuple (Tuple(..))
 import Model.Path
 import Model.Notebook.Cell
 import Model.Notebook.Port
-import Network.HTTP.Affjax (Affjax(), AJAX(), affjax, get, put_, delete_, defaultRequest)
+import Network.HTTP.Affjax (Affjax(), AJAX(), affjax, defaultRequest, retry)
 import Network.HTTP.Affjax.Response (Respondable, ResponseType(JSONResponse))
 import Network.HTTP.Method (Method(..))
 import Network.HTTP.RequestHeader (RequestHeader(..))
@@ -49,22 +50,22 @@ instance listingRespondable :: Respondable Listing where
   responseType = JSONResponse
   fromResponse = read
 
-children :: forall e. DirPath -> Aff (ajax :: AJAX | e) (Array R.Resource)
+children :: forall e. DirPath -> Aff (ajax :: AJAX, avar :: AVAR | e) (Array R.Resource)
 children dir = do
   cs <- children' $ printPath dir
   pure $ (R._root .~ (either (const rootDir) id (Right dir))) <$> cs
 
-children' :: forall e. String -> Aff (ajax :: AJAX | e) (Array R.Resource)
+children' :: forall e. String -> Aff (ajax :: AJAX, avar :: AVAR | e) (Array R.Resource)
 children' str = runListing <$> (getResponse msg $ listing str)
   where
   msg = "error getting resource children"
 
-listing :: forall e. String -> Affjax e Listing
-listing str = get (Config.metadataUrl <> str)
+listing :: forall e. String -> Affjax (avar :: AVAR | e) Listing
+listing str = retryGet $ Config.metadataUrl <> str
 
-makeFile :: forall e. AnyPath -> Maybe MimeType -> String -> Aff (ajax :: AJAX | e) Unit
+makeFile :: forall e. AnyPath -> Maybe MimeType -> String -> Aff (ajax :: AJAX, avar :: AVAR | e) Unit
 makeFile ap mime content =
-  getResponse msg $ go unit 
+  getResponse msg $ go unit
   where
   resource :: R.Resource
   resource = R.newFile # R._path .~ ap
@@ -82,16 +83,16 @@ makeFile ap mime content =
   isJson = maybe (Left "empty file") Right firstLine >>= jsonParser
 
   go :: _ -> Aff _ _
-  go _ = affjax $ defaultRequest
+  go _ = retry Nothing affjax $ defaultRequest
     { method = PUT
     , headers = maybe [] (pure <<< ContentType) mime
     , content = Just content
     , url = Config.dataUrl <> R.resourcePath resource
     }
 
-loadNotebook :: forall e. R.Resource -> Aff (ajax :: AJAX | e) N.Notebook
+loadNotebook :: forall e. R.Resource -> Aff (ajax :: AJAX, avar :: AVAR | e) N.Notebook
 loadNotebook res = do
-  val <- getResponse "error loading notebook" $ get (Config.dataUrl <> R.resourcePath res <> "/index")
+  val <- getResponse "error loading notebook" $ retryGet (Config.dataUrl <> R.resourcePath res <> "/index")
   case decodeJson (foreignToJson val) of
     Left err -> throwError (error err)
     Right notebook ->
@@ -111,7 +112,7 @@ foreign import foreignToJson :: Foreign -> Json
 -- | a `This` value the name will be used as a basis for generating a new
 -- | notebook. If the `name` value is a `Both` value the notebook will be saved
 -- | and then moved. If the name is a `That` the notebook will be saved.
-saveNotebook :: forall e. N.Notebook -> Aff (ajax :: AJAX | e) N.Notebook
+saveNotebook :: forall e. N.Notebook -> Aff (ajax :: AJAX, avar :: AVAR | e) N.Notebook
 saveNotebook notebook = case notebook ^. N._name of
   That name -> save name notebook *> pure notebook
   This name -> do
@@ -137,20 +138,20 @@ saveNotebook notebook = case notebook ^. N._name of
       else pure notebook
   where
 
-  getNewName' :: String -> Aff (ajax :: AJAX | e) String
+  getNewName' :: String -> Aff (ajax :: AJAX, avar :: AVAR | e) String
   getNewName' name =
     let baseName = name ++ "." ++ Config.notebookExtension
     in getNewName (notebook ^. N._path) baseName
 
-  save :: String -> N.Notebook -> Aff (ajax :: AJAX | e) Unit
+  save :: String -> N.Notebook -> Aff (ajax :: AJAX, avar :: AVAR | e) Unit
   save name notebook =
     let notebookPath = (notebook ^. N._path) </> dir name <./> Config.notebookExtension </> file "index"
-    in getResponse "error while saving notebook" $ put_ (Config.dataUrl <> printPath notebookPath) notebook
+    in getResponse "error while saving notebook" $ retryPut (Config.dataUrl <> printPath notebookPath) notebook
 
 -- | Generates a new resource name based on a directory path and a name for the
 -- | resource. If the name already exists in the path a number is appended to
 -- | the end of the name.
-getNewName :: forall e. DirPath -> String -> Aff (ajax :: AJAX | e) String
+getNewName :: forall e. DirPath -> String -> Aff (ajax :: AJAX, avar :: AVAR | e) String
 getNewName parent name = do
   items <- children' (printPath parent)
   pure if exists' name items then getNewName' items 1 else name
@@ -163,40 +164,40 @@ getNewName parent name = do
       let newName = S.joinWith "." $ (body <> " " <> show i):suffixes
       pure if exists' newName items
            then getNewName' items (i + 1)
-           else newName 
+           else newName
 
-exists :: forall e. String -> DirPath -> Aff (ajax :: AJAX | e) Boolean
+exists :: forall e. String -> DirPath -> Aff (ajax :: AJAX, avar :: AVAR | e) Boolean
 exists name parent = exists' name <$> children' (printPath parent)
 
 exists' :: forall e. String -> Array R.Resource -> Boolean
-exists' name items = isJust $ findIndex (\r -> r ^. R._name == name) items 
+exists' name items = isJust $ findIndex (\r -> r ^. R._name == name) items
 
-forceDelete :: forall e. R.Resource -> Aff (ajax :: AJAX | e) Unit 
-forceDelete resource = 
-  getResponse msg $ delete_ path
+forceDelete :: forall e. R.Resource -> Aff (ajax :: AJAX, avar :: AVAR | e) Unit
+forceDelete resource =
+  getResponse msg $ retryDelete path
   where
   msg :: String
   msg = "can not delete"
 
   path = (if R.isDatabase resource then Config.mountUrl else Config.dataUrl)
          <> R.resourcePath resource
-         
-delete :: forall e. R.Resource -> Aff (ajax :: AJAX | e) (Maybe R.Resource)
+
+delete :: forall e. R.Resource -> Aff (ajax :: AJAX, avar :: AVAR | e) (Maybe R.Resource)
 delete resource =
   if not (R.isDatabase resource || alreadyInTrash resource)
-  then 
+  then
     moveToTrash resource
   else do
     forceDelete resource
     pure Nothing
   where
-  msg :: String 
+  msg :: String
   msg = "can not delete"
 
   moveToTrash :: R.Resource -> Aff _ (Maybe R.Resource)
   moveToTrash res = do
     let d = (res ^. R._root) </> dir Config.trashFolder
-        path = (res # R._root .~ d) ^. R._path 
+        path = (res # R._root .~ d) ^. R._path
     name <- getNewName d (res ^. R._name)
     move res (path # R._nameAnyPath .~ name)
     pure (Just $ R.Directory d)
@@ -217,15 +218,15 @@ delete resource =
   go (Tuple d name) =
     case name of
       Right _ -> false
-      Left n -> if n == DirName Config.trashFolder then true else alreadyInTrash' d 
-    
-  
-move :: forall a e. R.Resource -> AnyPath -> Aff (ajax :: AJAX | e) AnyPath
+      Left n -> if n == DirName Config.trashFolder then true else alreadyInTrash' d
+
+
+move :: forall a e. R.Resource -> AnyPath -> Aff (ajax :: AJAX, avar :: AVAR | e) AnyPath
 move src tgt = do
   let url = if R.isDatabase src
             then Config.mountUrl
             else Config.dataUrl
-  result <- affjax $ defaultRequest
+  result <- retry Nothing affjax $ defaultRequest
     { method = MOVE
     , headers = [RequestHeader "Destination" $ either printPath printPath tgt]
     , url = url <> R.resourcePath src
@@ -234,9 +235,9 @@ move src tgt = do
      then pure tgt
      else throwError (error result.response)
 
-mountInfo :: forall e. R.Resource -> Aff (ajax :: AJAX | e) String
+mountInfo :: forall e. R.Resource -> Aff (ajax :: AJAX, avar :: AVAR | e) String
 mountInfo res = do
-  result <- get (Config.mountUrl <> R.resourcePath res)
+  result <- retryGet (Config.mountUrl <> R.resourcePath res)
   if succeeded result.status
      then case parse result.response of
        Left err -> throwError $ error (show err)
@@ -246,9 +247,9 @@ mountInfo res = do
   parse :: String -> F String
   parse = parseJSON >=> prop "mongodb" >=> readProp "connectionUri"
 
-saveMount :: forall e. R.Resource -> String -> Aff (ajax :: AJAX | e) Unit
+saveMount :: forall e. R.Resource -> String -> Aff (ajax :: AJAX, avar :: AVAR | e) Unit
 saveMount res uri = do
-  result <- affjax $ defaultRequest
+  result <- retry Nothing affjax $ defaultRequest
     { method = PUT
     , headers = [ContentType applicationJSON]
     , content = Just $ stringify { mongodb: { connectionUri: uri } }

--- a/src/Api/Query.purs
+++ b/src/Api/Query.purs
@@ -1,7 +1,7 @@
 module Api.Query (query, port, sample, SQL(), fields, count, all, templated) where
 
 import Prelude
-import Api.Common (getResponse, succeeded, retryGet)
+import Api.Common (getResponse, succeeded, retryGet, slamjax)
 import Config (queryUrl, dataUrl)
 import Control.Apply (lift2)
 import Control.Bind ((<=<), (>=>))
@@ -26,7 +26,7 @@ import Data.Tuple (Tuple(..))
 import Model.Notebook.Port (VarMapValue())
 import Model.Path (AnyPath())
 import Model.Resource (Resource(), resourcePath, isFile, _name)
-import Network.HTTP.Affjax (Affjax(), AJAX(), affjax, defaultRequest, retry)
+import Network.HTTP.Affjax (Affjax(), AJAX(), affjax, defaultRequest)
 import Network.HTTP.Method (Method(..))
 import Network.HTTP.RequestHeader (RequestHeader(..))
 import Optic.Core 
@@ -63,7 +63,7 @@ port res dest sql vars =
   if not (isFile dest)
   then pure empty
   else do
-    result <- retry Nothing affjax $ defaultRequest
+    result <- slamjax $ defaultRequest
             { method = POST
             , headers = [RequestHeader "Destination" $ resourcePath dest]
             , url = queryUrl <> resourcePath res <> queryVars

--- a/src/Api/Query.purs
+++ b/src/Api/Query.purs
@@ -26,7 +26,7 @@ import Data.Tuple (Tuple(..))
 import Model.Notebook.Port (VarMapValue())
 import Model.Path (AnyPath())
 import Model.Resource (Resource(), resourcePath, isFile, _name)
-import Network.HTTP.Affjax (Affjax(), AJAX(), affjax, defaultRequest)
+import Network.HTTP.Affjax (Affjax(), AJAX(), affjax, defaultRequest, retry)
 import Network.HTTP.Method (Method(..))
 import Network.HTTP.RequestHeader (RequestHeader(..))
 import Optic.Core 
@@ -45,7 +45,7 @@ query res sql =
   msg = "error in query"
   uri = mkURI res sql
 
-count :: forall e. Resource -> Aff (ajax :: AJAX | e) Int
+count :: forall e. Resource -> Aff (ajax :: AJAX, avar :: AVAR | e) Int
 count res = do
   fromMaybe 0 <<< readTotal <$> query res sql
   where
@@ -58,7 +58,7 @@ count res = do
 
 port :: forall e. Resource -> Resource -> SQL ->
         StrMap VarMapValue ->
-        Aff (ajax :: AJAX | e) JObject
+        Aff (ajax :: AJAX, avar :: AVAR | e) JObject
 port res dest sql vars =
   if not (isFile dest)
   then pure empty
@@ -104,13 +104,13 @@ sample' res mbOffset mbLimit =
         (maybe "" (("?offset=" <>) <<< show) mbOffset) <>
         (maybe "" (("&limit=" <>) <<< show ) mbLimit)
 
-sample :: forall e. Resource -> Int -> Int -> Aff (ajax :: AJAX | e) JArray
+sample :: forall e. Resource -> Int -> Int -> Aff (ajax :: AJAX, avar :: AVAR | e) JArray
 sample res offset limit = sample' res (Just offset) (Just limit)
 
-all :: forall e. Resource -> Aff (ajax :: AJAX | e) JArray
+all :: forall e. Resource -> Aff (ajax :: AJAX, avar :: AVAR | e) JArray
 all res = sample' res Nothing Nothing
 
-fields :: forall e. Resource -> Aff (ajax :: AJAX | e) (Array String)
+fields :: forall e. Resource -> Aff (ajax :: AJAX, avar :: AVAR | e) (Array String)
 fields res = do
   jarr <- sample res 0 100
   case jarr of

--- a/src/EffectTypes.purs
+++ b/src/EffectTypes.purs
@@ -33,6 +33,7 @@ type NotebookComponentEff e = ( timer :: TIMER
                               , echartResize :: ECHARTS_RESIZE
                               , now :: Now
                               , ajax :: AJAX
+                              , avar :: AVAR
                               , zClipboard :: ZCLIPBOARD | e)
 
 type NotebookAppEff e = HalogenEffects (NotebookComponentEff e)


### PR DESCRIPTION
This adds retries to the ajax requests in `Api.Fs`. In particular, I would appreciate feedback on the following two things:

1. Should there be timeouts, and if so, what sounds reasonable? Currently the retries proceed indefinitely.

2. Do we need retries anywhere else? In my (limited) manual testing, adding them to this module sufficed to prevent the interface from getting killed when the server goes down temporarily, but I'm curious if there are other places that would benefit from the added robustness.

Resolves #343 (@jdegoes)