### PR TITLE
Refactoring / Improvement to tests

### DIFF
--- a/test/src/Test/Selenium.purs
+++ b/test/src/Test/Selenium.purs
@@ -2,7 +2,7 @@ module Test.Selenium where
 
 import Prelude
 import DOM (DOM())
-import Control.Bind ((>=>))
+import Control.Bind ((>=>), (=<<))
 import Control.Monad.Eff (Eff())
 import Control.Monad.Eff.Class (liftEff)
 import Control.Monad.Eff.Console (log, CONSOLE())
@@ -91,10 +91,10 @@ findItem name = do
 toolbarButton :: String -> Check (Maybe Element)
 toolbarButton key = do
   config <- getConfig
-  css config.toolbar.main >>= element >>= maybe noToolbar \toolbar ->
-    checkLocator (locator key) >>= child toolbar
+  toolbar <- getElementByCss config.toolbar.main "no toolbar"
+  checkLocator (locator key) >>= child toolbar
+
   where
-  noToolbar = errorMsg "no toolbar"
   locator :: String -> Element -> Check Element
   locator key el = do
     config <- getConfig
@@ -132,54 +132,48 @@ checkMountedDatabase = do
   error = errorMsg "There is no test database"
   success _ = successMsg "test database found"
 
+getItemToolbar :: Check { listGroupItem :: Element, itemToolbar :: Element}
+getItemToolbar = do
+  config <- getConfig
+  listGroupItem <- getElementByCss config.item.main "there is no list-group-item"
+  css config.item.toolbar
+    >>= child listGroupItem
+    >>= maybe toolbarErrorMsg (\tb -> pure { listGroupItem : listGroupItem, itemToolbar : tb })
+  where
+    toolbarErrorMsg = errorMsg "there is no toolbar in list-group-item"
+
 checkItemToolbar :: Check Unit
 checkItemToolbar = do
   sectionMsg "CHECK ITEM TOOLBAR"
   home
-  config <- getConfig
-  css config.item.main >>= element >>= maybe errParent goParent
-  where
-  errParent = errorMsg "there is no list-group-item"
-  goParent el = do
-    getConfig >>= (\config -> css config.item.toolbar) >>=
-    child el >>= maybe errToolbar (goToolbar el)
-
-  errToolbar = errorMsg "there is no toolbar in list-group-item"
-  goToolbar el toolbar = do
-    apathize do
-      displayed <- visible toolbar
-      if displayed
-        then errorMsg "toolbar should not be displayed"
-        else do
-        successMsg "toolbar is hidden"
-        actions do
-          hover el
-        displayedHovered <- visible toolbar
-        if displayedHovered
-          then successMsg "hovered toolbar is visible"
-          else errorMsg "hovered toolbar is not visible"
-    apathize do
-      style <- getCss el "background-color"
-      actions $ leftClick el
-      newStyle <- getCss el "background-color"
-      if newStyle == style
-        then errorMsg "background-color has not been changed after click"
-        else successMsg "bacground-color has been changed after click"
+  { listGroupItem : groupItem, itemToolbar : toolbar } <- getItemToolbar
+  apathize do
+    assertBoolean "toolbar should not be displayed" <<< not =<< visible toolbar
+    successMsg "toolbar is hidden"
+    actions $ hover groupItem
+    assertBoolean "hovered toolbar should be visible" =<< visible toolbar
+    successMsg "hovered toolbar is visible"
+  apathize do
+    style <- getCss groupItem "background-color"
+    actions $ leftClick groupItem
+    newStyle <- getCss groupItem "background-color"
+    assertBoolean "background-color should have been changed after click" $ newStyle /= style
+    successMsg "background-color has been changed after click"
 
 checkURL :: Check Unit
 checkURL = do
   sectionMsg "CHECKING URL"
   home
-  url <- getURL
-  either errHash goHash $ matchHash routing $ dropHash url
+  getURL >>= getHashFromURL >>= checkHash
+
   where
-  errHash _ = errorMsg "incorrect hash"
-  goHash (Salted sort search salt) = do
+  checkHash :: Routes -> Check Unit
+  checkHash (Salted sort search salt) = do
     successMsg "hash is correct"
     if searchPath search == Just "/"
       then successMsg "search path is correct"
       else errorMsg "incorrect search path"
-  goHash _ =
+  checkHash _ =
     errorMsg "need additional redirects"
 
 
@@ -188,30 +182,30 @@ goDown = do
   sectionMsg "CHECKING GO DOWN"
   home
   url <- getURL
-  findTestDb >>= maybe noTestDb (goTestDb url)
+  testDb <- getTestDb
+  oldHash <- either (const $ errorMsg "incorrect initial hash in goDown") pure $ matchHash routing (dropHash url)
+  checkOldHash url testDb oldHash
+
   where
-  noTestDb = errorMsg "no test db"
-  goTestDb url el =
-    either incorrectOldHash (goOldHash url el) $ matchHash routing (dropHash url)
-  incorrectOldHash _ = errorMsg "incorrect initial hash in goDown"
-  goOldHash url el old@(Salted oldSort oldSearch oldSalt) = do
+
+  getTestDb = findTestDb >>= maybe (errorMsg "no test db") pure
+
+  checkOldHash url el old@(Salted oldSort oldSearch oldSalt) = do
     actions $ doubleClick leftButton el
     config <- getConfig
     waitCheck (changed url) config.selenium.waitTime
     loaded
-    newUrl <- getURL
-    either errHash (goHash old) $ matchHash routing (dropHash newUrl)
-  goOldHash _ _ _ = errorMsg "weird initial hash in goDown"
+    getURL >>= getHashFromURL >>= checkHashes old
+  checkOldHash _ _ _ = errorMsg "weird initial hash in goDown"
 
-  errHash _ = errorMsg "incorrect has after goDown"
-  goHash (Salted oldSort oldSearch oldSalt) (Salted sort search salt) = do
+  checkHashes (Salted oldSort oldSearch oldSalt) (Salted sort search salt) = do
     config <- getConfig
     if (oldSalt == salt) &&
        (oldSort == sort) &&
        ((searchPath search) == (Just $ "/" <> config.database.name <> "/"))
       then successMsg "correct hash after goDown"
       else errorMsg $ "incorrect hash after goDown " <> (fromMaybe "" $ searchPath search)
-  goHash _ _ = do
+  checkHashes _ _ = do
     errorMsg "weird hash after goDown"
 
   changed oldUrl = do
@@ -221,43 +215,47 @@ goDown = do
       else pure true
 
 
-breadcrumbs :: Check Unit
-breadcrumbs = do
+checkBreadcrumbs :: Check Unit
+checkBreadcrumbs = do
   sectionMsg "BREADCRUMBS"
   home
   texts <- bTexts
   config <- getConfig
-  if not $ elem config.breadcrumbs.home texts
-    then errorMsg "incorrect root breadcrumb"
-    else do
-    successMsg "correct root breadcrumb"
-    goDown
-    nTexts <- bTexts
-    if not $ elem config.breadcrumbs.home texts
-      then errorMsg "incorrect root breadcrumb after goDown"
-      else if not $ elem config.database.name nTexts
-           then errorMsg "breadcrumbs are not updated"
-           else do
-             successMsg "breadcrumbs are updated"
-             as <- anchors
-             mbEl <- foldl foldMFn (pure Nothing) as
-             maybe errHome goHome mbEl
+  assertBoolean "incorrect root breadcrumb" $ elem config.breadcrumbs.home texts
+  successMsg "correct root breadcrumb"
+
+  goDown
+  nTexts <- bTexts
+  assertBoolean "incorrect root breadcrumb after goDown" $ elem config.breadcrumbs.home texts
+  assertBoolean "breadcrumbs are not updated" $ elem config.database.name nTexts
+  successMsg "breadcrumbs are updated"
+
+  homeBreadcrumb <- getHomeBreadcrumb
+  actions $ leftClick homeBreadcrumb
+  loaded
+  checkURL
+  successMsg "Ok, went home after click on root breadcrumb"
 
   where
+  getHomeBreadcrumb :: Check Element
+  getHomeBreadcrumb =
+    anchors
+      >>= foldl foldMFn (pure Nothing)
+      >>= maybe errHome pure
+
   errHome = errorMsg "There is no Home breadcrumb: since you have already checked that it exists, there is probably error in test"
-  goHome el = do
-    actions $ leftClick el
-    loaded
-    checkURL
-    successMsg "Ok, went home after click on root breadcrumb"
+
+  breadcrumbs :: Check Element
+  breadcrumbs = do
+    config <- getConfig
+    getElementByCss config.breadcrumbs.main "There is no breadcrumbs"
+
   anchors :: Check (List Element)
   anchors = do
+    bs <- breadcrumbs
     config <- getConfig
-    css config.breadcrumbs.main >>= element >>= maybe err go
-    where
-    err = errorMsg "There is no breadcrumbs"
-    go bs =
-      getConfig >>= \config -> css config.breadcrumbs.text >>= children bs
+    css config.breadcrumbs.text
+      >>= children bs
 
   bTexts :: Check (List String)
   bTexts = anchors >>= traverse innerHtml
@@ -287,25 +285,19 @@ sorting = do
   sectionMsg "SORTING CHECK"
   goDown
   texts <- getItemTexts
-  url <- getURL
-  either errHash (goHash texts) $ matchHash routing $ dropHash url
+  getURL >>= getHashFromURL >>= checkHash texts
   where
-
-  errHash _ = errorMsg "Incorrect hash"
-  goHash texts (Salted sort search salt) = do
+  checkHash :: List String -> Routes -> Check Unit
+  checkHash texts (Salted sort search salt) = do
     config <- getConfig
-    css config.sort.button >>= element >>=
-      maybe errNoSortButton (goSortButton texts sort)
-  goHash _ _ = errorMsg "need addtional redirects in sorting"
-
-  errNoSortButton = errorMsg "there is no sort button"
-  goSortButton texts sort el = do
-    actions $ click leftButton el
+    sortButton <- getElementByCss config.sort.button "there is no sort button"
+    actions $ click leftButton sortButton
     loaded
     nTexts <- getItemTexts
     if reverse nTexts == texts
       then successMsg "OK, sort works"
       else errorMsg "Sorting doesn't work"
+  checkHash _ _ = errorMsg "need additional redirects in sorting"
 
 
 fileUpload :: Check Unit
@@ -313,38 +305,37 @@ fileUpload = do
   sectionMsg "FILE UPLOAD"
   goDown
   config <- getConfig
-  css config.upload.input >>= element >>= maybe errNoInput goInput
-  where
-  errNoInput = errorMsg "There is no upload input"
-  goInput el = do
-    config <- getConfig
-    oldItems <- S.fromList <$> getItemTexts
-    script """
-    var els = document.getElementsByTagName('i');
-    for (var i = 0; i < els.length; i++) {
-      if (/hidden-file-input/.test(els[i].className)) {
-        els[i].className = "";
-      }
+
+  uploadInput <- getElementByCss config.upload.input "There is no upload input"
+  oldItems <- S.fromList <$> getItemTexts
+  script """
+  var els = document.getElementsByTagName('i');
+  for (var i = 0; i < els.length; i++) {
+    if (/hidden-file-input/.test(els[i].className)) {
+      els[i].className = "";
     }
-    """
-    keys config.upload.filePath el
-    waitCheck inNotebook config.selenium.waitTime
-    successMsg "Ok, explore notebook created"
-    back
-    loaded
-    items <- S.fromList <$> getItemTexts
-    if S.isEmpty $ S.difference items oldItems
-      then errorMsg "items has not changed after upload"
-      else successMsg "new items added after upload"
+  }
+  """
 
+  keys config.upload.filePath uploadInput
+  waitCheck inNotebook config.selenium.waitTime
+  successMsg "Ok, explore notebook created"
+  back
+  loaded
 
+  items <- S.fromList <$> getItemTexts
+  if S.isEmpty $ S.difference items oldItems
+    then errorMsg "items has not changed after upload"
+    else successMsg "new items added after upload"
 
+  where
   inNotebook = do
     url <- getURL
     rgx <- nbRegex
     if R.test rgx url
       then pure true
       else later 1000 inNotebook
+
   nbRegex = do
     config <- getConfig
     pure $ R.regex ("notebook.html#/explore/" <>
@@ -356,68 +347,89 @@ moveDelete :: Check Unit
 moveDelete = do
   sectionMsg "MOVE DELETE"
   goDown
-  findUploaded >>= maybe errUploaded goUploaded
+
+  getUploadedItem
+    >>= checkMove
+    >>= checkDelete
+
   where
   errUploaded = errorMsg "File has not been uploaded"
-  goUploaded el = do
+
+  getUploadedItem :: Check Element
+  getUploadedItem =
+    findUploaded
+      >>= maybe (errorMsg "File has not been uploade") pure
+
+  -- | Move an item, and return the new/moved item
+  checkMove :: Element -> Check Element
+  checkMove item = do
     config <- getConfig
-    checkLocator moveLoc >>= child el >>= maybe errIcon (goIcon el)
-  errIcon = errorMsg "no move/rename icon"
-  goIcon el icon = do
-    config <- getConfig
-    actions do
-      leftClick el
-    waitCheck (checker $ visible icon) config.selenium.waitTime
-    actions do
-      leftClick icon
+    itemGetMoveIcon item >>= itemClickToolbarIcon item
     waitCheck modalShown config.selenium.waitTime
-    css config.move.nameField >>= element >>= maybe errNoInput goInput
+
+    getElementByCss config.move.nameField "no rename field"
+      >>= editNameField
+
+    getElementByCss config.move.submit "no submit button"
+      >>= actions <<< leftClick
+
+    waitCheck (later 3000 $ pure false) 5000
+    renamedItem <- findItem config.move.other >>= maybe (errorMsg "not renamed") pure
+    successMsg "successfully renamed"
+    pure renamedItem
+
+    where
+      -- | Type a new name into the "name" field
+      editNameField :: Element -> Check Unit
+      editNameField nameField = do
+        config <- getConfig
+        actions do
+          leftClick nameField
+          keyDown commandKey
+          sendKeys "a"
+          keyUp commandKey
+          sendKeys $ Str.fromChar $ Ch.fromCharCode 57367
+          sendKeys config.move.other
+
+      -- | Get an item's "move/rename" icon
+      itemGetMoveIcon :: Element -> Check Element
+      itemGetMoveIcon item =
+        checkLocator moveLoc
+          >>= child item
+          >>= maybe (errorMsg "no move/rename icon") pure
+
+  checkDelete :: Element -> Check Unit
+  checkDelete item = do
+    config <- getConfig
+    itemGetDeleteIcon item >>= itemClickToolbarIcon item
+    waitCheck (later 3000 $ pure false) 5000
+    findItem config.move.other
+      >>= maybe (pure unit) (const $ errorMsg "not deleted")
+    successMsg "successfully deleted"
+
+    where
+      itemGetDeleteIcon :: Element -> Check Element
+      itemGetDeleteIcon item =
+        checkLocator deleteLoc
+          >>= child item
+          >>= maybe (errorMsg "no delete icon") pure
+
+  -- | Activate the item's toolbar and click a button/icon in it
+  itemClickToolbarIcon :: Element -> Element -> Check Unit
+  itemClickToolbarIcon item icon = do
+    config <- getConfig
+    actions $ leftClick item
+    waitCheck (checker $ visible icon) config.selenium.waitTime
+    actions $ leftClick icon
+
+  -- | Is a modal dialog shown?
+  modalShown :: Check Boolean
   modalShown = do
     config <- getConfig
     vis <- css config.modal >>= element >>= maybe (pure false) visible
     if vis
       then pure true
       else later 1000 modalShown
-
-  errNoInput = errorMsg "no rename field"
-  goInput el = do
-    config <- getConfig
-    actions do
-      leftClick el
-      keyDown commandKey
-      sendKeys "a"
-      keyUp commandKey
-      sendKeys $ Str.fromChar $ Ch.fromCharCode 57367
-      sendKeys config.move.other
-    css config.move.submit >>= element >>= maybe errNoSubmit goSubmit
-
-  errNoSubmit = errorMsg "no submit button"
-  goSubmit button = do
-    config <- getConfig
-    actions do
-      leftClick button
-    waitCheck (later 3000 $ pure false) 5000
-    findItem config.move.other >>= maybe errRename goRename
-
-  errRename = errorMsg "not renamed"
-  goRename el = do
-    successMsg "successfully renamed"
-    checkLocator deleteLoc >>= child el >>= maybe errDelete (goDelete el)
-
-  errDelete = errorMsg "there is no delete icon"
-  goDelete el icon = do
-    config <- getConfig
-    actions do
-      leftClick el
-    waitCheck (checker $ visible icon) config.selenium.waitTime
-    actions do
-      leftClick icon
-    waitCheck (later 3000 $ pure false) 5000
-    findItem config.move.other >>= maybe okDeleted (const errDeleted)
-
-  errDeleted = errorMsg "item has not been deleted"
-  okDeleted = do
-    successMsg "item has been deleted"
 
   moveLoc :: Element -> Check Element
   moveLoc el = getConfig >>= \config -> buttonLoc config.move.markMove el
@@ -437,75 +449,98 @@ moveDelete = do
     foldFn Nothing (Tuple el Nothing) = Nothing
     foldFn Nothing (Tuple el (Just _)) = Just el
 
+assertBoolean :: String -> Boolean -> Check Unit
+assertBoolean _ true = pure unit
+assertBoolean err false = errorMsg err
+
+getElementByCss :: String -> String -> Check Element
+getElementByCss cls errorMessage =
+  css cls
+    >>= element
+    >>= maybe (errorMsg errorMessage) pure
+
+getHashFromURL :: String -> Check Routes
+getHashFromURL =
+  dropHash
+    >>> matchHash routing
+    >>> either (const $ errorMsg "incorrect hash") pure
 
 trashCheck :: Check Unit
 trashCheck = do
   sectionMsg "TRASH CHECK"
   goDown
-  visible <- isTrashVisible
-  if visible
-    then errorMsg "Trash is shown"
-    else do
-    config <- getConfig
-    successMsg "Trash is hidden"
-    toolbarButton config.toolbar.showHide >>= maybe errShowHide goShowHide
+  assertBoolean "Trash must not be shown" <<< not =<< isTrashVisible
+  successMsg "Trash is hidden"
+
+  showHideButton <- getShowHideButton
+  actions $ leftClick showHideButton
+  waitCheck (later 1000 $ pure true) 2000
+  assertBoolean "Trash should be shown" =<< isTrashVisible
+
+  trashItem <- fromJust <$> findItem trashKey
+  actions $ doubleClick leftButton trashItem
+  loaded
+  deletedItem <- findDeletedItem
+  successMsg "Deleted item found"
 
   where
-  isTrashVisible = findItem trashKey >>= maybe (pure false) visible
+  isTrashVisible :: Check Boolean
+  isTrashVisible =
+    findItem trashKey
+      >>= maybe (pure false) visible
 
+  trashKey :: String
   trashKey = R.replace (R.regex "\\." R.noFlags{global=true}) "\\." SDCfg.trashFolder
 
-  errShowHide = errorMsg "No show/hide button"
-  goShowHide btn = do
-    actions do
-      leftClick btn
-    waitCheck (later 1000 $ pure true) 2000
-    visible <- isTrashVisible
-    if not visible
-      then errorMsg "Trash should be visible now"
-      else do
-      successMsg "Trash is visible"
-      config <- getConfig
-      trash <- fromJust <$> findItem trashKey
-      actions do
-        doubleClick leftButton trash
-      loaded
-      findItem config.move.other >>= maybe errNoDeleted goDeleted
+  getShowHideButton :: Check Element
+  getShowHideButton = do
+    config <- getConfig
+    toolbarButton config.toolbar.showHide
+      >>= maybe (errorMsg "No show/hide button") pure
 
-  errNoDeleted = errorMsg "Can't find deleted item"
-  goDeleted _ = successMsg "Deleted item found"
-
+  findDeletedItem :: Check Element
+  findDeletedItem = do
+    config <- getConfig
+    findItem config.move.other
+      >>= maybe (errorMsg "Can't find deleted item") pure
 
 createFolder :: Check Unit
 createFolder = do
   sectionMsg "NEW FOLDER CHECK"
   goDown
   config <- getConfig
-  toolbarButton config.toolbar.newFolder >>= maybe errButton goButton
+
+  newFolderButton <- getNewFolderButton
+  actions $ leftClick newFolderButton
+  waitCheck (later 1000 $ pure true) config.selenium.waitTime
+
+  folder <- getNewFolder
+  actions $ doubleClick leftButton folder
+  loaded
+
+  getURL >>= getHashFromURL >>= checkHash
+
   where
-  errButton = errorMsg "No create folder button"
-  goButton btn = do
+
+  getNewFolderButton :: Check Element
+  getNewFolderButton = do
     config <- getConfig
-    actions $ leftClick btn
-    waitCheck (later 1000 $ pure true) config.selenium.waitTime
-    findItem SDCfg.newFolderName >>= maybe errNoNewFolder goNewFolder
+    toolbarButton config.toolbar.newFolder
+      >>= maybe (errorMsg "No create folder button") pure
 
-  errNoNewFolder = errorMsg "new folder has not been created"
-  goNewFolder folder = do
-    actions $ doubleClick leftButton folder
-    loaded
-    url <- getURL
-    either errHash goHash $ matchHash routing $ dropHash url
+  getNewFolder :: Check Element
+  getNewFolder =
+    findItem SDCfg.newFolderName
+      >>= maybe (errorMsg "new folder has not been created") pure
 
-  errHash _ = errorMsg "incorrect hash"
-
-  goHash (Salted sort search salt) = do
+  checkHash :: Routes -> Check Unit
+  checkHash (Salted sort search salt) = do
     config <- getConfig
     let expectedPath = "/" <> config.database.name <> "/" <> SDCfg.newFolderName <> "/"
     if (searchPath search) == (Just expectedPath)
       then successMsg "ok, hash correct"
       else errorMsg "hash incorrect in created folder"
-  goHash _ = errorMsg "incorrect hash"
+  checkHash _ = errorMsg "incorrect hash"
 
 
 createNotebook :: Check Unit
@@ -513,23 +548,28 @@ createNotebook = do
   sectionMsg "NEW NOTEBOOK CHECK"
   goDown
   config <- getConfig
-  toolbarButton config.toolbar.newNotebook >>= maybe errButton goButton
-  where
-  errButton = errorMsg "No create notebook button"
-  goButton btn = do
-    config <- getConfig
-    actions $ leftClick btn
-    e <- attempt $ waitCheck notebookCheck config.selenium.waitTime
-    case e of
-      Left _ -> errorMsg "no redirect to notebook"
-      Right _ -> do
-        successMsg "ok, notebook created"
-        back
-        loaded
-        findItem SDCfg.newNotebookName >>= maybe errNoNotebook goNotebook
+  actions <<< leftClick =<< getNewNotebookButton
+  attempt (waitCheck notebookCheck config.selenium.waitTime)
+    >>= either (\_ -> errorMsg "no redirect to notebook") (\_ -> successMsg "ok, notebook created")
 
-  errNoNotebook = errorMsg "No notebook in parent directory"
-  goNotebook _ = successMsg "OK, new notebook found in parent directory"
+  back
+  loaded
+  newNotebook <- getNewNotebook
+  successMsg "OK, new notebook found in parent directory"
+
+  where
+  getNewNotebook :: Check Element
+  getNewNotebook =
+    findItem SDCfg.newNotebookName
+      >>= maybe (errorMsg "No notebook in parent directory") pure
+
+  getNewNotebookButton :: Check Element
+  getNewNotebookButton = do
+    config <- getConfig
+    toolbarButton config.toolbar.newNotebook
+      >>= maybe (errorMsg "No create notebook button") pure
+
+  notebookCheck :: Check Boolean
   notebookCheck = do
     url <- getURL
     if R.test (R.regex "notebook.html" R.noFlags) url
@@ -572,7 +612,7 @@ test config =
       checkItemToolbar
       checkURL
       goDown
-      breadcrumbs
+      checkBreadcrumbs
       sorting
       fileUpload
       moveDelete

--- a/test/src/Test/Selenium/Common.purs
+++ b/test/src/Test/Selenium/Common.purs
@@ -1,0 +1,72 @@
+module Test.Selenium.Common
+  ( assertBoolean
+  , getElementByCss
+  , getHashFromURL
+  , dropHash
+  , loaded
+  )
+  where
+
+import Prelude
+import Data.Either (either, isLeft)
+import Data.Maybe (Maybe(..), maybe)
+import Data.Foldable (traverse_)
+import Data.Tuple (Tuple(..))
+import qualified Data.String.Regex as R
+import qualified Data.StrMap as SM
+
+import Driver.File.Routing (Routes(..), routing)
+import Routing (matchHash)
+
+import Selenium
+import Selenium.Types
+
+import Test.Selenium.Log
+import Test.Selenium.Monad
+
+-- | Assert the truth of a boolean, providing an error message
+assertBoolean :: String -> Boolean -> Check Unit
+assertBoolean _ true = pure unit
+assertBoolean err false = errorMsg err
+
+getElementByCss :: String -> String -> Check Element
+getElementByCss cls errorMessage =
+  css cls
+    >>= element
+    >>= maybe (errorMsg errorMessage) pure
+
+getHashFromURL :: String -> Check Routes
+getHashFromURL =
+  dropHash
+    >>> matchHash routing
+    >>> either (const $ errorMsg "incorrect hash") pure
+
+dropHash :: String -> String
+dropHash h = R.replace (R.regex "^[^#]*#" R.noFlags) "" h
+
+checkElements :: Check Unit
+checkElements = do
+  config <- getConfig
+  traverse_ traverseFn $ SM.toList config.locators
+  successMsg "all elements here, page is loaded"
+  where
+  traverseFn :: Tuple String String -> Check Unit
+  traverseFn (Tuple key selector) = do
+    driver <- getDriver
+    css selector >>= element >>= checkMsg key
+
+  checkMsg :: String -> Maybe _ -> Check Unit
+  checkMsg msg Nothing = errorMsg $ msg <> " not found"
+  checkMsg _ _ = pure unit
+
+loaded :: Check Unit
+loaded = do
+  driver <- getDriver
+  config <- getConfig
+  waitCheck checkEls config.selenium.waitTime
+  where
+  checkEls = do
+    res <- attempt $ checkElements
+    if isLeft res
+      then later 1000 $ checkEls
+      else pure true


### PR DESCRIPTION
This PR is meant to make the frontend test code a bit easier to follow and maintain. The main difference is that this version separates the acquisition of UI elements from the actions that are performed on them; as such, chains of auxiliary functions are replaced with simple, non-nested monadic actions.

I have run this locally (with `gulp test`) and it passes; the intent is for this PR to only introduce syntactic changes, not semantic ones.