### PR TITLE
[tests] Resolve slamengine-config path properly

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -100,7 +100,7 @@ rimraf.sync("tmp/test");
 fs.mkdirSync("tmp/test");
 
 // Copy the configuration file for use by slamengine
-copyFile(config.slamengine.config, "tmp/" + config.slamengine.config, function(){});
+copyFile(path.resolve(config.slamengine.config), slamengineConfigPath, function(){});
 
 process.chdir("tmp/test");
 


### PR DESCRIPTION
Resolves [SD-913](https://slamdata.atlassian.net/browse/SD-913)

It is bizarre that this only failed about 30% of the time, but this change appears to fix this problem (I have run the tests on Travis probably more than 30-50 times since this change).