### PR TITLE
[tests] Test mounting a database with a bad port

### DIFF
--- a/test/config.json
+++ b/test/config.json
@@ -73,7 +73,9 @@
         "nameField": ".modal.fade.in .mount-name input",
         "uriField": ".modal.fade.in .mount-uri input",
         "usernameField": ".modal.fade.in .mount-userinfo input:first-of-type",
-        "saveButton": ".modal.fade.in button.btn.btn-primary"
+        "saveButton": ".modal.fade.in button.btn.btn-primary",
+        "cancelButton": ".modal.fade.in button.btn:first-of-type",
+        "warningBox": ".modal.fade.in .alert-danger"
     },
     "modal": ".modal.fade.in",
     "toolbar": {
@@ -108,5 +110,5 @@
         "new cell search": ".new-cell-menu button[title='Search']",
         "logo versioned": ".nav-logo a[title^=Version]"
     },
-    "version": "2.1.6"
+    "version": "2.1.7"
 }

--- a/test/src/Test/Config.purs
+++ b/test/src/Test/Config.purs
@@ -45,6 +45,8 @@ type Config =
                       , uriField :: String
                       , usernameField :: String
                       , saveButton :: String
+                      , cancelButton :: String
+                      , warningBox :: String
                       }
   , modal :: String
   , toolbar :: { main :: String

--- a/test/src/Test/Selenium.purs
+++ b/test/src/Test/Selenium.purs
@@ -27,7 +27,7 @@ foreign import makePublic :: forall a eff. String -> a -> Eff (module :: MODULE 
 
 main = do
   makePublic "test" test
-  
+
 test :: Config -> Aff _ Unit
 test config =
   maybe error go $ str2browser config.selenium.browser
@@ -43,4 +43,4 @@ test config =
     either throwError (const $ pure unit) res
 
 
-  
+

--- a/test/src/Test/Selenium/Common.purs
+++ b/test/src/Test/Selenium/Common.purs
@@ -6,6 +6,7 @@ module Test.Selenium.Common
   , fileComponentLoaded
   , notebookLoaded
   , modalShown
+  , modalDismissed
   , awaitUrlChanged
 
   , sendSelectAll
@@ -99,6 +100,14 @@ modalShown = do
     css config.modal
       >>= element
       >>= maybe (pure false) visible
+
+modalDismissed :: Check Boolean
+modalDismissed = do
+  config <- getConfig
+  checker $
+    css config.modal
+      >>= element
+      >>= maybe (pure true) (map not <<< visible)
 
 awaitUrlChanged :: String -> Check Boolean
 awaitUrlChanged oldURL = checker $ (oldURL /=) <$> getURL

--- a/test/src/Test/Selenium/File.purs
+++ b/test/src/Test/Selenium/File.purs
@@ -168,20 +168,18 @@ badMountDatabase = do
   badMountConfig
     >>= mountDatabaseWithMountConfig
 
-  waitCheck (checker expectWarningMessage) 8000
+  warningBox <- getElementByCss config.configureMount.warningBox "no warning box"
+
+  -- wait for any old validation messages to disappear
+  waitCheck (checker $ not <$> visible warningBox) config.selenium.waitTime
+  -- wait for the server error to appear
+  waitCheck (checker $ visible warningBox) 8000
 
   cancelButton <- getElementByCss config.configureMount.cancelButton "no cancel button"
   actions $ leftClick cancelButton
   waitCheck modalDismissed config.selenium.waitTime
 
   where
-    expectWarningMessage :: Check Boolean
-    expectWarningMessage = do
-      config <- getConfig
-      getElementByCss config.configureMount.warningBox "no warning box"
-        >>= innerHtml
-        <#> R.test (R.regex "Invalid server and / or port specified" R.noFlags)
-
     badMountConfig :: Check MountConfigR
     badMountConfig = do
       mountConfig <- mountConfigFromConfig

--- a/test/src/Test/Selenium/Notebook.purs
+++ b/test/src/Test/Selenium/Notebook.purs
@@ -16,12 +16,12 @@ import Utils.Log
 -- | We are in notebook after `setUp`. No need to test if notebook created
 -- | it's tested in `Test.Selenium.File`
 setUp :: Check Unit
-setUp = do 
+setUp = do
   home
-  mountDatabase
+  goodMountDatabase
   enterMount
   createNotebookAndThen $ pure unit
-  
+
 test :: Check Unit
 test = do
   setUp


### PR DESCRIPTION
It was necessary to upgrade the SlamEngine jar used in the tests to at least 2.1.7, which changed the mongo timeout to 5s.

In addition, one change in SlamEngine behavior is that it seems to now be required to specify the name of the database in the connection URI (e.g. `mongo://...:12345/testdb`). I've updated the test code accordingly.

The added test tries to mount a database with an incorrect port, and checks that the correct error is presented in the correct way.

This is a continuation of #269, and adds a test that was not possible at the time that ticket was resolved.