### PR TITLE
Fix several bugs in the tests; upgrade purescript-webdriver

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -46,7 +46,7 @@
     "purescript-affjax": "^0.5.4",
     "purescript-uri": "~0.1.0-rc.1",
     "purescript-nonempty-arrays": "~0.3.0",
-    "purescript-webdriver": "^0.2.1",
+    "purescript-webdriver": "^0.2.2",
     "purescript-halogen-bootstrap": "^0.3.0"
   },
   "resolutions": {

--- a/test/src/Test/Selenium/File.purs
+++ b/test/src/Test/Selenium/File.purs
@@ -153,7 +153,7 @@ unmountDatabase = do
 
   actions $ leftClick mountItem
   itemGetDeleteIcon mountItem >>= itemClickToolbarIcon mountItem
-  waitCheck (later 3000 $ pure false) 5000
+  _ <- later 3000 $ pure unit
   findItem config.mount.name
     >>= maybe (pure unit) (const $ errorMsg "did not unmount")
   successMsg "successfully unmounted"
@@ -495,7 +495,7 @@ moveDelete = do
     getElementByCss config.move.submit "no submit button"
       >>= actions <<< leftClick
 
-    waitCheck (later 3000 $ pure false) 5000
+    _ <- later 3000 $ pure unit
     renamedItem <- findItem config.move.other >>= maybe (errorMsg "not renamed") pure
     successMsg "successfully renamed"
     pure renamedItem
@@ -522,7 +522,7 @@ moveDelete = do
   checkDelete item = do
     config <- getConfig
     itemGetDeleteIcon item >>= itemClickToolbarIcon item
-    waitCheck (later 3000 $ pure false) 5000
+    _ <- later 3000 $ pure unit
     findItem config.move.other
       >>= maybe (pure unit) (const $ errorMsg "not deleted")
     successMsg "successfully deleted"
@@ -608,7 +608,7 @@ createFolder = do
 
   newFolderButton <- getNewFolderButton
   actions $ leftClick newFolderButton
-  waitCheck (later 1000 $ pure true) config.selenium.waitTime
+  _ <- later 1000 $ pure unit
 
   folder <- getNewFolder
   actions $ doubleClick leftButton folder

--- a/test/src/Test/Selenium/Monad.purs
+++ b/test/src/Test/Selenium/Monad.purs
@@ -131,7 +131,7 @@ checker check = do
   res <- check
   if res
     then pure true
-    else later 1000 check
+    else later 1000 $ checker check
 
 stop :: Check Unit
 stop = waitCheck (later top $ pure false) top


### PR DESCRIPTION
Upgrade `purescript-webdriver` to version with corrected binding to `wait`.

There was a subtle bug in `Test.Selenium.Monad.checker` that caused it to only loop once, where it was intended to loop forever.

Finally, there were a lot of instances of `waitCheck (later 1000 $ pure false)...`, which appears to have been intended to introduce a delay. (I think that this must have started somewhere, and I cargo culted it elsewhere without understanding it.) This actually worked by coincidence with the old broken version of `wait`, but it fails properly now.

I have replaced these with simple calls to `later`, but we should investigate replacing all of these with proper `waitCheck` conditions that depend on some real aspect of the page. Otherwise, this stuff is just non-deterministic and we are merely reducing the frequency of spurious test failure rather than fixing it.

@garyb 