### PR TITLE
Change retry policy to not retry upon proper error; upgrade affjax

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -44,7 +44,7 @@
     "purescript-control": "~0.3.0",
     "purescript-lazy": "~0.4.0",
     "purescript-globals": "~0.2.0",
-    "purescript-affjax": "~0.5.0",
+    "purescript-affjax": "^0.5.4",
     "purescript-uri": "~0.1.0-rc.1",
     "purescript-nonempty-arrays": "~0.3.0",
     "purescript-webdriver": "~0.1.0"

--- a/src/Api/Common.purs
+++ b/src/Api/Common.purs
@@ -4,6 +4,7 @@ import Prelude
 import Control.Monad.Aff (Aff())
 import Control.Monad.Aff.AVar (AVAR())
 import Control.Monad.Eff.Exception (error)
+import Control.Monad.Eff.Ref (REF())
 import Control.Monad.Error.Class (throwError)
 import Data.Argonaut.Combinators ((~>), (:=))
 import Data.Argonaut.Core (Json(), JAssoc(), jsonEmptyObject)
@@ -12,7 +13,7 @@ import Data.Foldable (foldl)
 import Data.Maybe (Maybe(..))
 import Network.HTTP.Affjax.Request (Requestable)
 import Network.HTTP.Affjax.Response (Respondable)
-import Network.HTTP.Affjax (Affjax(), AJAX(), URL(), AffjaxRequest(), defaultRequest, affjax, retry)
+import Network.HTTP.Affjax (Affjax(), AJAX(), URL(), AffjaxRequest(), defaultRequest, affjax, retry, defaultRetryPolicy)
 import Network.HTTP.Method (Method(..))
 
 import Network.HTTP.MimeType (MimeType(..), mimeTypeToString)
@@ -27,20 +28,22 @@ succeeded (StatusCode int) =
   200 <= code && code < 300
   where code = int
 
--- | A version of `affjax` with our retry policy.
-slamjax :: forall e a b. (Requestable a, Respondable b) => AffjaxRequest a -> Affjax (avar :: AVAR | e) b
-slamjax = retry Nothing affjax
+type RetryEffects e = (avar :: AVAR, ref :: REF | e)
 
-retryGet :: forall e a. (Respondable a) => URL -> Affjax (avar :: AVAR | e) a
+-- | A version of `affjax` with our retry policy.
+slamjax :: forall e a b. (Requestable a, Respondable b) => AffjaxRequest a -> Affjax (RetryEffects e) b
+slamjax = retry defaultRetryPolicy affjax
+
+retryGet :: forall e a. (Respondable a) => URL -> Affjax (RetryEffects e) a
 retryGet u = slamjax $ defaultRequest { url = u }
 
-retryDelete :: forall e a. (Respondable a) => URL -> Affjax (avar :: AVAR | e) a
+retryDelete :: forall e a. (Respondable a) => URL -> Affjax (RetryEffects e) a
 retryDelete u = slamjax $ defaultRequest { url = u, method = DELETE }
 
-retryPost :: forall e a b. (Requestable a, Respondable b) => URL -> a -> Affjax (avar :: AVAR | e) b
+retryPost :: forall e a b. (Requestable a, Respondable b) => URL -> a -> Affjax (RetryEffects e) b
 retryPost u c = slamjax $ defaultRequest { method = POST, url = u, content = Just c }
 
-retryPut :: forall e a b. (Requestable a, Respondable b) => URL -> a -> Affjax (avar :: AVAR | e) b
+retryPut :: forall e a b. (Requestable a, Respondable b) => URL -> a -> Affjax (RetryEffects e) b
 retryPut u c = slamjax $ defaultRequest { method = PUT, url = u, content = Just c }
 
 getResponse :: forall a e. String -> Affjax e a -> Aff (ajax :: AJAX | e) a

--- a/src/Controller/Common.purs
+++ b/src/Controller/Common.purs
@@ -1,6 +1,7 @@
 module Controller.Common where
 
 import Prelude
+import Api.Common (RetryEffects())
 import Api.Fs (children)
 import Control.Monad.Aff (attempt)
 import Control.Monad.Aff.Class (liftAff)
@@ -14,7 +15,7 @@ import Model.Resource
 import Model.Path (DirPath())
 import Network.HTTP.Affjax (AJAX())
 
-getChildren :: forall i e. (Resource -> Boolean) -> (Array Resource -> Event (ajax :: AJAX | e) i) -> DirPath -> Event (ajax :: AJAX | e) i
+getChildren :: forall i e. (Resource -> Boolean) -> (Array Resource -> Event (RetryEffects (ajax :: AJAX | e)) i) -> DirPath -> Event (RetryEffects (ajax :: AJAX | e)) i
 getChildren pred f r = do
   ei <- liftAff $ attempt $ children r
   case ei of
@@ -24,8 +25,8 @@ getChildren pred f r = do
       f items' `andThen` \_ -> fold (getChildren pred f <$> parents)
     _ -> empty
 
-getDirectories :: forall i e. (Array Resource -> Event (ajax :: AJAX | e) i) -> DirPath -> Event (ajax :: AJAX | e) i
+getDirectories :: forall i e. (Array Resource -> Event (RetryEffects (ajax :: AJAX | e)) i) -> DirPath -> Event (RetryEffects (ajax :: AJAX | e)) i
 getDirectories = getChildren (\x -> isDirectory x || isDatabase x)
 
-getFiles :: forall i e. (Array Resource -> Event (ajax :: AJAX | e) i) -> DirPath -> Event (ajax :: AJAX | e) i
+getFiles :: forall i e. (Array Resource -> Event (RetryEffects (ajax :: AJAX | e)) i) -> DirPath -> Event (RetryEffects (ajax :: AJAX | e)) i
 getFiles = getChildren isFile


### PR DESCRIPTION
Resolves #365.

The (new) default retry policy only retries on exceptional cases (i.e. `onerror`); if it receives a response (no matter the status code), it doesn't retry.

This is related to #364 (after this PR, an error is presented as expected).