### PR TITLE
[tests] Fix typos in config.json

### DIFF
--- a/test/config.json
+++ b/test/config.json
@@ -111,7 +111,7 @@
         "notebook name editor": ".notebook-name input#name-editor",
         "notebook content": ".notebook-content",
         "new cell menu": ".new-cell-menu",
-        "new cell plus": ".new-cell-menu button.btn-lg.btn-link[title='Insert new cell'",
+        "new cell plus": ".new-cell-menu button.btn-lg.btn-link[title='Insert new cell']",
         "new cell query": ".new-cell-menu button[title='Query']",
         "new cell markdown": ".new-cell-menu button[title='Markdown']",
         "new cell explore": ".new-cell-menu button[title='Explore']",
@@ -119,7 +119,7 @@
         "logo versioned": ".nav-logo a[title^=Version]"
     },
     "newCellMenu": {
-        "expandCollapse": ".new-cell-menu button.btn-lg.btn-link[title='Insert new cell'",
+        "expandCollapse": ".new-cell-menu button.btn-lg.btn-link[title='Insert new cell']",
         "queryButton": ".new-cell-menu button[title='Query']",
         "mdButton": ".new-cell-menu button[title='Markdown']",
         "exploreButton": ".new-cell-menu button[title='Explore']",


### PR DESCRIPTION
https://slamdata.atlassian.net/browse/SD-912

I suspect that the version of Firefox on Travis must have been more sensitive to syntax errors like this than the one I'm testing with locally (at least, that's the only way I can explain the disparity in behavior.) In any case, this *appears* to resolve SD-912, but it's hard to tell for sure.

There are numerous other problems with the tests that prevent them from running successfully more than once in a row on Travis, but this was one of the big ones, I think.