### PR TITLE
[tests] Replace all delays with conditions in File component tests

### DIFF
--- a/test/config.json
+++ b/test/config.json
@@ -7,7 +7,7 @@
     "selenium": {
         "jar": "test/jars/selenium.jar",
         "browser": "firefox",
-        "waitTime": 6000
+        "waitTime": 20000
     },
     "sauceLabs": {
         "enabled": false,

--- a/test/src/Test/Selenium/Monad.purs
+++ b/test/src/Test/Selenium/Monad.purs
@@ -5,6 +5,7 @@ import Control.Monad.Error.Class (throwError)
 import Control.Monad.Eff.Exception (error)
 import Data.Either
 import Data.Maybe
+import Data.Maybe.Unsafe (fromJust)
 import Data.List
 import DOM
 import Test.Config (Config())
@@ -143,6 +144,13 @@ checker check = do
   if res
     then pure true
     else later 1000 $ checker check
+
+-- | This repeats its argument until it returns just; this is only sensible in
+-- | case the output of the passed check over time is monotonic.
+waitUntilJust :: forall a. Check (Maybe a) -> Int -> Check a
+waitUntilJust check time = do
+  waitCheck (checker $ isJust <$> check) time
+  fromJust <$> check
 
 stop :: Check Unit
 stop = waitCheck (later top $ pure false) top


### PR DESCRIPTION
Also increased default selenium wait time from `6s` to `20s` to decrease likelihood of false negatives.

This is a first pass at addressing #398; another pass will be needed that deals with the Notebook tests.

All File-component tests now pass on Sauce Labs except for the ones that deal with uploading files (see https://github.com/slamdata/purescript-webdriver/issues/9).