### PR TITLE
Upgrade purescript-markdown-halogen to v0.3.1 (fix #419)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -34,7 +34,7 @@
     "purescript-lens": "~0.8.0",
     "purescript-maps": "~0.4.0",
     "purescript-markdown": "^1.9.0",
-    "purescript-markdown-halogen": "^0.3.0",
+    "purescript-markdown-halogen": "^0.3.1",
     "purescript-minimatch": "~0.2.0",
     "purescript-nonempty": "~0.1.1",
     "purescript-nonempty-arrays": "~0.3.0",


### PR DESCRIPTION
The change to `purescript-markdown-halogen` is that each input field shall have a default value `""` if none is set. This fixes the quirky behavior when trying to edit a date field in Chrome.

Resolves #419 