### PR TITLE
[tests] Fix slamengine-config

### DIFF
--- a/test/slamengine-config.json
+++ b/test/slamengine-config.json
@@ -3,10 +3,5 @@
     "port": 63175
   },
   "mountings": {
-    "/test-mount/": {
-      "mongodb": {
-        "connectionUri": "mongodb://localhost:63174/"
-      }
-    }
   }
 }


### PR DESCRIPTION
Looks like this file got accidentally changed in https://github.com/slamdata/slamdata/commit/81bbbea5ccd1fc5ec889b1382432a63579978e32#commitcomment-12790675

This commit restores the correct contents of this file. We mount the database from inside the tests, so we do not want this to be in the configuration.