### PR TITLE
Increase selenium test timeout to 1 minute

### DIFF
--- a/test/config.json
+++ b/test/config.json
@@ -7,7 +7,7 @@
     "selenium": {
         "jar": "test/jars/selenium.jar",
         "browser": "firefox",
-        "waitTime": 20000
+        "waitTime": 60000
     },
     "sauceLabs": {
         "enabled": false,


### PR DESCRIPTION
Things tend to take longer on Sauce Labs; this is to avoid spurious test failures. As of now, the tests all pass on SL :confetti_ball: 