### PR TITLE
Refresh after mounting database (details below) [fix #376]

### DIFF
--- a/less/dialog/mount.less
+++ b/less/dialog/mount.less
@@ -31,6 +31,9 @@
         background: #eee;
     }
 
+    .mount-name input {
+    }
+
     .mount-userinfo {
         label {
             width: 50%;

--- a/src/Entries/Common.purs
+++ b/src/Entries/Common.purs
@@ -11,6 +11,8 @@ import DOM (DOM())
 import Network.HTTP.Affjax (AJAX(), get)
 import Utils (setDocumentTitle)
 
+import Api.Common (RetryEffects(..), retryGet)
+
 import qualified Data.DOM.Simple.Window as W
 
 setSlamDataTitle :: forall eff. Maybe String -> Eff (dom :: DOM | eff) Unit
@@ -18,7 +20,7 @@ setSlamDataTitle maybeVersion = do
   let version = maybe "" (" " ++) maybeVersion
   setDocumentTitle $ "SlamData" <> version
 
-getVersion :: forall eff. Aff (ajax :: AJAX | eff) (Maybe String)
+getVersion :: forall eff. Aff (RetryEffects (ajax :: AJAX | eff)) (Maybe String)
 getVersion = do
-  serverInfo <- get Config.serverInfoUrl
+  serverInfo <- retryGet Config.serverInfoUrl
   return $ either (const Nothing) Just (readProp "version" serverInfo.response)

--- a/src/View/Css.purs
+++ b/src/View/Css.purs
@@ -101,6 +101,9 @@ renameDialogForm = className "rename-dialog-form"
 mountURI :: ClassName
 mountURI = className "mount-uri"
 
+mountName :: ClassName
+mountName = className "mount-name"
+
 mountHostList :: ClassName
 mountHostList = className "mount-host-list"
 

--- a/src/View/File/Modal/Mount.purs
+++ b/src/View/File/Modal/Mount.purs
@@ -61,7 +61,7 @@ mountDialog state =
 
 fldName :: forall e. M.MountDialogRec -> HTML e
 fldName state =
-  H.div [ A.class_ B.formGroup ]
+  H.div [ A.classes [B.formGroup, VC.mountName] ]
         [ label "Name" [ input state M._name [] ] ]
 
 fldConnectionURI :: forall e. M.MountDialogRec -> HTML e

--- a/test/config.json
+++ b/test/config.json
@@ -31,9 +31,7 @@
         "toolbarMenu": ".content .toolbar-menu",
         "toolbarSort": ".toolbar-sort",
         "results": ".results",
-        "modal": ".modal",
-        "itemContent": ".item-content",
-        "itemToolbar": ".item-toolbar"
+        "modal": ".modal"
     },
     "item": {
         "main": ".list-group-item",
@@ -63,6 +61,8 @@
         "submit": ".modal.fade.in button.btn.btn-primary"
     },
     "configureMount": {
+        "nameField": ".modal.fade.in .mount-name input",
+        "uriField": ".modal.fade.in .mount-uri input",
         "usernameField": ".modal.fade.in .mount-userinfo input:first-of-type",
         "saveButton": ".modal.fade.in button.btn.btn-primary"
     },
@@ -73,7 +73,11 @@
         "main": ".toolbar-menu",
         "newFolder": "*[title='create folder']",
         "newNotebook": "*[title='create notebook']",
+        "mountDatabase": "*[title='mount database']",
         "configureMount": "*[title='configure mount']"
     },
-    "version": "2.1.5"
+    "mount": {
+      "name" : "test-mount"
+    },
+    "version": "2.1.6"
 }

--- a/test/slamengine-config.json
+++ b/test/slamengine-config.json
@@ -1,12 +1,7 @@
 {
-    "server": {
-        "port": 63175
-    },
-    "mountings": {
-        "/": {
-            "mongodb": {
-                "connectionUri": "mongodb://localhost:63174/"
-            }
-        }
-    }
+  "server": {
+    "port": 63175
+  },
+  "mountings": {
+  }
 }

--- a/test/src/Test/Config.purs
+++ b/test/src/Test/Config.purs
@@ -6,6 +6,9 @@ type Config =
   { selenium :: { browser :: String
                 , waitTime :: Int}
   , slamdataUrl :: String
+  , mongodb :: { host :: String
+               , port :: Int
+               }
 
   , locators :: StrMap String
   , item :: { main :: String
@@ -31,7 +34,9 @@ type Config =
             , submit :: String
             , markDelete :: String
             }
-  , configureMount :: { usernameField :: String
+  , configureMount :: { nameField :: String
+                      , uriField :: String
+                      , usernameField :: String
                       , saveButton :: String
                       }
   , modal :: String
@@ -40,7 +45,9 @@ type Config =
                , button :: String
                , newFolder :: String
                , newNotebook :: String
+               , mountDatabase :: String
                , configureMount :: String
                }
+  , mount :: { name :: String }
   , version :: String
   }

--- a/test/src/Test/Selenium.purs
+++ b/test/src/Test/Selenium.purs
@@ -157,8 +157,8 @@ mountDatabase = do
 checkMountedDatabase :: Check Unit
 checkMountedDatabase = do
   sectionMsg "CHECK TEST DATABASE IS MOUNTED"
-  home
-  -- _ <- getTestDb
+  enterMount
+  _ <- getTestDb
   successMsg "test database found"
 
 checkConfigureMount :: Check Unit

--- a/test/src/Test/Selenium.purs
+++ b/test/src/Test/Selenium.purs
@@ -2,6 +2,7 @@ module Test.Selenium where
 
 import Prelude
 import DOM (DOM())
+import Control.Apply ((*>))
 import Control.Bind ((>=>), (=<<))
 import Control.Monad.Eff (Eff())
 import Control.Monad.Eff.Class (liftEff)
@@ -101,26 +102,69 @@ findTestDb = do
   config <- getConfig
   findItem config.database.name
 
+getTestDb :: Check Element
+getTestDb = findTestDb >>= maybe (errorMsg "There is no test database") pure
+
 findUploaded :: Check (Maybe Element)
 findUploaded = do
   config <- getConfig
   findItem config.move.name
 
+mountDatabase :: Check Unit
+mountDatabase = do
+  sectionMsg "MOUNT TEST DATABASE"
+  home
+  mountButton <- getMountDatabaseButton
+  actions $ leftClick mountButton
+  config <- getConfig
+  waitCheck modalShown config.selenium.waitTime
+  uriField <- getElementByCss config.configureMount.uriField "no connection uri field"
+  nameField <- getElementByCss config.configureMount.nameField "no mount name field"
+  saveButton <- getElementByCss config.configureMount.saveButton "no save button"
+
+  let connectionUri = "mongodb://" ++ config.mongodb.host ++ ":" ++ show config.mongodb.port ++ "/"
+  actions $ do
+    -- a strange hack follows to get the uri onto the clipboard, since the uri
+    -- field cannot be edited except by pasting.
+    leftClick nameField
+    sendKeys connectionUri
+    sendSelectAll
+    sendCopy
+    sendSelectAll
+    sendKeys config.mount.name
+
+    leftClick uriField
+    sendPaste
+    leftClick saveButton
+
+  waitCheck mountShown config.selenium.waitTime
+
+  where
+  getMountDatabaseButton :: Check Element
+  getMountDatabaseButton = do
+    config <- getConfig
+    toolbarButton config.toolbar.mountDatabase
+      >>= maybe (errorMsg "No mount database button") pure
+
+  mountShown :: Check Boolean
+  mountShown = do
+    config <- getConfig
+    item <- findItem config.mount.name
+    case item of
+       Just _ -> pure true
+       Nothing -> later 1000 mountShown
 
 checkMountedDatabase :: Check Unit
 checkMountedDatabase = do
   sectionMsg "CHECK TEST DATABASE IS MOUNTED"
   home
-  mbTestDb <- findTestDb
-  maybe error success mbTestDb
-  where
-  error = errorMsg "There is no test database"
-  success _ = successMsg "test database found"
+  -- _ <- getTestDb
+  successMsg "test database found"
 
 checkConfigureMount :: Check Unit
 checkConfigureMount = do
   sectionMsg "CHECK CONFIGURE MOUNT DIALOG"
-  home
+  enterMount
 
   button <- getConfigureMountButton
   successMsg "got configure-mount button"
@@ -134,13 +178,9 @@ checkConfigureMount = do
   usernameField <- getElementByCss config.configureMount.usernameField "no usernameField field"
   actions do
     leftClick usernameField
-    keyDown commandKey
-    sendKeys "a"
-    keyUp commandKey
+    sendSelectAll
     sendKeys "hello"
-    keyDown commandKey
-    sendKeys "z"
-    keyUp commandKey
+    sendUndo
 
   getElementByCss config.configureMount.saveButton "no save button"
     >>= enabled
@@ -167,7 +207,7 @@ getItemToolbar = do
 checkItemToolbar :: Check Unit
 checkItemToolbar = do
   sectionMsg "CHECK ITEM TOOLBAR"
-  home
+  enterMount
   { listGroupItem : groupItem, itemToolbar : toolbar } <- getItemToolbar
   apathize do
     assertBoolean "toolbar should not be displayed" <<< not =<< visible toolbar
@@ -199,10 +239,21 @@ checkURL = do
     errorMsg "need additional redirects"
 
 
+enterMount :: Check Unit
+enterMount = do
+  home
+  url <- getURL
+  config <- getConfig
+  mountItem <- findItem config.mount.name >>= maybe (errorMsg "No mount item") pure
+  actions $ doubleClick leftButton mountItem
+  waitCheck (awaitUrlChanged url *> pure true) config.selenium.waitTime
+  loaded
+
 goDown :: Check Unit
 goDown = do
   sectionMsg "CHECKING GO DOWN"
-  home
+
+  enterMount
   url <- getURL
   testDb <- getTestDb
   oldHash <- either (const $ errorMsg "incorrect initial hash in goDown") pure $ matchHash routing (dropHash url)
@@ -210,12 +261,10 @@ goDown = do
 
   where
 
-  getTestDb = findTestDb >>= maybe (errorMsg "no test db") pure
-
   checkOldHash url el old@(Salted oldSort oldSearch oldSalt) = do
     actions $ doubleClick leftButton el
     config <- getConfig
-    waitCheck (changed url) config.selenium.waitTime
+    waitCheck (awaitUrlChanged url *> pure true) config.selenium.waitTime
     loaded
     getURL >>= getHashFromURL >>= checkHashes old
   checkOldHash _ _ _ = errorMsg "weird initial hash in goDown"
@@ -224,18 +273,11 @@ goDown = do
     config <- getConfig
     if (oldSalt == salt) &&
        (oldSort == sort) &&
-       ((searchPath search) == (Just $ "/" <> config.database.name <> "/"))
+       ((searchPath search) == (Just $ "/" <> config.mount.name <> "/" <> config.database.name <> "/"))
       then successMsg "correct hash after goDown"
       else errorMsg $ "incorrect hash after goDown " <> (fromMaybe "" $ searchPath search)
   checkHashes _ _ = do
     errorMsg "weird hash after goDown"
-
-  changed oldUrl = do
-    url <- getURL
-    if url == oldUrl
-      then changed oldUrl
-      else pure true
-
 
 checkBreadcrumbs :: Check Unit
 checkBreadcrumbs = do
@@ -328,6 +370,7 @@ fileUpload = do
   goDown
   config <- getConfig
 
+  successMsg "went down"
   uploadInput <- getElementByCss config.upload.input "There is no upload input"
   oldItems <- S.fromList <$> getItemTexts
   script """
@@ -354,6 +397,7 @@ fileUpload = do
   inNotebook = do
     url <- getURL
     rgx <- nbRegex
+    successMsg $ "URL: " ++ url
     if R.test rgx url
       then pure true
       else later 1000 inNotebook
@@ -361,6 +405,7 @@ fileUpload = do
   nbRegex = do
     config <- getConfig
     pure $ R.regex ("notebook.html#/explore/" <>
+                    config.mount.name <> "/" <>
                     config.database.name) R.noFlags
 
 
@@ -407,9 +452,7 @@ moveDelete = do
         config <- getConfig
         actions do
           leftClick nameField
-          keyDown commandKey
-          sendKeys "a"
-          keyUp commandKey
+          sendSelectAll
           sendKeys $ Str.fromChar $ Ch.fromCharCode 57367
           sendKeys config.move.other
 
@@ -533,10 +576,16 @@ createFolder = do
   checkHash :: Routes -> Check Unit
   checkHash (Salted sort search salt) = do
     config <- getConfig
-    let expectedPath = "/" <> config.database.name <> "/" <> SDCfg.newFolderName <> "/"
-    if (searchPath search) == (Just expectedPath)
+    let expectedPath = "/" <> config.mount.name <> "/" <> config.database.name <> "/" <> SDCfg.newFolderName <> "/"
+    let actualPath = searchPath search
+    if actualPath == (Just expectedPath)
       then successMsg "ok, hash correct"
-      else errorMsg "hash incorrect in created folder"
+      else errorMsg $
+        "hash incorrect in created folder; expected '"
+         <> expectedPath
+         <> "', but got '"
+         <> show actualPath
+         <> "'."
   checkHash _ = errorMsg "incorrect hash"
 
 
@@ -581,7 +630,7 @@ title = do
   windowTitle <- lift $ getTitle driver
   if Str.contains config.version windowTitle
     then successMsg "Title contains version"
-    else errorMsg "Title doesn't contain version"
+    else errorMsg $ "Title (" ++ windowTitle ++ ") doesn't contain version"
 
 test :: Config -> A.Aff _ Unit
 test config =
@@ -593,6 +642,7 @@ test config =
     driver <- build $ browser br
     res <- A.attempt $ flip runReaderT {config: config, driver: driver} do
       home
+      mountDatabase
       checkMountedDatabase
       checkConfigureMount
       checkItemToolbar

--- a/test/src/Test/Selenium/Common.purs
+++ b/test/src/Test/Selenium/Common.purs
@@ -5,6 +5,12 @@ module Test.Selenium.Common
   , dropHash
   , loaded
   , modalShown
+  , awaitUrlChanged
+
+  , sendSelectAll
+  , sendCopy
+  , sendPaste
+  , sendUndo
   )
   where
 
@@ -20,6 +26,8 @@ import Driver.File.Routing (Routes(..), routing)
 import Routing (matchHash)
 
 import Selenium
+import Selenium.ActionSequence
+import Selenium.Key
 import Selenium.Types
 
 import Test.Selenium.Log
@@ -80,4 +88,35 @@ modalShown = do
   if vis
     then pure true
     else later 1000 modalShown
+
+awaitUrlChanged :: String -> Check Unit
+awaitUrlChanged oldUrl = do
+  url <- getURL
+  if url == oldUrl
+    then later 1000 $ awaitUrlChanged oldUrl
+    else pure unit
+
+sendSelectAll :: Sequence Unit
+sendSelectAll = do
+  keyDown commandKey
+  sendKeys "a"
+  keyUp commandKey
+
+sendCopy :: Sequence Unit
+sendCopy = do
+  keyDown commandKey
+  sendKeys "c"
+  keyUp commandKey
+
+sendPaste :: Sequence Unit
+sendPaste = do
+  keyDown commandKey
+  sendKeys "v"
+  keyUp commandKey
+
+sendUndo :: Sequence Unit
+sendUndo = do
+  keyDown commandKey
+  sendKeys "z"
+  keyUp commandKey
 


### PR DESCRIPTION
After adding a mount, it is now directly added to the file listing.

~~After mounting the database, we should refresh the file listing for the user. In this commit, this is done by reloading the page, but it would be nice to just trigger an ajax request for the data itself and have it
be updated. However, I did not go so far as to do that, since the way to do it seems kind of gnarly: you update the "salt" in the url, which should trigger a new request---but in order to do this, several more pieces of state are needed which are not accessible from within `saveMount`.~~

~~*I wasn't sure how to introduce the state plumbing needed to do the above, so I just went with a full refresh—but if anyone has a suggestion for how to do it, I'd be happy to use it, since it would simplify some problems that are described below.** (/cc @garyb)~~

~~It does not suffice to merely refresh, however, since saving a mount results in the server restarting itself. In addition to awaiting the availability of the server (which can be done with a retrying request to its 'info' endpoint), we very unfortunately have to wait for the server to go down before we check if it is available! Otherwise, we may catch the server just before it goes down, and then attempt to
reload the page after the server has gone down.~~

~~This is nondeterministic, and it is very dissatisfying to me that this level of detail about how the backend works is ending up in the frontend. I have approximated correct behavior by waiting for 1s before checking if the server is available.~~

### Test notes

I have changed the tests to not start with a preconfigured mount, but rather to add a mount using the user interface. This is related to #269. The test that I have added fails without the changes in this pull request.

Updated the SlamEngine version in the tests to 2.1.6. The old version that was in here had a bug where it would not restart itself properly. I am beginning to test creating new mounts, which requires that to work correctly.

The configuration file may be overwritten in the course of the tests (e.g. as soon as we test adding a new mount), so I have changed the test script to backup and restore the slamengine config.

Resolves #376 