### PR TITLE
Removed resource from uri

### DIFF
--- a/src/Api/Common.purs
+++ b/src/Api/Common.purs
@@ -10,6 +10,8 @@ import Data.Argonaut.Combinators ((~>), (:=))
 import Data.Argonaut.Core (Json(), JAssoc(), jsonEmptyObject)
 import Data.Int (fromNumber, toNumber)
 import Data.Foldable (foldl)
+import Data.Path.Pathy
+import Model.Path (AnyPath())
 import Data.Maybe (Maybe(..))
 import Network.HTTP.Affjax.Request (Requestable)
 import Network.HTTP.Affjax.Response (Respondable)
@@ -34,17 +36,17 @@ type RetryEffects e = (avar :: AVAR, ref :: REF | e)
 slamjax :: forall e a b. (Requestable a, Respondable b) => AffjaxRequest a -> Affjax (RetryEffects e) b
 slamjax = retry defaultRetryPolicy affjax
 
-retryGet :: forall e a. (Respondable a) => URL -> Affjax (RetryEffects e) a
-retryGet u = slamjax $ defaultRequest { url = u }
+retryGet :: forall e a fd. (Respondable a) => Path Abs fd Sandboxed -> Affjax (RetryEffects e) a
+retryGet u = slamjax $ defaultRequest { url = printPath u }
 
-retryDelete :: forall e a. (Respondable a) => URL -> Affjax (RetryEffects e) a
-retryDelete u = slamjax $ defaultRequest { url = u, method = DELETE }
+retryDelete :: forall e a fd. (Respondable a) => Path Abs fd Sandboxed -> Affjax (RetryEffects e) a
+retryDelete u = slamjax $ defaultRequest { url = printPath u, method = DELETE }
 
-retryPost :: forall e a b. (Requestable a, Respondable b) => URL -> a -> Affjax (RetryEffects e) b
-retryPost u c = slamjax $ defaultRequest { method = POST, url = u, content = Just c }
+retryPost :: forall e a b fd. (Requestable a, Respondable b) => Path Abs fd Sandboxed -> a -> Affjax (RetryEffects e) b
+retryPost u c = slamjax $ defaultRequest { method = POST, url = printPath u, content = Just c }
 
-retryPut :: forall e a b. (Requestable a, Respondable b) => URL -> a -> Affjax (RetryEffects e) b
-retryPut u c = slamjax $ defaultRequest { method = PUT, url = u, content = Just c }
+retryPut :: forall e a b fd. (Requestable a, Respondable b) => Path Abs fd Sandboxed-> a -> Affjax (RetryEffects e) b
+retryPut u c = slamjax $ defaultRequest { method = PUT, url = printPath u, content = Just c }
 
 getResponse :: forall a e. String -> Affjax e a -> Aff (ajax :: AJAX | e) a
 getResponse msg affjax = do

--- a/src/Config.purs
+++ b/src/Config.purs
@@ -2,29 +2,9 @@ module Config where
 
 import Prelude ((<>))
 
+
 baseUrl :: String
 baseUrl = ""
-
-serviceBaseUrl :: String
-serviceBaseUrl = "/"
-
-uploadUrl :: String
-uploadUrl = serviceBaseUrl <> "upload"
-
-metadataUrl :: String
-metadataUrl = serviceBaseUrl <> "metadata/fs/"
-
-mountUrl :: String
-mountUrl = serviceBaseUrl <> "mount/fs/"
-
-dataUrl :: String
-dataUrl = serviceBaseUrl <> "data/fs/"
-
-queryUrl :: String
-queryUrl = serviceBaseUrl <> "query/fs/"
-
-serverInfoUrl :: String
-serverInfoUrl = serviceBaseUrl <> "server/info"
 
 browserUrl :: String
 browserUrl = baseUrl <> "index.html"

--- a/src/Config/Paths.purs
+++ b/src/Config/Paths.purs
@@ -1,0 +1,26 @@
+module Config.Paths where
+
+import Config
+import Model.Path
+import Data.Path.Pathy
+
+serviceBaseUrl :: DirPath
+serviceBaseUrl = rootDir
+
+uploadUrl :: FilePath
+uploadUrl = serviceBaseUrl </> file "upload"
+
+metadataUrl :: DirPath
+metadataUrl = serviceBaseUrl </> dir "metadata" </> dir "fs"
+
+mountUrl :: DirPath
+mountUrl = serviceBaseUrl </> dir "mount" </> dir "fs"
+
+dataUrl :: DirPath
+dataUrl = serviceBaseUrl </> dir "data" </> dir "fs"
+
+queryUrl :: DirPath
+queryUrl = serviceBaseUrl </> dir "query" </> dir "fs"
+
+serverInfoUrl :: FilePath 
+serverInfoUrl = serviceBaseUrl </> dir "server" </> file "info"

--- a/src/Entries/Common.purs
+++ b/src/Entries/Common.purs
@@ -5,6 +5,7 @@ import Control.Monad.Eff.Class (liftEff)
 import Control.Monad.Aff (Aff())
 import Control.Monad.Eff (Eff())
 import Data.Foreign.Class (readProp)
+import Data.Path.Pathy (rootDir, dir, file, (</>))
 import Data.Either (either)
 import Data.Maybe (Maybe(..), maybe)
 import DOM (DOM())
@@ -22,5 +23,5 @@ setSlamDataTitle maybeVersion = do
 
 getVersion :: forall eff. Aff (RetryEffects (ajax :: AJAX | eff)) (Maybe String)
 getVersion = do
-  serverInfo <- retryGet Config.serverInfoUrl
+  serverInfo <- retryGet Config.Paths.serverInfoUrl  
   return $ either (const Nothing) Just (readProp "version" serverInfo.response)

--- a/src/Model/Path.purs
+++ b/src/Model/Path.purs
@@ -4,7 +4,7 @@ import Prelude
 import Control.Alt ((<|>))
 import Control.Bind ((=<<))
 import Data.Array ()
-import Data.Maybe (Maybe(..), maybe)
+import Data.Maybe (Maybe(..), maybe, fromMaybe)
 import Utils (encodeURIComponent, decodeURIComponent)
 import Data.Either (Either(..))
 import Data.Path.Pathy
@@ -19,6 +19,9 @@ type AnyPath = Either FilePath DirPath
 infixl 6 <./>
 (<./>) :: forall a s. Path a Dir s -> String -> Path a Dir s
 (<./>) p ext = renameDir (changeDirExt $ const ext) p
+
+rootify :: DirPath -> Path Rel Dir Sandboxed
+rootify p = fromMaybe (dir "/") $ relativeTo p rootDir
 
 -- | Setted by default to support cells without
 -- | `pathToNotebook` field. After first save `pathToNotebook` is

--- a/src/View/File/Modal/DownloadDialog.purs
+++ b/src/View/File/Modal/DownloadDialog.purs
@@ -8,6 +8,7 @@ import Utils (encodeURIComponent)
 import Data.Either (either, isLeft, isRight)
 import Data.Inject1 (inj)
 import Data.Maybe (Maybe(..), isJust, isNothing, maybe, fromMaybe)
+import Data.Path.Pathy (printPath)
 import Input.File (FileInput(..))
 import Model.File (_dialog)
 import Model.File.Dialog.Download
@@ -18,6 +19,7 @@ import View.Common (closeButton, fadeWhen)
 import View.File.Common (HTML())
 import View.Modal.Common (header, body, footer, h4, nonSubmit)
 
+import qualified Config.Paths as Config
 import qualified Halogen.HTML as H
 import qualified Halogen.HTML.Attributes as A
 import qualified Halogen.HTML.Events as E
@@ -146,7 +148,7 @@ downloadDialog state =
   btnDownload :: forall e. HTML e
   btnDownload =
     let headers = encodeURIComponent $ show $ reqHeadersToJSON $ toHeaders state
-        url = Config.dataUrl ++ either (const "#") resourcePath (state ^. _source) ++ "?request-headers=" ++ headers
+        url = printPath Config.dataUrl ++ either (const "#") resourcePath (state ^. _source) ++ "?request-headers=" ++ headers
         disabled = isJust $ state ^. _error
     in H.a [ A.classes $ [B.btn, B.btnPrimary] ++ if disabled then [B.disabled] else []
            , A.disabled disabled


### PR DESCRIPTION
Resource in `POST` is untouched, we use it with relative paths in notebook (i.e. next cell for search or query) 

It should fix #428 