### PR TITLE
Add preventDefault to mount dialog (#400)

### DIFF
--- a/src/View/File/Modal/Mount.purs
+++ b/src/View/File/Modal/Mount.purs
@@ -27,7 +27,7 @@ import Utils (select, clearValue)
 import Utils.Halide (selectThis, onPaste)
 import View.Common (glyph, closeButton)
 import View.File.Common (HTML())
-import View.Modal.Common (header, h4, body, footer)
+import View.Modal.Common (header, h4, body, footer, nonSubmit)
 
 import qualified Data.String.Regex as Rx
 import qualified Halogen.HTML as H
@@ -44,7 +44,7 @@ import qualified View.Css as VC
 mountDialog :: forall e. M.MountDialogRec -> Array (HTML e)
 mountDialog state =
   [ header $ h4 "Mount"
-  , body [ H.form [ A.class_ VC.dialogMount ]
+  , body [ H.form [ A.class_ VC.dialogMount, nonSubmit ]
                   $ (if state.new then [fldName state] else [])
                  ++ [ fldConnectionURI state
                     , selScheme state


### PR DESCRIPTION
This is meant to resolve #400, but sadly I cannot reproduce the intermittent issue that prompted this change anymore. If indeed it is the case that the button was causing the page to refresh (by virtue of
being inside a `<form>`), then this should solve the problem. But it is not really clear to me that this is what was going on, since I don't know why it would be non-deterministic.

In any case, the change is probably harmless.

@garyb Would you mind reviewing and merging? (I suppose you already reviewed it in the `wip` version.) Thanks!