### PR TITLE
Support running tests on SauceLabs

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -46,7 +46,7 @@
     "purescript-affjax": "^0.5.4",
     "purescript-uri": "~0.1.0-rc.1",
     "purescript-nonempty-arrays": "~0.3.0",
-    "purescript-webdriver": "^0.2.2",
+    "purescript-webdriver": "^0.2.3",
     "purescript-halogen-bootstrap": "^0.3.0"
   },
   "resolutions": {

--- a/test/config.json
+++ b/test/config.json
@@ -9,6 +9,10 @@
         "browser": "firefox",
         "waitTime": 6000
     },
+    "sauceLabs": {
+        "enabled": false,
+        "platform": "OS X 10.10"
+    },
     "slamdataUrl": "http://localhost:63175",
 
     "slamengine": {

--- a/test/src/Env.js
+++ b/test/src/Env.js
@@ -1,0 +1,13 @@
+// module Test.Env
+
+exports.getEnv = function (key) {
+  return function () {
+    var val = process.env[key];
+    if (typeof val !== "undefined") {
+      return val;
+    }
+
+    throw new Error("Environment variable '" + key + "' not set");
+  };
+};
+

--- a/test/src/Env.purs
+++ b/test/src/Env.purs
@@ -1,0 +1,12 @@
+module Test.Env
+  ( ENV()
+  , getEnv
+  )
+  where
+
+import Control.Monad.Eff (Eff())
+import Control.Monad.Eff.Exception (EXCEPTION())
+
+foreign import data ENV :: !
+foreign import getEnv :: forall eff. String -> Eff (env :: ENV, err :: EXCEPTION | eff) String
+

--- a/test/src/Test/Config.purs
+++ b/test/src/Test/Config.purs
@@ -5,6 +5,9 @@ import Data.StrMap
 type Config =
   { selenium :: { browser :: String
                 , waitTime :: Int}
+  , sauceLabs :: { enabled :: Boolean
+                 , platform :: String
+                 }
   , slamdataUrl :: String
   , mongodb :: { host :: String
                , port :: Int

--- a/test/src/Test/Selenium.purs
+++ b/test/src/Test/Selenium.purs
@@ -2,15 +2,18 @@ module Test.Selenium where
 
 import Prelude
 
+import Control.Monad (when)
 import Control.Monad.Eff (Eff())
 import Control.Monad.Aff (Aff(), attempt)
 import Control.Monad.Aff.Console (log)
 import Control.Monad.Error.Class (throwError)
+import Control.Monad.Eff.Class (liftEff)
 import Control.Monad.Eff.Exception (error)
 import Control.Monad.Reader.Trans
 import Control.Monad.Reader.Class
 import Control.Monad.Trans
-import Data.Maybe (maybe)
+import Data.Foldable (traverse_)
+import Data.Maybe (maybe, isJust)
 import Data.Either (either)
 import Selenium
 import Selenium.Browser
@@ -18,11 +21,11 @@ import Selenium.Builder
 import Test.Config (Config())
 import Text.Chalk
 
+import qualified Test.Selenium.SauceLabs as SL
 import qualified Test.Selenium.File as File
 import qualified Test.Selenium.Notebook as Notebook
 
 foreign import data MODULE :: !
-
 foreign import makePublic :: forall a eff. String -> a -> Eff (module :: MODULE | eff) Unit
 
 main = do
@@ -34,8 +37,13 @@ test config =
   where
   error = void $ log $ red "Incorrect browser"
   go br = do
-    log $ yellow $ config.selenium.browser <> " setted as browser for tests\n\n"
-    driver <- build $ browser br
+    log $ yellow $ config.selenium.browser <> " set as browser for tests\n\n"
+    msauceConfig <- liftEff $ SL.sauceLabsConfigFromConfig config
+    when (isJust msauceConfig) $
+      void $ log $ yellow $ "set up to run on Sauce Labs"
+    driver <- build $ do
+      browser br
+      traverse_ SL.buildSauceLabs msauceConfig
     res <- attempt $ flip runReaderT {config: config, driver: driver} do
       File.test
       Notebook.test

--- a/test/src/Test/Selenium/SauceLabs.js
+++ b/test/src/Test/Selenium/SauceLabs.js
@@ -1,0 +1,10 @@
+// module Test.Selenium.SauceLabs
+
+exports.sauceCapabilities = function (config) {
+  return { username: config.credentials.username
+         , accessKey: config.credentials.accessKey
+         , platform: config.platform
+         , browserName: config.browserName
+         };
+};
+

--- a/test/src/Test/Selenium/SauceLabs.purs
+++ b/test/src/Test/Selenium/SauceLabs.purs
@@ -1,0 +1,58 @@
+module Test.Selenium.SauceLabs
+  ( SauceLabsCredentialsR()
+  , SauceLabsConfigR()
+  , sauceLabsCredentialsFromEnv
+  , sauceLabsConfigFromConfig
+  , buildSauceLabs
+  )
+  where
+
+import Prelude
+import Control.Monad.Eff (Eff())
+import Control.Monad.Eff.Exception (EXCEPTION())
+import Data.Maybe (Maybe(..))
+import Selenium.Builder
+import Selenium.Types
+
+import Test.Config (Config())
+import Test.Env (ENV(), getEnv)
+
+type SauceLabsCredentialsR =
+  { username :: String
+  , accessKey :: String
+  }
+
+type SauceLabsConfigR =
+  { credentials :: SauceLabsCredentialsR
+  , platform :: String
+  , browserName :: String
+  }
+
+sauceLabsCredentialsFromEnv :: forall eff. Eff (env :: ENV, err :: EXCEPTION | eff) SauceLabsCredentialsR
+sauceLabsCredentialsFromEnv = do
+  username <- getEnv "SAUCE_USERNAME"
+  accessKey <- getEnv "SAUCE_ACCESS_KEY"
+  pure { username : username
+       , accessKey : accessKey
+       }
+
+sauceLabsConfigFromConfig :: forall eff. Config -> Eff (env :: ENV, err :: EXCEPTION | eff) (Maybe SauceLabsConfigR)
+sauceLabsConfigFromConfig config =
+  if config.sauceLabs.enabled then do
+    creds <- sauceLabsCredentialsFromEnv
+    pure $ Just
+      { credentials : creds
+      , platform : config.sauceLabs.platform
+      , browserName : config.selenium.browser
+      }
+  else
+    pure Nothing
+
+
+foreign import sauceCapabilities :: SauceLabsConfigR -> Capabilities
+
+buildSauceLabs :: SauceLabsConfigR -> Build Unit
+buildSauceLabs config = do
+  usingServer "http://ondemand.saucelabs.com:80/wd/hub"
+  withCapabilities $ sauceCapabilities config
+


### PR DESCRIPTION
To try this out:

First, make sure the proper environment variables are set for your Sauce Labs credentials:

~~~~bash
export SAUCE_USERNAME=...
export SAUCE_ACCESS_KEY=...
~~~~

Then, make sure that Sauce Connect is running properly on your machine (this will entail opening port 443 on your router). Next, flip the `sauceLabs.enabled` switch in the test configuration file to enable Sauce Labs testing.

*NB*: The tests may fail on Sauce Labs, because they are still non-deterministic in some areas (see my ticket, #398), and execution speed differs on the Sauce Labs setup.

------------------------------

This PR upgrades `purescript-webdriver` to a version that supports setting capabilities.

When we restore the CI, we should revisit this and get it set up to run automatically.