### PR TITLE
Add gulp task to automatically trim trailing whitespace

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,7 +8,8 @@ var gulp = require("gulp"),
     webpack = require("webpack-stream"),
     run = require("gulp-run"),
     rimraf = require("rimraf"),
-    fs = require("fs");
+    fs = require("fs"),
+    trimlines = require("gulp-trimlines");
 
 var slamDataSources = [
   "src/**/*.purs",
@@ -52,6 +53,13 @@ gulp.task("add-headers", function () {
             .pipe(contentFilter(contentFilterParams))
             .pipe(header(licenseHeader))
             .pipe(gulp.dest("./"));
+});
+
+gulp.task("trim-whitespace", function () {
+  var options = { leading: false };
+  return gulp.src(slamDataSources, {base: "./"})
+            .pipe(trimlines(options))
+            .pipe(gulp.dest("."));
 });
 
 var bundleTasks = [];
@@ -149,4 +157,4 @@ mkWatch("watch-notebook-fast", "fast-bundle-notebook", allSources);
 
 gulp.task("watch", ["watch-less", "watch-file", "watch-notebook"]);
 gulp.task("dev", ["watch-less", "watch-file-fast", "watch-notebook-fast"]);
-gulp.task("default", ["add-headers", "less", "bundle"]);
+gulp.task("default", ["add-headers", "trim-whitespace", "less", "bundle"]);

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "gulp-less": "^3.0.3",
     "gulp-purescript": "^0.6.0",
     "gulp-run": "^1.6.10",
+    "gulp-trimlines": "^1.0.0",
     "minimist": "^1.1.2",
     "mongodb": "^2.0.39",
     "rimraf": "^2.4.2",

--- a/src/Api/Fs.purs
+++ b/src/Api/Fs.purs
@@ -84,7 +84,7 @@ listing p = maybe
               $ relativeTo p rootDir
 
 makeFile :: forall e. FilePath -> Maybe MimeType -> String -> Aff (RetryEffects (ajax :: AJAX | e)) Unit
-makeFile path mime content = 
+makeFile path mime content =
   getResponse msg go
   where
   msg :: String
@@ -104,7 +104,7 @@ makeFile path mime content =
     { method = PUT
     , headers = maybe [] (pure <<< ContentType) mime
     , content = Just content
-    , url = fromMaybe "" 
+    , url = fromMaybe ""
             $ (\x -> printPath
                      $ Config.dataUrl
                      </> x)
@@ -171,9 +171,9 @@ saveNotebook notebook = case notebook ^. N._name of
 
   save :: String -> N.Notebook -> Aff (RetryEffects (ajax :: AJAX | e)) Unit
   save name notebook =
-    let notebookPath = Config.dataUrl 
-                       </> rootify (notebook ^. N._path) 
-                       </> dir name <./> Config.notebookExtension 
+    let notebookPath = Config.dataUrl
+                       </> rootify (notebook ^. N._path)
+                       </> dir name <./> Config.notebookExtension
                        </> file "index"
     in getResponse "error while saving notebook" $ retryPut notebookPath notebook
 
@@ -207,7 +207,7 @@ forceDelete resource =
   where
   msg :: String
   msg = "can not delete"
-  
+
   path = (if R.isDatabase resource then Config.mountUrl else Config.dataUrl)
          </> rootify (R.resourceDir resource)
          </> file (R.resourceName resource)

--- a/src/Api/Query.purs
+++ b/src/Api/Query.purs
@@ -96,7 +96,7 @@ port res dest sql vars =
                     $ queryUrl
                     </> rootify (resourceDir res)
                     </> dir (resourceName res)
-                    </> file queryVars 
+                    </> file queryVars
             , content = Just (templated res sql)
             }
 
@@ -156,7 +156,7 @@ mkURI :: Resource -> SQL -> FilePath
 mkURI res sql =
   queryUrl
   </> file ("?q=" <> encodeURIComponent (templated res sql))
- 
+
 mkURI' :: Resource -> SQL -> FilePath
 mkURI' res sql =
   queryUrl

--- a/src/Config/Paths.purs
+++ b/src/Config/Paths.purs
@@ -27,7 +27,7 @@ uploadUrl :: FilePath
 uploadUrl = serviceBaseUrl </> file "upload"
 
 metadataUrl :: DirPath
-metadataUrl = serviceBaseUrl </> dir "metadata" </> dir "fs" 
+metadataUrl = serviceBaseUrl </> dir "metadata" </> dir "fs"
 
 mountUrl :: DirPath
 mountUrl = serviceBaseUrl </> dir "mount" </> dir "fs"
@@ -38,5 +38,5 @@ dataUrl = serviceBaseUrl </> dir "data" </> dir "fs"
 queryUrl :: DirPath
 queryUrl = serviceBaseUrl </> dir "query" </> dir "fs"
 
-serverInfoUrl :: FilePath 
+serverInfoUrl :: FilePath
 serverInfoUrl = serviceBaseUrl </> dir "server" </> file "info"

--- a/src/Control/Timer.purs
+++ b/src/Control/Timer.purs
@@ -24,7 +24,7 @@ foreign import data TIMER :: !
 foreign import data Timeout :: *
 foreign import data Interval :: *
 
-foreign import timeout :: forall a e. Int -> Eff (timer :: TIMER|e) a -> Eff (timer ::TIMER|e) Timeout 
+foreign import timeout :: forall a e. Int -> Eff (timer :: TIMER|e) a -> Eff (timer ::TIMER|e) Timeout
 foreign import clearTimeout :: forall e. Timeout -> Eff (timer :: TIMER|e) Unit
 foreign import interval :: forall a e. Int -> Eff (timer :: TIMER|e) a -> Eff (timer :: TIMER|e) Interval
 foreign import clearInterval :: forall e. Interval -> Eff (timer :: TIMER|e) Unit

--- a/src/Controller/File.purs
+++ b/src/Controller/File.purs
@@ -107,7 +107,7 @@ handleFileListChanged el state = do
               `andThen` \_ -> toInput (ItemRemove fileItem)
           Right _ ->
             liftEff (setLocation $ itemURL (state ^. _sort) (state ^. _salt) Edit fileItem) *> empty
-      
+
 
 
 handleUploadFile :: forall e. HTMLElement -> Event e

--- a/src/Controller/File/Dialog/Download.purs
+++ b/src/Controller/File/Dialog/Download.purs
@@ -32,7 +32,7 @@ import Model.File.Dialog (_DownloadDialog)
 import Model.File.Dialog.Download
 import Model.Path (parseAnyPath)
 import Model.Resource (Resource(..), getPath, resourceName)
-import Optic.Core 
+import Optic.Core
 import Optic.Refractor.Prism (_Just)
 import Utils (newTab)
 
@@ -82,4 +82,4 @@ validate rec
 checkExists :: Resource -> Array Resource -> Boolean
 checkExists r rs =
   let path = getPath r
-  in isJust $ findIndex (\r' -> getPath r' == path) rs 
+  in isJust $ findIndex (\r' -> getPath r' == path) rs

--- a/src/Controller/File/Item.purs
+++ b/src/Controller/File/Item.purs
@@ -54,7 +54,7 @@ handleDeleteItem :: forall e. Item -> Event e
 handleDeleteItem (PhantomItem _) = empty
 handleDeleteItem item = do
   mbTrashFolder <- liftAff $ delete (itemResource item)
-  (toInput $ ItemRemove item) <> 
+  (toInput $ ItemRemove item) <>
   (maybe empty (toInput <<< ItemAdd <<< Item) mbTrashFolder)
 
 handleMoveItem :: forall e. Item -> Event e

--- a/src/Controller/File/Search.purs
+++ b/src/Controller/File/Search.purs
@@ -31,7 +31,7 @@ import Input.File (FileInput(..))
 import Model.File (State(), _sort, _path, _search)
 import Model.File.Salt (newSalt)
 import Model.File.Search (_loading, _value, _timeout, _valid)
-import Optic.Core 
+import Optic.Core
 import Text.SlamSearch (mkQuery)
 import Utils (setLocation)
 

--- a/src/Controller/Notebook/Cell/FileInput.purs
+++ b/src/Controller/Notebook/Cell/FileInput.purs
@@ -32,7 +32,7 @@ import Model.Notebook.Cell (Cell(), _FileInput, _content, _cellId, _input, _outp
 import Model.Notebook.Cell.FileInput (FileInput(), _files, _showFiles, _file, fileFromString, portFromFile)
 import Model.Notebook.Port (Port(..))
 import Model.Resource (Resource())
-import Optic.Core 
+import Optic.Core
 import Optic.Extended (TraversalP(), (^?))
 
 toggleFileList :: forall e. Cell -> I e

--- a/src/Controller/Notebook/Cell/JTableContent.purs
+++ b/src/Controller/Notebook/Cell/JTableContent.purs
@@ -51,7 +51,7 @@ import Input.Notebook (Input(..), CellResultContent(..))
 import Model.Notebook.Cell
 import Model.Notebook.Port (VarMapValue(), _VarMap, Port(..))
 import Model.Resource (Resource(), mkFile, isTempFile, _path)
-import Optic.Core 
+import Optic.Core
 import Optic.Extended (TraversalP(), (^?))
 import Utils (s2i)
 

--- a/src/Controller/Notebook/Cell/Search.purs
+++ b/src/Controller/Notebook/Cell/Search.purs
@@ -28,7 +28,7 @@ import Control.Monad.Eff.Class (liftEff)
 import Control.Monad.Eff.Exception (message)
 import Control.Monad.Aff (attempt)
 import Control.Monad.Aff.Class (liftAff)
-import Optic.Core 
+import Optic.Core
 import Optic.Fold ((^?))
 
 import Data.Maybe (fromMaybe, maybe, Maybe(..))
@@ -114,4 +114,4 @@ viewSearch cell =
   error =
     update cell (_failures .~ ["Incorrect type of input"])
       `andThen` \_ -> finish cell
-  
+

--- a/src/Controller/Notebook/Cell/Viz.purs
+++ b/src/Controller/Notebook/Cell/Viz.purs
@@ -16,7 +16,7 @@ limitations under the License.
 
 module Controller.Notebook.Cell.Viz where
 
-import Prelude 
+import Prelude
 import Api.Query (count, all, sample)
 import Control.Apply ((*>))
 import Control.Monad.Aff.Class (liftAff)
@@ -37,11 +37,11 @@ import Halogen.HTML.Events.Monad (andThen)
 import Input.Notebook (Input(..))
 import Model.Notebook (State(), _notebook)
 import Model.Notebook.Cell (Cell(), _content, _Visualize, _cellId, CellId(), _runState, _input, _hasRun, newVisualizeContent, RunState(..))
-import Model.Notebook.Cell.Viz 
+import Model.Notebook.Cell.Viz
 import Model.Notebook.Domain hiding (_path, _name)
 import Model.Notebook.Port (_PortResource)
 import Model.Resource -- (Resource())
-import Optic.Core 
+import Optic.Core
 import Optic.Fold ((^?))
 import Optic.Extended (TraversalP())
 import Data.Argonaut.JCursor (JCursor())
@@ -73,7 +73,7 @@ setChartHeight cell height =
     Just h ->
       (update cell (_content.._Visualize.._chartHeight .~ h)) <>
       (pure $ ResizeECharts (show $ cell ^. _cellId))
-      
+
 s2i' :: String -> Maybe Int
 s2i' s = if s == "" then pure 0 else s2i s
 
@@ -100,7 +100,7 @@ insertViz :: forall e. State -> Cell -> I e
 insertViz state parent =
   case insertCell parent newVisualizeContent (state ^. _notebook) of
     Tuple note cell ->
-      (pure $ WithState (_notebook .~ note)) 
+      (pure $ WithState (_notebook .~ note))
       `andThen` \_ ->
       (updateInserted cell)
       `andThen` \_ ->
@@ -123,7 +123,7 @@ updateViz cell r =
 
 updateInserted :: forall e. Cell -> I e
 updateInserted cell =
-  maybe errorInPort (updateData cell) $ cell ^? _input .. _PortResource   
+  maybe errorInPort (updateData cell) $ cell ^? _input .. _PortResource
   where
   error :: String -> I e
   error msg = update cell (_content.._Visualize.._error .~ msg)
@@ -155,8 +155,8 @@ updateData cell file = do
          (updateOpts (cell # _content .. _Visualize .~ vRec'))
   where
   errored :: String -> I e
-  errored msg = update cell (_content.. _Visualize .. _error .~ msg) 
-  
+  errored msg = update cell (_content.. _Visualize .. _error .~ msg)
+
   errorEmptyInput :: I e
   errorEmptyInput = errored "Empty input"
 
@@ -166,7 +166,7 @@ configure r =
       cats = fst <$> (filter (snd >>> Me.isCatAxis) tpls)
       vals = fst <$> (filter (snd >>> Me.isValAxis) tpls)
       times = fst <$> (filter (snd >>> Me.isTimeAxis) tpls)
-      
+
       pie = (r ^._pieConfiguration) #
             (_cats %~ autoSelect) ..
             (_firstMeasures %~ autoSelect) ..
@@ -175,7 +175,7 @@ configure r =
             (_secondSeries.._variants .~ ((cats <-> p.cats <-> p.firstSeries) `onlyIfSelected` p.firstSeries)) ..
             (_firstMeasures.._variants .~ (depends p.cats vals))
 
-             
+
 
       bar = (r ^._barConfiguration) #
             (_cats %~ autoSelect) ..
@@ -203,8 +203,8 @@ configure r =
                             then L.Nil
                             else L.singleton Line
       error = if L.null available then "No available chart types, please, rerun cell" else ""
-      
-      
+
+
 
   in r # _pieConfiguration .~ pie
        # _barConfiguration .~ bar
@@ -227,10 +227,10 @@ updateOpts cell =
   where
   go r = do
     let opts = case r ^._chartType of
-          Pie -> mkPie r (r ^. _pieConfiguration) 
+          Pie -> mkPie r (r ^. _pieConfiguration)
           Line -> mkLine r (r ^. _lineConfiguration)
           Bar -> mkBar r (r ^. _barConfiguration)
-    if L.null $ keys (r ^._all) 
+    if L.null $ keys (r ^._all)
       then empty :: I e
       else
       (update cell (_content.._Visualize.._output .~ opts)) `andThen` \_ ->

--- a/src/Controller/Notebook/Cell/Viz/Bar.purs
+++ b/src/Controller/Notebook/Cell/Viz/Bar.purs
@@ -29,7 +29,7 @@ import ECharts.Chart
 import ECharts.Common
 import ECharts.Coords
 import ECharts.Formatter
-import ECharts.Grid 
+import ECharts.Grid
 import ECharts.Item.Data
 import ECharts.Item.Value
 import ECharts.Legend
@@ -70,7 +70,7 @@ extractData r conf =
 
   vals :: Array (Maybe Number)
   vals =
-    (>>= Me.valFromSemanthic) <$> 
+    (>>= Me.valFromSemanthic) <$>
     (maybe [ ] Me.runAxis ((conf ^._firstMeasures.._selection) >>= (flip lookup (r ^._all))))
 
   maxLen :: Int
@@ -79,7 +79,7 @@ extractData r conf =
   nothings :: forall a. Array (Maybe a)
   nothings = replicate maxLen Nothing
 
-  
+
   sers1 :: Array (Maybe String)
   sers1 =
     (>>= Me.catFromSemanthic) <$>
@@ -111,7 +111,7 @@ alter' :: Number -> Maybe (Array Number) -> Maybe (Array Number)
 alter' v vals =
   Just (v:(fromMaybe [] vals ))
 
-aggregate :: Accum -> _ -> AggregatedAccum 
+aggregate :: Accum -> _ -> AggregatedAccum
 aggregate acc conf =
   agg <$> acc
   where agg = runAggregation (conf ^._firstAggregation)
@@ -142,8 +142,8 @@ mkSeries acc =
 
   named :: Array (Tuple Key Number) -> String -> Map String Number
   named lst cat =
-    (fromList <<< L.toList) $ 
-    ((\x -> lmap keyName x) <$> 
+    (fromList <<< L.toList) $
+    ((\x -> lmap keyName x) <$>
      (filter (\(Tuple k _) -> keyCategory k == cat) lst))
 
   named' :: Array (Tuple Key Number) -> Array (Map String Number)
@@ -177,10 +177,10 @@ mkSeries acc =
     Just $ (n:(fromMaybe [] ns))
 
   group :: Map String (Array Number)
-  group = nameMap $ L.fromList $ toList acc 
+  group = nameMap $ L.fromList $ toList acc
 
   serie :: Tuple String (Array Number) -> Series
-  serie (Tuple name nums) = 
+  serie (Tuple name nums) =
   BarSeries { common: universalSeriesDefault { name = if name == ""
                                                       then Nothing
                                                       else Just name
@@ -196,7 +196,7 @@ mkSeries acc =
       [x, _, _] -> x
       _ -> ""
 
-    
+
   series :: Array Series
   series =
     serie <$> (L.fromList $ toList group)
@@ -210,8 +210,8 @@ mkBar r conf =
                            , yAxis = Just yAxis
                            , tooltip = Just $ Tooltip $
                                        tooltipDefault {trigger = Just TriggerAxis}
-                           , legend = Just $ mkLegend series 
-                           } 
+                           , legend = Just $ mkLegend series
+                           }
 
   where
   mkLegend :: Array Series -> Legend
@@ -224,12 +224,12 @@ mkBar r conf =
   extractName :: Series -> Maybe String
   extractName (BarSeries r) = r.common.name
   extractName _ = Nothing
-    
+
   tpls :: Tuple Axises (Array Series)
   tpls = mkSeries extracted
 
   extracted :: AggregatedAccum
-  extracted = extractClean r conf 
-    
+  extracted = extractClean r conf
+
   yAxis :: Axises
   yAxis = OneAxis $ Axis axisDefault { "type" = Just ValueAxis }

--- a/src/Controller/Notebook/Cell/Viz/Key.purs
+++ b/src/Controller/Notebook/Cell/Viz/Key.purs
@@ -31,7 +31,7 @@ keyMbSeries1 :: Key -> Maybe String
 keyMbSeries1 (Tuple _ mbT) = mbT >>= (pure <<< fst)
 
 keyMbSeries2 :: Key -> Maybe String
-keyMbSeries2 (Tuple _ mbT) = mbT >>= snd 
+keyMbSeries2 (Tuple _ mbT) = mbT >>= snd
 
 mkKey :: String -> Maybe String -> Maybe String -> Key
 mkKey cat f s =

--- a/src/Controller/Notebook/Cell/Viz/Line.purs
+++ b/src/Controller/Notebook/Cell/Viz/Line.purs
@@ -29,7 +29,7 @@ import ECharts.Chart
 import ECharts.Common
 import ECharts.Coords
 import ECharts.Formatter
-import ECharts.Grid 
+import ECharts.Grid
 import ECharts.Item.Data
 import ECharts.Item.Value
 import ECharts.Legend
@@ -68,7 +68,7 @@ extractData r conf =
 
   vals1 :: Array (Maybe Number)
   vals1 =
-    (>>= Me.valFromSemanthic) <$> 
+    (>>= Me.valFromSemanthic) <$>
     (maybe [ ] Me.runAxis ((conf ^._firstMeasures.._selection) >>= (flip lookup (r ^._all))))
 
   vals2 :: Array (Maybe Number)
@@ -82,7 +82,7 @@ extractData r conf =
 
   nothings :: forall a. Array (Maybe a)
   nothings = replicate maxLen Nothing
-  
+
   sers1 :: Array (Maybe String)
   sers1 =
     (>>= Me.catFromSemanthic) <$>
@@ -92,13 +92,13 @@ extractData r conf =
   sers2 =
     (>>= Me.catFromSemanthic) <$>
     (maybe nothings Me.runAxis ((conf ^._secondSeries.._selection) >>= (flip lookup (r ^._all))))
-  
+
 extractData' :: Array (Maybe String) -> Array (Maybe String) -> Array (Maybe String) ->
                 Array (Maybe Number) -> Array (Maybe Number) -> Accum -> Accum
 extractData' mbds mbss1 mbss2 mbvs1 mbvs2 acc = fromMaybe acc do
-  d <- head mbds >>= id 
-  ds <- tail mbds 
-  mbs1 <- head mbss1 
+  d <- head mbds >>= id
+  ds <- tail mbds
+  mbs1 <- head mbss1
   sers1 <- tail mbss1
   mbs2 <- head mbss2
   sers2 <- tail mbss2
@@ -148,16 +148,16 @@ mkSeries needTwoAxis ty acc =
   series =
     case group of
       Tuple firsts seconds ->
-        L.fromList $ 
+        L.fromList $
         (firstSerie <$> toList firsts) <>
         (if needTwoAxis
          then secondSerie <$> toList seconds
          else L.Nil)
-  
+
   catVals :: Array String
   catVals = nub $ keyCategory <$> ks
 
-  xAxis = OneAxis $ Axis 
+  xAxis = OneAxis $ Axis
           axisDefault { "type" = Just ty
                       , "data" = Just $ CommonAxisData <$> catVals
                       }
@@ -194,8 +194,8 @@ mkSeries needTwoAxis ty acc =
 
   named :: Array (Tuple Key Number) -> String -> Map String Number
   named lst cat =
-    (fromList <<< L.toList) $ 
-    ((\x -> lmap keyName x) <$> 
+    (fromList <<< L.toList) $
+    ((\x -> lmap keyName x) <$>
      (filter (\(Tuple k _) -> keyCategory k == cat) lst))
 
   named' :: Array (Tuple Key Number) -> Array (Map String Number)
@@ -215,7 +215,7 @@ mkSeries needTwoAxis ty acc =
               Nothing -> Just 0.0
               a -> a) key m
 
-  named'' :: Array (Map String Number) -> Map String (Array Number) 
+  named'' :: Array (Map String Number) -> Map String (Array Number)
   named'' m =
     reverse <$> (foldl foldFn empty (L.fromList <<< toList <$> m))
 
@@ -241,7 +241,7 @@ mkLine r conf =
                            , yAxis = Just yAxis
                            , tooltip = Just $ Tooltip $
                                        tooltipDefault {trigger = Just TriggerItem}
-                           , legend = Just $ mkLegend series 
+                           , legend = Just $ mkLegend series
                            }
   where
 
@@ -260,7 +260,7 @@ mkLine r conf =
   xAxisType = getXAxisType r conf
 
   extracted :: AggregatedAccum
-  extracted = extractClean r conf 
+  extracted = extractClean r conf
 
   tpls :: Tuple Axises (Array Series)
   tpls = mkSeries (needTwoAxises r conf) xAxisType extracted

--- a/src/Controller/Notebook/Cell/Viz/Pie.purs
+++ b/src/Controller/Notebook/Cell/Viz/Pie.purs
@@ -20,7 +20,7 @@ import Prelude
 
 import Controller.Notebook.Common (I())
 import Model.Notebook.Cell (Cell())
-import Model.Notebook.Cell.Viz 
+import Model.Notebook.Cell.Viz
 import Data.Selection
 
 import ECharts.Axis
@@ -28,7 +28,7 @@ import ECharts.Chart
 import ECharts.Common
 import ECharts.Coords
 import ECharts.Formatter
-import ECharts.Grid 
+import ECharts.Grid
 import ECharts.Item.Data
 import ECharts.Item.Value
 import ECharts.Legend
@@ -66,12 +66,12 @@ mkSeries acc =
   where
   rows :: Int -> Int -> Array PieSeriesRec -> Array Series
   rows count ix lst =
-    zipWith (donut count ix $ length lst) (range 0 $ length lst) lst 
+    zipWith (donut count ix $ length lst) (range 0 $ length lst) lst
 
   donut :: Int -> Int -> Int -> Int -> PieSeriesRec -> Series
   donut rowCount rowIx donutCount donutIx r  =
     case mkRadius rowCount rowIx of
-      Tuple maxR center -> 
+      Tuple maxR center ->
         PieSeries {
           common: universalSeriesDefault {
              itemStyle = Just $ ItemStyle {
@@ -99,11 +99,11 @@ mkSeries acc =
         record = {inner: Percent (step * (ix + 1.0))
                  , outer: Percent (step * (ix + 2.0))}
     in Just $ Rs record
-    
+
   mkRadius :: Int -> Int -> Tuple Number (Maybe Center)
   mkRadius count ix =
     let countNum = toNumber count
-        ixNum = toNumber ix 
+        ixNum = toNumber ix
     in if count <= rowLength
        then mkRadius' countNum ixNum
        else mkRadius'' countNum ixNum
@@ -112,8 +112,8 @@ mkSeries acc =
   mkRadius' count ix =
     let r = 85.0 / count
         step = 100.0 / count
-        modulus = maybe 0.0 toNumber $ mod <$> fromNumber ix <*> fromNumber count 
-        x = 55.0 + (modulus + 0.5 - count/2.0) * step 
+        modulus = maybe 0.0 toNumber $ mod <$> fromNumber ix <*> fromNumber count
+        x = 55.0 + (modulus + 0.5 - count/2.0) * step
         y = 50.0
         c = Just $ Tuple (Percent x) (Percent y)
     in Tuple r c
@@ -123,8 +123,8 @@ mkSeries acc =
     let l = toNumber rowLength
         r = 85.0 / l
         step = 100.0 / l
-        modulus = maybe 0.0 toNumber $ mod <$> fromNumber ix <*> fromNumber l 
-        x = 55.0 + (modulus - l/2.0 + 0.5) * step 
+        modulus = maybe 0.0 toNumber $ mod <$> fromNumber ix <*> fromNumber l
+        x = 55.0 + (modulus - l/2.0 + 0.5) * step
         y = 1.2 * floor (ix / l) * r + r
         c = Just $ Tuple (Percent x) (Percent y)
     in Tuple r c
@@ -134,7 +134,7 @@ mkSeries acc =
 
   named :: Array (Tuple Key Number) -> String -> Map String (Tuple String Number)
   named lst cat =
-    (fromList <<< L.toList) $ 
+    (fromList <<< L.toList) $
     ((bimap keyName (Tuple cat)) <$>
      (filter (\(Tuple k _) -> keyCategory k == cat) lst))
 
@@ -166,14 +166,14 @@ mkSeries acc =
   group :: Map String (Array (Tuple String Number))
   group = nameMap $ L.fromList $ toList acc
 
-  dat :: String -> Tuple String Number -> ItemData 
+  dat :: String -> Tuple String Number -> ItemData
   dat str (Tuple s n) = (Dat $ (dataDefault $ Simple n) {name = Just $ s <>
                                                                 (if str == ""
                                                                 then ""
                                                                 else ":" <> str)})
 
   serie :: Tuple String (Array (Tuple String Number)) ->
-           Tuple String PieSeriesRec 
+           Tuple String PieSeriesRec
   serie (Tuple k tpls) =
     Tuple k (pieSeriesDefault { "data" = Just $ (dat k) <$> tpls})
 
@@ -185,13 +185,13 @@ mkSeries acc =
     (snd <$>) <$>
     (groupBy (\a b -> (split ":" (fst a) !! 1) == (split ":" (fst b) !! 1)) series)
 
-  
+
 mkPie :: forall e. VizRec -> _ -> Option
 mkPie r conf =
   Option $ optionDefault { tooltip = Just $ Tooltip $
                                      tooltipDefault {trigger = Just TriggerItem}
                          , series = Just $ Just <$> series
-                         , legend = Just $ mkLegend series 
+                         , legend = Just $ mkLegend series
                          }
   where
   mkLegend :: Array Series -> Legend
@@ -210,8 +210,8 @@ mkPie r conf =
   extractOneDatum :: ItemData -> Maybe String
   extractOneDatum (Dat r) = r.name
   extractOneDatum _ = Nothing
-  
-    
+
+
   series = mkSeries extracted
-  extracted = extractClean r conf 
-  
+  extracted = extractClean r conf
+

--- a/src/Data/KeyCombo.purs
+++ b/src/Data/KeyCombo.purs
@@ -27,7 +27,7 @@ module Data.KeyCombo
   , printKeyComboMac
   ) where
 
-import Prelude 
+import Prelude
 import Data.Array (nub, sort, snoc)
 import Data.Char (fromCharCode)
 import Data.Foldable (foldl)

--- a/src/Data/Selection.purs
+++ b/src/Data/Selection.purs
@@ -32,7 +32,7 @@ newtype Selection a = Selection (SelectionR a)
 
 
 _Selection :: forall a. LensP (Selection a) (SelectionR a)
-_Selection = lens (\(Selection obj) -> obj) (const Selection) 
+_Selection = lens (\(Selection obj) -> obj) (const Selection)
 
 _variants :: forall a. LensP (Selection a) (Array a)
 _variants = _Selection <<< lens _.variants _{variants = _}
@@ -59,8 +59,8 @@ autoSelect :: forall a. (Eq a) => Selection a -> Selection a
 autoSelect initial@(Selection {variants: arr, selection: sel}) =
   if length arr == 1
   then Selection {variants: arr, selection: head arr}
-  else initial 
-  
+  else initial
+
 
 infix 9 <->
 (<->) = except'
@@ -80,4 +80,4 @@ instance decodeJsonSelection :: (DecodeJson a) => DecodeJson (Selection a) where
          (obj .? "selection")
     pure $ Selection r
 
-    
+

--- a/src/Driver/File/Search.purs
+++ b/src/Driver/File/Search.purs
@@ -32,7 +32,7 @@ import qualified Data.String as Str
 import qualified Data.String.Regex as Rgx
 import qualified Data.Minimatch as MM
 import qualified Model.Resource as M
-import Optic.Core 
+import Optic.Core
 
 isSearchQuery :: S.SearchQuery -> Boolean
 isSearchQuery query =
@@ -50,7 +50,7 @@ check p prj =
     S.Contains (S.Text str) -> match $ "*" <> escapeGlob str <> "*"
     S.Gt (S.Text str) -> compare str == GT
     S.Gte (S.Text str) -> compare str == GT || compare str == EQ
-    S.Lt (S.Text str) -> compare str == LT 
+    S.Lt (S.Text str) -> compare str == LT
     S.Lte (S.Text str) -> compare str == LT || compare str == EQ
     S.Ne (S.Text str) -> compare str == LT || compare str == GT
     S.Eq (S.Text str) -> compare str == EQ
@@ -93,7 +93,7 @@ filterByTerm r
   in
   case labels of
     -- no labels -> check by both fields
-    Nil -> check' name 
+    Nil -> check' name
     -- we've already checked _path_ when had got it from backend
     Cons (S.Common "path") Nil -> true
     -- check _name_

--- a/src/Driver/Notebook.purs
+++ b/src/Driver/Notebook.purs
@@ -57,7 +57,7 @@ import Model.Notebook.Menu
 import Model.Notebook.Port
 import Model.Path (decodeURIPath, dropNotebookExt)
 import Model.Resource (Resource(), resourceName, resourceDir)
-import Optic.Core 
+import Optic.Core
 import Routing (matches')
 import Utils (replaceLocation)
 import Data.Map (lookup)
@@ -120,13 +120,13 @@ driver ref k =
             update (_notebook .~ nb)
             if isEdit editable
               then
-              for_ (filter (filterFn (nb ^._dependencies)) 
+              for_ (filter (filterFn (nb ^._dependencies))
                     (nb ^._cells)) \cell -> do
                 update (_requesting <>~ [cell ^._cellId])
                 k $ RequestCellContent cell
-              else 
+              else
               for_ (filter (^._hasRun) (nb ^._cells)) (k <<< ViewCellContent)
-              
+
             for_ (nb ^. _cells) \cell -> do
               case Tuple (cell ^. _content) (cell ^._output) of
                 Tuple (Search _) Closed ->
@@ -182,7 +182,7 @@ notebookAutosave refState refTimer input k = do
             Right nb -> do
               let update = (_notebook %~ replacePendingPorts)
                        <<< (_notebook .. _name .~ (nb ^. _name))
-                           
+
               k $ WithState update
               -- This crime is to update the state so that when NotebookRoute is
               -- triggered in the router, the state will have the saved-name for

--- a/src/Driver/Notebook/Cell.purs
+++ b/src/Driver/Notebook/Cell.purs
@@ -33,10 +33,10 @@ driveEvent :: forall e. Driver Input (NotebookComponentEff e) -> I e -> Eff (Not
 driveEvent = runEvent (const $ return unit)
 
 driveCellContent :: forall eff. Input -> Driver Input (NotebookComponentEff eff) -> Eff (NotebookAppEff eff) Unit
-driveCellContent (RequestCellContent cell) driver = 
+driveCellContent (RequestCellContent cell) driver =
   case cell ^. _content of
     Explore _ -> runWith cell driver
-    Search _ -> runWith cell driver  
+    Search _ -> runWith cell driver
     Visualize _ -> runWith cell driver
     _ -> return unit
 driveCellContent (ReceiveCellContent cell) driver =
@@ -51,7 +51,7 @@ driveCellContent (ViewCellContent cell) driver =
     Explore _ -> view cell driver
     Visualize _ -> view cell driver
     Query _ -> view cell driver
-    _ -> pure unit 
+    _ -> pure unit
 
 driveCellContent _ _ = pure unit
 

--- a/src/Driver/Notebook/ECharts.purs
+++ b/src/Driver/Notebook/ECharts.purs
@@ -50,31 +50,31 @@ type EChartsKey = String
 
 newtype EContainer = EContainer HTMLElement
 
-foreign import containerEq :: EContainer -> EContainer -> Boolean 
+foreign import containerEq :: EContainer -> EContainer -> Boolean
 
 instance eqEContainer :: Eq EContainer where
   eq = containerEq
-  
+
 
 type EChartsRec =
   { chart :: EC.EChart
   , container :: EContainer
-  } 
+  }
 type EChartsKnot = { charts :: M.StrMap EChartsRec
                    , options :: M.StrMap EC.Option
                    , timeouts :: M.StrMap Timeout
                    }
 
-_charts :: forall a b r. Lens { charts :: a | r} { charts :: b | r} a b 
-_charts = lens _.charts _{charts = _} 
+_charts :: forall a b r. Lens { charts :: a | r} { charts :: b | r} a b
+_charts = lens _.charts _{charts = _}
 
-_options :: forall a b r. Lens { options :: a | r} { options :: b |r} a b 
-_options = lens _.options _{options = _} 
+_options :: forall a b r. Lens { options :: a | r} { options :: b |r} a b
+_options = lens _.options _{options = _}
 
-_chart :: forall a b r. Lens { chart :: a | r} { chart :: b |r} a b 
-_chart = lens _.chart _{chart = _} 
+_chart :: forall a b r. Lens { chart :: a | r} { chart :: b |r} a b
+_chart = lens _.chart _{chart = _}
 
-_container :: forall a b r. Lens { container :: a | r} { container :: b |r} a b 
+_container :: forall a b r. Lens { container :: a | r} { container :: b |r} a b
 _container = lens _.container _{container = _}
 
 initKnot :: EChartsKnot
@@ -82,9 +82,9 @@ initKnot =
   { charts: M.empty
   , options: M.empty
   , timeouts: M.empty
-  } 
+  }
 
-ref :: forall e. Eff (ref :: REF | e) (Ref EChartsKnot) 
+ref :: forall e. Eff (ref :: REF | e) (Ref EChartsKnot)
 ref = newRef initKnot
 
 echartsPostRender :: forall e. Ref EChartsKnot -> Input ->
@@ -116,23 +116,23 @@ echartsPostRender knotRef input node driver = do
 init :: forall e. HTMLElement -> String -> Ref EChartsKnot ->
         Eff (NotebookAppEff e) Unit
 init el key knotRef = do
-  knot <- readRef knotRef 
+  knot <- readRef knotRef
   chart <- EC.init Nothing el
   modifyRef knotRef (_charts %~ M.insert key { chart: chart
                                              , container: EContainer el })
   maybe (pure unit) (set chart) $ M.lookup key knot.options
 
-set :: forall e. EC.EChart -> EC.Option -> Eff (NotebookAppEff e) Unit 
+set :: forall e. EC.EChart -> EC.Option -> Eff (NotebookAppEff e) Unit
 set chart opts = void $ do
   EC.setOption opts true chart
   EC.resize chart
-  
+
 
 reinit :: forall e. HTMLElement -> String -> Ref EChartsKnot -> EChartsRec ->
-          Eff (NotebookAppEff e) Unit 
+          Eff (NotebookAppEff e) Unit
 reinit el key knotRef r = do
   knot <- readRef knotRef
-  if r.container == EContainer el 
+  if r.container == EContainer el
     then pure unit
     else do
     chart <- EC.init Nothing el

--- a/src/Entries/Common.purs
+++ b/src/Entries/Common.purs
@@ -39,5 +39,5 @@ setSlamDataTitle maybeVersion = do
 
 getVersion :: forall eff. Aff (RetryEffects (ajax :: AJAX | eff)) (Maybe String)
 getVersion = do
-  serverInfo <- retryGet Config.Paths.serverInfoUrl  
+  serverInfo <- retryGet Config.Paths.serverInfoUrl
   return $ either (const Nothing) Just (readProp "version" serverInfo.response)

--- a/src/Entries/File.purs
+++ b/src/Entries/File.purs
@@ -43,4 +43,4 @@ main = onLoad $ void $ do
     liftEff $ setSlamDataTitle version
     liftEff $ driver $ inj $ WithState (_version .~ version)
   where
-  postRender _ node _ = initZClipboard node 
+  postRender _ node _ = initZClipboard node

--- a/src/Entries/Notebook.purs
+++ b/src/Entries/Notebook.purs
@@ -60,9 +60,9 @@ main = onLoad $ void $ do
   Tuple node driver <- runUIWith app post
   mountUI node
   platformName <- navigator globalWindow >>= platform
-  let p = if isJust $ indexOf "Win" platformName 
+  let p = if isJust $ indexOf "Win" platformName
           then Win
-          else if isJust $ indexOf "Mac" platformName 
+          else if isJust $ indexOf "Mac" platformName
                then Mac
                else Other
   driver $ WithState (_platform .~ p)

--- a/src/Input/File.purs
+++ b/src/Input/File.purs
@@ -28,7 +28,7 @@ import Data.Maybe.Unsafe (fromJust)
 import Input.File.Item (ItemInput(), inputItem)
 import Input.File.Mount (MountInput(), inputMount)
 import Model.File (State(), _items, _dialog, _sort, isSearching)
-import Optic.Core 
+import Optic.Core
 import Optic.Refractor.Prism (_Just)
 
 type Input = Either ItemInput (Either FileInput MountInput)

--- a/src/Input/File/Item.purs
+++ b/src/Input/File/Item.purs
@@ -62,4 +62,4 @@ modify func items ix =
     if ix == i
     then func true item
     else func false item
- 
+

--- a/src/Model/File.purs
+++ b/src/Model/File.purs
@@ -44,7 +44,7 @@ import Model.File.Salt (Salt(..))
 import Model.File.Search (Search(), initialSearch, _value)
 import Model.File.Sort (Sort(..))
 import Model.Path (DirPath())
-import Optic.Core 
+import Optic.Core
 
 -- | Application state
 newtype State = State StateRec

--- a/src/Model/File/Dialog.purs
+++ b/src/Model/File/Dialog.purs
@@ -21,7 +21,7 @@ import Data.Maybe (Maybe(..))
 import Model.File.Dialog.Download (DownloadDialogRec())
 import Model.File.Dialog.Mount (MountDialogRec())
 import Model.File.Dialog.Rename (RenameDialogRec())
-import Optic.Core 
+import Optic.Core
 
 data Dialog
   = RenameDialog RenameDialogRec

--- a/src/Model/File/Dialog/Download.purs
+++ b/src/Model/File/Dialog/Download.purs
@@ -21,7 +21,7 @@ import Data.Either (Either(..))
 import Data.Maybe (Maybe(..))
 import Data.Path.Pathy (rootDir)
 import Model.Resource (Resource(..), resourceName, root)
-import Optic.Core 
+import Optic.Core
 import Optic.Extended (TraversalP())
 import Network.HTTP.MimeType (MimeType(..))
 import Network.HTTP.RequestHeader (RequestHeader(..))

--- a/src/Model/File/Dialog/Rename.purs
+++ b/src/Model/File/Dialog/Rename.purs
@@ -21,7 +21,7 @@ import Data.Maybe (Maybe(..))
 import Data.Path.Pathy (rootDir)
 import Model.Path (DirPath(), dropNotebookExt)
 import Model.Resource (Resource(..), resourceDir, resourceName, root, isNotebook)
-import Optic.Core 
+import Optic.Core
 
 newtype RenameDialogRec = RenameDialogRec
   { showList :: Boolean

--- a/src/Model/File/Item.purs
+++ b/src/Model/File/Item.purs
@@ -19,7 +19,7 @@ module Model.File.Item where
 import Prelude (Ordering())
 import Model.Resource (Resource(..), resourcePath, resourceName, sortResource)
 import Model.File.Sort (Sort())
-import Optic.Core 
+import Optic.Core
 
 data Item
   = Item Resource

--- a/src/Model/File/Search.purs
+++ b/src/Model/File/Search.purs
@@ -30,7 +30,7 @@ import Control.Timer (Timeout())
 import Data.Maybe (Maybe(..))
 import Data.These (These(..))
 
-import Optic.Core 
+import Optic.Core
 
 -- | State of search field
 newtype Search = Search SearchRec

--- a/src/Model/Notebook/Cell.purs
+++ b/src/Model/Notebook/Cell.purs
@@ -30,8 +30,8 @@ import Global (readInt, isNaN)
 import Model.Notebook.Cell.FileInput
 import Model.Notebook.Cell.JTableContent
 import Model.Notebook.Port
-import Model.Resource 
-import Optic.Core 
+import Model.Resource
+import Optic.Core
 import Optic.Extended (TraversalP())
 import Data.Path.Pathy (rootDir, parseAbsDir, sandbox, (</>), printPath, file)
 import Model.Path (DirPath(), phantomNotebookPath)
@@ -80,7 +80,7 @@ newCell cellId content =
        , message: ""
        , hiddenEditor: false
        , runState: RunInitial
-       , embedHovered: false 
+       , embedHovered: false
        , hasRun: false
        , pathToNotebook: rootDir
        }
@@ -142,7 +142,7 @@ instance encodeJsonCell :: EncodeJson Cell where
     ~> "output" := cell.output
     ~> "content" := cell.content
     ~> "hasRun" := cell.hasRun
-    ~> "runState" := cell.runState 
+    ~> "runState" := cell.runState
     ~> jsonEmptyObject
 
 instance decodeJsonCell :: DecodeJson Cell where
@@ -153,7 +153,7 @@ instance decodeJsonCell :: DecodeJson Cell where
     parent <- obj .? "parent"
     input <- obj .? "input"
     output <- obj .? "output"
-    runState <- obj .? "runState" <|> pure RunInitial 
+    runState <- obj .? "runState" <|> pure RunInitial
     let hasRun = either (const false) id (obj .? "hasRun")
     pure (cell # (_parent .~ parent)
               .. (_input  .~ input)

--- a/src/Model/Notebook/Cell/Common.purs
+++ b/src/Model/Notebook/Cell/Common.purs
@@ -16,10 +16,10 @@ limitations under the License.
 
 module Model.Notebook.Cell.Common where
 
-import Optic.Core 
+import Optic.Core
 
-_input :: forall a b r. Lens {input :: a | r} {input :: b | r} a b 
-_input = lens _.input _{input = _} 
+_input :: forall a b r. Lens {input :: a | r} {input :: b | r} a b
+_input = lens _.input _{input = _}
 
-_table :: forall a b r. Lens {table :: a | r} {table :: b | r} a b 
+_table :: forall a b r. Lens {table :: a | r} {table :: b | r} a b
 _table = lens _.table _{table = _}

--- a/src/Model/Notebook/Cell/Explore.purs
+++ b/src/Model/Notebook/Cell/Explore.purs
@@ -28,7 +28,7 @@ import Data.Argonaut.Decode (DecodeJson, decodeJson)
 import Data.Argonaut.Encode (EncodeJson)
 import Model.Notebook.Cell.FileInput (FileInput(), initialFileInput)
 import Model.Notebook.Cell.JTableContent (JTableContent(), initialJTableContent)
-import Optic.Core 
+import Optic.Core
 
 import qualified Model.Notebook.Cell.Common as C
 

--- a/src/Model/Notebook/Cell/FileInput.purs
+++ b/src/Model/Notebook/Cell/FileInput.purs
@@ -34,7 +34,7 @@ import Data.Maybe (Maybe(..))
 import Data.Path.Pathy ((</>), parseAbsFile, sandbox, rootDir)
 import Model.Resource (Resource(), resourcePath, newFile, _path)
 import Model.Notebook.Port (Port(PortInvalid, PortResource))
-import Optic.Core 
+import Optic.Core
 
 newtype FileInput =
   FileInput { showFiles :: Boolean

--- a/src/Model/Notebook/Cell/JTableContent.purs
+++ b/src/Model/Notebook/Cell/JTableContent.purs
@@ -34,7 +34,7 @@ import Data.Argonaut.Encode (EncodeJson)
 import Data.Either (Either(..), either)
 import Data.Maybe (Maybe(..))
 import Data.These (These(..), these)
-import Optic.Core 
+import Optic.Core
 
 -- | The current JTable pagination parameters and loaded JSON values if present.
 newtype JTableContent =
@@ -112,7 +112,7 @@ instance decodeResult :: DecodeJson Result where
          <$> obj .? "totalPages"
          <*> obj .? "values"
     pure $ Result r
-    
+
 
 -- | Lens for the Result newtype.
 _Result :: LensP Result _

--- a/src/Model/Notebook/Cell/Query.purs
+++ b/src/Model/Notebook/Cell/Query.purs
@@ -27,7 +27,7 @@ import Data.Argonaut.Core (jsonEmptyObject)
 import Data.Argonaut.Decode (DecodeJson, decodeJson)
 import Data.Argonaut.Encode (EncodeJson)
 import Model.Notebook.Cell.JTableContent (JTableContent(), initialJTableContent)
-import Optic.Core 
+import Optic.Core
 
 import qualified Model.Notebook.Cell.Common as C
 

--- a/src/Model/Notebook/Cell/Search.purs
+++ b/src/Model/Notebook/Cell/Search.purs
@@ -29,7 +29,7 @@ import Data.Argonaut.Decode (DecodeJson, decodeJson)
 import Data.Argonaut.Encode (EncodeJson)
 import Model.Notebook.Cell.FileInput (FileInput(), initialFileInput)
 import Model.Notebook.Cell.JTableContent (JTableContent(), initialJTableContent)
-import Optic.Core 
+import Optic.Core
 
 import qualified Model.Notebook.Cell.Common as C
 

--- a/src/Model/Notebook/Cell/Viz.purs
+++ b/src/Model/Notebook/Cell/Viz.purs
@@ -26,8 +26,8 @@ import Data.Argonaut.JCursor (JCursor())
 import Data.Map (Map(), empty, keys)
 import Model.Notebook.ECharts (Semanthic(..), Axis(..), dependsOn)
 import Data.Argonaut.JCursor (JCursor())
-import Optic.Core 
-import qualified Data.Set as S 
+import Optic.Core
+import qualified Data.Set as S
 import Data.Argonaut.Core (JArray())
 import Data.Array (findIndex, filter, head, sort, reverse, length)
 import Data.Foldable (foldl)
@@ -58,7 +58,7 @@ instance chartTypeEq :: Eq ChartType where
 instance chartTypeOrd :: Ord ChartType where
   compare Pie Pie = EQ
   compare Line Line = EQ
-  compare Bar Bar = EQ 
+  compare Bar Bar = EQ
   compare Pie _ = LT
   compare _ Pie = GT
   compare Line _ = LT
@@ -71,7 +71,7 @@ instance encodeJsonChartType :: EncodeJson ChartType where
 
 instance decodeJson :: DecodeJson ChartType where
   decodeJson json = maybe (Left "incorrect chart type string") Right do
-    str <- toString json 
+    str <- toString json
     str2chartType str
 
 str2chartType :: String -> Maybe ChartType
@@ -81,7 +81,7 @@ str2chartType str = case str of
   "bar" -> pure Bar
   _ -> Nothing
 
-type JSelection = Selection JCursor 
+type JSelection = Selection JCursor
 
 depends :: JSelection -> Array JCursor -> Array JCursor
 depends sel lst = maybe lst go (sel ^._selection)
@@ -89,9 +89,9 @@ depends sel lst = maybe lst go (sel ^._selection)
   go y = filter (dependsOn y) lst
 
 data Aggregation
-  = Maximum 
-  | Minimum  
-  | Average 
+  = Maximum
+  | Minimum
+  | Average
   | Sum
   | Product
 
@@ -143,7 +143,7 @@ runAggregation Average nums = (foldl (+) zero nums) / (if length nums == 0
 runAggregation Sum nums = foldl (+) zero nums
 runAggregation Product nums = foldl (*) one nums
 
-instance encodeJsonAggregateion :: EncodeJson Aggregation where 
+instance encodeJsonAggregateion :: EncodeJson Aggregation where
   encodeJson = fromString <<< aggregation2str
 
 instance decodeJsonAggregation :: DecodeJson Aggregation where
@@ -155,7 +155,7 @@ instance decodeJsonAggregation :: DecodeJson Aggregation where
       "μ" -> pure Average
       "Σ" -> pure Sum
       "Π" -> pure Product
-      _ -> Nothing 
+      _ -> Nothing
 
 
 newtype PieConfiguration = PieConfiguration
@@ -241,7 +241,7 @@ instance decodeJsonLineConfiguration :: DecodeJson LineConfiguration where
          , secondAggregation: _} <$>
          (obj .? "dims") <*>
          (obj .? "firstMeasures") <*>
-         (obj .? "secondMeasures") <*> 
+         (obj .? "secondMeasures") <*>
          (obj .? "firstSeries") <*>
          (obj .? "secondSeries") <*>
          ((obj .? "firstAggregation") <|> pure Sum) <*>
@@ -257,7 +257,7 @@ newtype BarConfiguration = BarConfiguration
   }
 
 initialBarConfiguration :: BarConfiguration
-initialBarConfiguration = BarConfiguration 
+initialBarConfiguration = BarConfiguration
   { cats: initialSelection
   , firstMeasures: initialSelection
   , firstSeries: initialSelection
@@ -297,30 +297,30 @@ _LineConfiguraion = lens (\(LineConfiguration obj) -> obj) (const LineConfigurat
 
 _PieConfiguration :: LensP PieConfiguration _
 _PieConfiguration = lens (\(PieConfiguration obj) -> obj) (const PieConfiguration)
-  
-_cats :: forall a b r. Lens {cats::a|r} {cats::b|r} a b 
+
+_cats :: forall a b r. Lens {cats::a|r} {cats::b|r} a b
 _cats = lens _.cats _{cats = _}
 
 _dims :: forall a b r. Lens {dims::a|r} {dims::b|r} a b
-_dims = lens _.dims _{dims = _} 
+_dims = lens _.dims _{dims = _}
 
-_firstMeasures :: forall a b r. Lens {firstMeasures :: a |r} {firstMeasures :: b |r} a b 
+_firstMeasures :: forall a b r. Lens {firstMeasures :: a |r} {firstMeasures :: b |r} a b
 _firstMeasures = lens _.firstMeasures _{firstMeasures = _}
 
 _secondMeasures :: forall a b r. Lens {secondMeasures :: a |r} {secondMeasures :: b |r} a b
 _secondMeasures = lens _.secondMeasures _{secondMeasures = _}
 
-_firstSeries :: forall a b r. Lens {firstSeries :: a |r} {firstSeries :: b |r} a b 
-_firstSeries = lens _.firstSeries _{firstSeries = _} 
+_firstSeries :: forall a b r. Lens {firstSeries :: a |r} {firstSeries :: b |r} a b
+_firstSeries = lens _.firstSeries _{firstSeries = _}
 
-_secondSeries :: forall a b r. Lens {secondSeries :: a|r} {secondSeries :: b|r} a b 
+_secondSeries :: forall a b r. Lens {secondSeries :: a|r} {secondSeries :: b|r} a b
 _secondSeries = lens _.secondSeries _{secondSeries = _}
 
---_firstAggregation :: forall a b r. Lens {firstAggregation :: a |r} {firstAggregation :: b | r} a b 
-_firstAggregation = lens _.firstAggregation _{firstAggregation = _} 
+--_firstAggregation :: forall a b r. Lens {firstAggregation :: a |r} {firstAggregation :: b | r} a b
+_firstAggregation = lens _.firstAggregation _{firstAggregation = _}
 
 --_secondAggregation :: forall a b r. Lens {secondAggregation :: a } {secondAggregation :: b | r} a b
-_secondAggregation = lens _.secondAggregation _{secondAggregation = _} 
+_secondAggregation = lens _.secondAggregation _{secondAggregation = _}
 
 
 
@@ -393,22 +393,22 @@ instance decodeJsonVizRec :: DecodeJson VizRec where
          ((obj .? "height") <|> pure 400) <*>
          ((obj .? "width") <|> pure 600)
     pure $ VizRec r
-    
+
 
 
 _VizRec :: LensP VizRec _
 _VizRec = lens (\(VizRec o) -> o) (const VizRec)
 
 _output :: LensP VizRec Option
-_output = _VizRec <<< lens _.output _{output = _} 
+_output = _VizRec <<< lens _.output _{output = _}
 
-_error :: LensP VizRec String 
+_error :: LensP VizRec String
 _error = _VizRec <<< lens _.error _{error = _}
 
 _sample :: LensP VizRec (Map JCursor Axis)
 _sample = _VizRec <<< lens _.sample _{sample = _}
 
-_all :: LensP VizRec (Map JCursor Axis) 
+_all :: LensP VizRec (Map JCursor Axis)
 _all = _VizRec <<< lens _.all _{all = _}
 
 _chartType :: LensP VizRec ChartType
@@ -424,17 +424,17 @@ _availableChartTypes :: LensP VizRec (S.Set ChartType)
 _availableChartTypes = _VizRec <<< lens _.availableChartTypes _{availableChartTypes = _}
 
 
-_pieConfiguration :: LensP VizRec _ 
+_pieConfiguration :: LensP VizRec _
 _pieConfiguration = _VizRec <<<
                     (lens _.pieConfiguration _{pieConfiguration = _} ) <<<
                     _PieConfiguration
 
-_lineConfiguration :: LensP VizRec _ 
+_lineConfiguration :: LensP VizRec _
 _lineConfiguration = _VizRec <<<
                      (lens _.lineConfiguration _{lineConfiguration = _} ) <<<
                      _LineConfiguraion
 
-_barConfiguration :: LensP VizRec _ 
+_barConfiguration :: LensP VizRec _
 _barConfiguration = _VizRec <<<
                     (lens _.barConfiguration _{barConfiguration = _}) <<<
                     _BarConfiguration

--- a/src/Model/Notebook/Domain.purs
+++ b/src/Model/Notebook/Domain.purs
@@ -107,11 +107,11 @@ _activeCell :: TraversalP Notebook Cell
 _activeCell f s = cellById (s ^. _activeCellId) f s
 
 cellById :: CellId -> TraversalP Notebook Cell
-cellById cellId f s = 
+cellById cellId f s =
   case findIndex (\cell -> cell ^. _cellId == cellId) (s ^. _cells) of
     Nothing -> pure s
     Just i -> (_cells .. ix i) f s
-     
+
 
 instance encodeJsonNotebook :: EncodeJson Notebook where
   encodeJson (Notebook obj)
@@ -150,18 +150,18 @@ descendants cid ds = L.fromList (fst <$> (L.filter (\x -> snd x == cid) $ toList
 
 trash :: CellId -> Dependencies -> Dependencies
 trash cid ds =
-  let ds' = delete cid ds 
+  let ds' = delete cid ds
   in case descendants cid ds' of
     [] -> ds'
     xs -> foldl (\d x -> trash x d) ds' xs
 
-    
+
 
 addCell :: CellContent -> Notebook -> Tuple Notebook Cell
 addCell content oldNotebook = insertCell' Nothing content oldNotebook
 
 insertCell :: Cell -> CellContent -> Notebook -> Tuple Notebook Cell
-insertCell parent content oldNotebook = insertCell' (Just parent) content oldNotebook 
+insertCell parent content oldNotebook = insertCell' (Just parent) content oldNotebook
 
 insertCell' :: Maybe Cell -> CellContent -> Notebook -> Tuple Notebook Cell
 insertCell' mbParent content oldNotebook@(Notebook n) = Tuple new cell
@@ -176,7 +176,7 @@ insertCell' mbParent content oldNotebook@(Notebook n) = Tuple new cell
   input = case content of
     Explore _ -> maybe Closed PortResource (content ^? _FileInput .. _file .. _Right)
     _ -> maybe Closed (^. _output) mbParent
-  cell = newCell newId content 
+  cell = newCell newId content
          # (_input .~ input)
          ..(_pathToNotebook .~ (fromMaybe rootDir $ notebookPath oldNotebook))
          ..(_parent .~ ((^. _cellId) <$> mbParent))

--- a/src/Model/Notebook/ECharts.purs
+++ b/src/Model/Notebook/ECharts.purs
@@ -68,7 +68,7 @@ dependsOn a b = a /= b &&
   dependsOn' _ JCursorTop = true
   dependsOn' (JField _ c) (JField _ c') = dependsOn' c c'
   dependsOn' (JIndex _ c) (JIndex _ c') = dependsOn' c c'
-  dependsOn' _ _ = false 
+  dependsOn' _ _ = false
 
 
 data Semanthic
@@ -76,7 +76,7 @@ data Semanthic
   | Percent Number
   | Money Number String
   | Bool Boolean
-  | Category String 
+  | Category String
   | Time String
 
 instance encodeJsonSemanthic :: EncodeJson Semanthic where
@@ -131,7 +131,7 @@ instance decodeJsonSemanthic :: DecodeJson Semanthic where
         pure $ Percent p
       _ -> Left "incorrect type of semanthic"
 
-    
+
 
 data Axis
   = ValAxis (Array (Maybe Semanthic))
@@ -163,7 +163,7 @@ instance decodeJsonAxis :: DecodeJson Axis where
       "time-axis" -> pure $ TimeAxis mbs
       _ -> Left "incorrect axis type"
 
-    
+
 
 isValAxis :: Axis -> Boolean
 isValAxis (ValAxis _) = true
@@ -218,8 +218,8 @@ isComplement (CatAxis _) (CatAxis _) = false
 isComplement (TimeAxis _) (TimeAxis _) = false
 isComplement _ _ = true
 
-catFromSemanthic :: Semanthic -> Maybe String 
-catFromSemanthic v = 
+catFromSemanthic :: Semanthic -> Maybe String
+catFromSemanthic v =
   case v of
     Value v -> pure $ show v
     Percent v -> pure $ show v <> "%"
@@ -252,15 +252,15 @@ checkPredicate p lst =
   then Just lst
   else Nothing
   where isPredicate = Conj <<< (maybe true p)
-        
+
 checkValues :: Array (Maybe Semanthic) -> Maybe (Array (Maybe Semanthic))
 checkValues = checkPredicate isValue
 
 checkMoney :: Array (Maybe Semanthic) -> Maybe (Array (Maybe Semanthic))
-checkMoney = checkPredicate isMoney 
+checkMoney = checkPredicate isMoney
 
 checkPercent :: Array (Maybe Semanthic) -> Maybe (Array (Maybe Semanthic))
-checkPercent = checkPredicate isPercent 
+checkPercent = checkPredicate isPercent
 
 checkBool :: Array (Maybe Semanthic) -> Maybe (Array (Maybe Semanthic))
 checkBool = checkPredicate isBool
@@ -333,7 +333,7 @@ analyzeMoney :: String -> Maybe Semanthic
 analyzeMoney str = do
   ms <- match rgx str
   s <- (ms !! 1)
-  n <- (s >>= s2n) 
+  n <- (s >>= s2n)
   curSymbol <- let fstSymbol = take 1 str
                in if fstSymbol == ""
                   then Nothing
@@ -349,11 +349,11 @@ analyzeDate :: String -> Maybe Semanthic
 analyzeDate str =
   if test rgx str
   then Just $ Time str
-  else Nothing 
+  else Nothing
   where
   rgxStr = "^(-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[0-1]|0[1-9]|[1-2][0-9]) (2[0-3]|[0-1][0-9]):([0-5][0-9]):([0-5][0-9])(\\.[0-9]+)?(Z|[+-](?:2[0-3]|[0-1][0-9]):[0-5][0-9])?$"
-  rgx = regex rgxStr noFlags 
-       
+  rgx = regex rgxStr noFlags
+
 toSemanthic :: Json -> Map JCursor Semanthic
 toSemanthic j = fromList' empty (rmap analyze <$> toPrims j)
   where
@@ -383,10 +383,10 @@ toSemanthic' arr =
 
 analyzeJArray :: JArray -> Map JCursor Axis
 analyzeJArray arr =
-  checkPairs $ 
-  fromList $ 
-  (rmap fromJust) <$> 
-  (L.filter (isJust <<< snd) $ 
+  checkPairs $
+  fromList $
+  (rmap fromJust) <$>
+  (L.filter (isJust <<< snd) $
     (toList (check <$> (toSemanthic' arr))))
 
 
@@ -397,11 +397,11 @@ getPossibleDependencies cursor m =
 
 checkPairs :: Map JCursor Axis -> Map JCursor Axis
 checkPairs m =
-  foldl check m ks 
+  foldl check m ks
   where
   ks = keys m
   check :: Map JCursor Axis -> JCursor -> Map JCursor Axis
-  check m cursor = 
+  check m cursor =
     if length (getPossibleDependencies cursor m) > 0
     then m
     else delete cursor m

--- a/src/Model/Notebook/Menu.purs
+++ b/src/Model/Notebook/Menu.purs
@@ -61,7 +61,7 @@ type MenuElement =
 type DropdownItem =
   { name :: String
   , visible :: Boolean
-  , children :: Array MenuElement 
+  , children :: Array MenuElement
   }
 
 initialDropdowns :: Array DropdownItem

--- a/src/Model/Notebook/Search.purs
+++ b/src/Model/Notebook/Search.purs
@@ -37,17 +37,17 @@ queryToSQL fields query =
   (if needDistinct whereClause then " DISTINCT " else " ") <>
   "* from {{path}} where " <> whereClause
   where
-  whereClause = 
+  whereClause =
     (joinWith " OR " $
-     pars <$> 
+     pars <$>
      joinWith " AND " <$>
-     (fromList <<< (fromList <$>) $ 
+     (fromList <<< (fromList <$>) $
       (runFree $ (termToSQL fields) <$> query)))
 
 
 
 needDistinct :: String -> Boolean
-needDistinct input = isJust $ indexOf "[*]" input 
+needDistinct input = isJust $ indexOf "[*]" input
 
 
 needFields :: SearchQuery -> Boolean
@@ -58,9 +58,9 @@ needFields query =
   needFields' _ (Term {labels: Nil}) = true
   needFields' _ _ = false
 
-termToSQL :: Array String -> Term -> String 
-termToSQL fields (Term {include: include, predicate: p, labels: ls}) = 
-  if not include 
+termToSQL :: Array String -> Term -> String
+termToSQL fields (Term {include: include, predicate: p, labels: ls}) =
+  if not include
   then "NOT " <> (pars $ termToSQL fields $ Term {include: true
                                                  , predicate: p
                                                  , labels: ls})
@@ -68,39 +68,39 @@ termToSQL fields (Term {include: include, predicate: p, labels: ls}) =
 
 
 renderPredicate :: Predicate -> Array String -> String
-renderPredicate p prj = 
+renderPredicate p prj =
   joinWith " OR " (predicateToSQL p <$> prj)
 
 
 
 predicateToSQL :: Predicate -> String -> String
-predicateToSQL (Contains (Range v v')) s = range v v' s 
+predicateToSQL (Contains (Range v v')) s = range v v' s
 predicateToSQL (Contains (Text v)) s =
-  joinWith " OR " $ 
+  joinWith " OR " $
   ["LOWER(" <> s <> ")" <> " LIKE '%" <> v <> "%'"] <>
   (if needUnq v then render' v else [ ] ) <>
   (if not (needDateTime v) && needDate v then render date else [ ]) <>
   (if needTime v then render time  else [] ) <>
   (if needDateTime v then render ts else [] ) <>
-  (if needInterval v then render i else [] )  
-  
+  (if needInterval v then render i else [] )
+
   where
   quoted = quote v
   date = dated quoted
-  time = timed quoted 
+  time = timed quoted
   ts = datetimed quoted
   i = intervaled quoted
   render' v = [ "LOWER(" <> s <> ") = " <> v]
   render v = [s <> " = " <> v ]
 
 
-  
+
 predicateToSQL (Contains (Tag v)) s = predicateToSQL (Contains (Text v)) (s <> "[*]")
 predicateToSQL (Eq v) s = qUnQ s "=" v
 predicateToSQL (Gt v) s = qUnQ s ">" v
-predicateToSQL (Gte v) s = qUnQ s ">=" v 
-predicateToSQL (Lt v) s = qUnQ s "<" v 
-predicateToSQL (Lte v) s = qUnQ s "<=" v 
+predicateToSQL (Gte v) s = qUnQ s ">=" v
+predicateToSQL (Lt v) s = qUnQ s "<" v
+predicateToSQL (Lte v) s = qUnQ s "<=" v
 predicateToSQL (Ne v) s = qUnQ s "<>" v
 predicateToSQL (Like v) s = "LOWER( " <> s <> ")" <> " LIKE " <>  glob2like v
 predicateToSQL _ _ = ""
@@ -108,7 +108,7 @@ predicateToSQL _ _ = ""
 range :: String -> String -> String -> String
 range v v' s =
   joinWith " OR " $
-  [ forR' quoted quoted' ] <> 
+  [ forR' quoted quoted' ] <>
   (if needUnq v && needUnq v' then [ forR v v' ] else [ ]) <>
   (if needDate v && needDate v' then [ forR date date' ] else [ ])
   where
@@ -128,27 +128,27 @@ range v v' s =
 import Utils.Log
 
 qUnQ :: String -> String -> Value -> String
-qUnQ s op v = pars $ 
-  joinWith " OR " $ 
+qUnQ s op v = pars $
+  joinWith " OR " $
   [ forV' quoted ] <>
   (if needUnq unquoted then [ forV unquoted ] else [] ) <>
-  (if not (needDateTime unquoted) && needDate unquoted then [ forV date ] else [] ) <> 
+  (if not (needDateTime unquoted) && needDate unquoted then [ forV date ] else [] ) <>
   (if needTime unquoted then [ forV time ] else [] ) <>
   (if needDateTime unquoted then [ forV ts ] else [] ) <>
   (if needInterval unquoted then [ forV i ] else [] )
   where
-  unquoted = valueToSQL v 
+  unquoted = valueToSQL v
   quoted = quote unquoted
   date = dated quoted
-  time = timed quoted 
-  ts = datetimed quoted 
+  time = timed quoted
+  ts = datetimed quoted
   i = intervaled quoted
 
   forV' v = fold ["LOWER(", s, ") ", op, " ", v]
   forV v = fold [s, " ", op, " ", v]
 
 needUnq :: String -> Boolean
-needUnq s = 
+needUnq s =
      fromMaybe false ((show >>> (== s)) <$> s2i s)
   || fromMaybe false ((show >>> (== s)) <$> s2n s)
   || s == "true"
@@ -157,7 +157,7 @@ needUnq s =
 
 needDate :: String -> Boolean
 needDate = test dateRegex
-  where 
+  where
   dateRegex = regex """^(((19|20)([2468][048]|[13579][26]|0[48])|2000)[-]02[-]29|((19|20)[0-9]{2}[-](0[4678]|1[02])[-](0[1-9]|[12][0-9]|30)|(19|20)[0-9]{2}[-](0[1359]|11)[-](0[1-9]|[12][0-9]|3[01])|(19|20)[0-9]{2}[-]02[-](0[1-9]|1[0-9]|2[0-8])))$""" noFlags
 
 
@@ -165,7 +165,7 @@ needTime :: String -> Boolean
 needTime = test timeRegex
   where
   timeRegex = regex "^([0-1]?[0-9]|2[0-3]):[0-5][0-9](:[0-5][0-9])?$" noFlags
-  
+
 
 needDateTime :: String -> Boolean
 needDateTime = test dtRegex
@@ -181,7 +181,7 @@ needInterval = test intervalRegex
 valueToSQL :: Value -> String
 valueToSQL (Text v) = v
 valueToSQL (Tag v) = v
-valueToSQL (Range v v') = "" 
+valueToSQL (Range v v') = ""
 
 labelsProjection :: Array String -> Array Label -> Array String
 labelsProjection fields [] = replace firstDot "" <$> fields
@@ -194,7 +194,7 @@ labelProjection (Common "*") = ["{*}", "[*]"]
 labelProjection (Common "{*}") = ["{*}"]
 labelProjection (Common "[*]") = ["[*]"]
 labelProjection (Common l) = [".\"" <> l <> "\""]
-labelProjection (Meta l) = labelProjection (Common l) 
+labelProjection (Meta l) = labelProjection (Common l)
 
 glob2like :: String -> String
 glob2like input =

--- a/src/Model/Path.purs
+++ b/src/Model/Path.purs
@@ -57,8 +57,8 @@ changeDirExt f (DirName name) =
   DirName ((if ext == "" then name else n) <> "." <> f ext)
   where
   mbIdx = lastIndexOf "." name
-  n = maybe name (\idx -> take idx name) mbIdx 
-  ext = maybe "" (\idx -> drop (idx + 1) name) mbIdx 
+  n = maybe name (\idx -> take idx name) mbIdx
+  ext = maybe "" (\idx -> drop (idx + 1) name) mbIdx
 
 
 dropDirExt :: DirName -> DirName

--- a/src/Model/Resource.purs
+++ b/src/Model/Resource.purs
@@ -65,7 +65,7 @@ import Data.Path.Pathy
 import Data.Tuple
 import Model.File.Sort (Sort(..))
 import Model.Path
-import Optic.Core 
+import Optic.Core
 import Optic.Refractor.Prism (_Right)
 import Optic.Types
 import Utils

--- a/src/Utils.purs
+++ b/src/Utils.purs
@@ -35,20 +35,20 @@ import qualified Data.String.Regex as Rgx
 import qualified Data.DOM.Simple.Window as W
 
 
-onLoad :: forall e. Eff (dom :: DOM | e) Unit -> Eff (dom :: DOM |e) Unit 
-onLoad action = do 
-  addUIEventListener LoadEvent handler W.globalWindow 
+onLoad :: forall e. Eff (dom :: DOM | e) Unit -> Eff (dom :: DOM |e) Unit
+onLoad action = do
+  addUIEventListener LoadEvent handler W.globalWindow
   where
   handler :: DOMEvent -> _
   handler _ = action
 
 bodyHTMLElement :: forall e. Eff (dom :: DOM | e) HTMLElement
-bodyHTMLElement = W.document W.globalWindow >>= body 
+bodyHTMLElement = W.document W.globalWindow >>= body
 
 mountUI :: forall e. HTMLElement -> Eff (dom :: DOM | e) Unit
 mountUI node = bodyHTMLElement >>= flip appendChild node
 
-locationString :: forall e. Eff (dom :: DOM | e) String 
+locationString :: forall e. Eff (dom :: DOM | e) String
 locationString = W.location W.globalWindow >>= locationParent
 
 setLocation :: forall e. String -> Eff (dom :: DOM | e) Unit
@@ -57,7 +57,7 @@ setLocation url = W.location W.globalWindow >>= W.setLocation url
 setDocumentTitle :: forall e. String -> Eff (dom :: DOM | e) Unit
 setDocumentTitle title = W.document W.globalWindow >>= setTitle title
 
-foreign import newTab :: forall e. String -> Eff (dom :: DOM | e) Unit 
+foreign import newTab :: forall e. String -> Eff (dom :: DOM | e) Unit
 foreign import mailOpen :: forall e. String -> Eff (dom :: DOM | e) Unit
 foreign import reload :: forall e. Eff (dom :: DOM | e) Unit
 foreign import clearValue :: forall e. HTMLElement -> Eff (dom :: DOM | e) Unit
@@ -72,7 +72,7 @@ endsWith needle haystack =
 s2i :: String -> Maybe Int
 s2i s =
   let n = readInt 10 s in
-  if isNaN n 
+  if isNaN n
   then Nothing
   else fromNumber n
 
@@ -83,6 +83,6 @@ s2n s =
   then Nothing
   else Just n
 
-       
+
 foreign import encodeURIComponent :: String -> String
-foreign import decodeURIComponent :: String -> String 
+foreign import decodeURIComponent :: String -> String

--- a/src/Utils/Event.purs
+++ b/src/Utils/Event.purs
@@ -24,7 +24,7 @@ import Data.DOM.Simple.Types (HTMLElement())
 foreign import raiseEventImpl :: forall e a.
                                  Fn2 String HTMLElement
                                  (Eff (dom :: DOM |e) HTMLElement)
-                                 
-                                 
+
+
 raiseEvent :: forall e a. String -> HTMLElement -> Eff (dom :: DOM |e) HTMLElement
-raiseEvent name el = runFn2 raiseEventImpl name el 
+raiseEvent name el = runFn2 raiseEventImpl name el

--- a/src/Utils/File.purs
+++ b/src/Utils/File.purs
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -}
 
-module Utils.File 
+module Utils.File
        ( fileListToArray
        , files
        , newReader
@@ -44,14 +44,14 @@ foreign import data FileList :: *
 foreign import data READ_FILE :: !
 
 foreign import fileListToArray :: FileList -> Array File
-foreign import name :: forall e. File -> Eff (file :: READ_FILE |e) String 
-foreign import newReaderEff :: forall e. Eff e FileReader 
+foreign import name :: forall e. File -> Eff (file :: READ_FILE |e) String
+foreign import newReaderEff :: forall e. Eff e FileReader
 foreign import readAsBinaryStringEff :: forall e. File -> FileReader ->
                                         Eff (file :: READ_FILE |e) Unit
-foreign import resultImpl :: forall e a. Fn3 (Maybe a) (a -> Maybe a) 
+foreign import resultImpl :: forall e a. Fn3 (Maybe a) (a -> Maybe a)
                              FileReader (Eff (file :: READ_FILE |e) (Maybe String))
 foreign import filesEff :: forall e. HTMLElement -> Eff (dom :: DOM |e) FileList
-foreign import onloadEff :: forall e e'. FileReader -> Eff e Unit -> 
+foreign import onloadEff :: forall e e'. FileReader -> Eff e Unit ->
                             Eff (file :: READ_FILE |e') Unit
 
 
@@ -61,11 +61,11 @@ newReader :: forall e. Aff e FileReader
 newReader = makeAff \_ k ->
   newReaderEff >>= \r -> k r
 
-resultEff :: forall e. FileReader -> Eff (file :: READ_FILE |e) (Maybe String) 
+resultEff :: forall e. FileReader -> Eff (file :: READ_FILE |e) (Maybe String)
 resultEff fr = runFn3 resultImpl Nothing Just fr
 
-files :: forall e. HTMLElement -> Aff (dom :: DOM |e) FileList 
-files node = makeAff \_ k -> do 
+files :: forall e. HTMLElement -> Aff (dom :: DOM |e) FileList
+files node = makeAff \_ k -> do
   fs <- filesEff node
   k fs
 
@@ -76,4 +76,4 @@ readAsBinaryString file reader = makeAff \er k -> do
     mbRes <- resultEff reader
     case mbRes of
       Nothing -> er $ error "files has not been read"
-      Just res -> k res 
+      Just res -> k res

--- a/src/Utils/Log.purs
+++ b/src/Utils/Log.purs
@@ -16,7 +16,7 @@ limitations under the License.
 
 module Utils.Log where
 
-import Prelude 
+import Prelude
 
 spyF :: forall a m. (Applicative m) => a -> m Unit
 spyF a = let x = spy a in pure unit

--- a/src/View/Common.purs
+++ b/src/View/Common.purs
@@ -74,7 +74,7 @@ logo mbVersion =
     [ H.img [A.src "img/logo.svg"] [] ]
   ]
   where
-  title = maybe [] (singleton <<< A.title <<< ("Version " <>)) 
+  title = maybe [] (singleton <<< A.title <<< ("Version " <>))
 
 closeButton :: forall i. (ET.Event ET.MouseEvent -> E.EventHandler i) -> H.HTML i
 closeButton handler =

--- a/src/View/File.purs
+++ b/src/View/File.purs
@@ -16,7 +16,7 @@ limitations under the License.
 
 module View.File (fileView) where
 
-import Prelude 
+import Prelude
 import Controller.File.Common (browseURL)
 import Css.Geometry (marginLeft)
 import Css.Size

--- a/src/View/File/Breadcrumb.purs
+++ b/src/View/File/Breadcrumb.purs
@@ -22,7 +22,7 @@ import Data.Maybe (Maybe(..))
 import Model.File
 import Model.File.Breadcrumb (Breadcrumb())
 import View.File.Common (HTML())
-import Optic.Core 
+import Optic.Core
 
 import qualified Halogen.HTML as H
 import qualified Halogen.HTML.Attributes as A

--- a/src/View/File/Item.purs
+++ b/src/View/File/Item.purs
@@ -30,7 +30,7 @@ import Model.File
 import Model.File.Item
 import Model.Resource (Resource(..), resourcePath, resourceName, isFile, isDatabase, isNotebook, hiddenTopLevel)
 import View.File.Common (HTML(), toolItem)
-import Optic.Core 
+import Optic.Core
 
 import qualified Halogen.HTML as H
 import qualified Halogen.HTML.Attributes as A

--- a/src/View/File/Modal/DownloadDialog.purs
+++ b/src/View/File/Modal/DownloadDialog.purs
@@ -29,7 +29,7 @@ import Input.File (FileInput(..))
 import Model.File (_dialog)
 import Model.File.Dialog.Download
 import Model.Resource (Resource(), resourcePath, isHidden, isFile)
-import Optic.Core 
+import Optic.Core
 import Optic.Refractor.Prism (_Left, _Right)
 import View.Common (closeButton, fadeWhen)
 import View.File.Common (HTML())

--- a/src/View/File/Modal/RenameDialog.purs
+++ b/src/View/File/Modal/RenameDialog.purs
@@ -26,7 +26,7 @@ import Input.File (FileInput(..))
 import Model.File (_dialog)
 import Model.File.Dialog.Rename (RenameDialogRec(), _showList, _name, _dir, _dirs, _error)
 import Model.Resource (Resource(), resourcePath, isHidden)
-import Optic.Core 
+import Optic.Core
 import View.Common (fadeWhen)
 import View.File.Common (HTML())
 import View.Modal.Common (header, h4, body, footer, nonSubmit)

--- a/src/View/File/Toolbar.purs
+++ b/src/View/File/Toolbar.purs
@@ -62,7 +62,7 @@ toolbar state =
 
   folder :: HTML e
   folder = toolItem' handleCreateFolder "create folder" B.glyphiconFolderClose
-  
+
   file :: HTML e
   file = H.li_ [ H.button [ E.onClick (\ev -> pure $ handleUploadFile ev.target) ]
                  [ H.i [ A.title "upload file"

--- a/src/View/Modal/Common.purs
+++ b/src/View/Modal/Common.purs
@@ -16,7 +16,7 @@ limitations under the License.
 
 module View.Modal.Common where
 
-import Prelude 
+import Prelude
 import Data.Functor (($>))
 import Control.Plus (empty)
 

--- a/src/View/Notebook.purs
+++ b/src/View/Notebook.purs
@@ -44,7 +44,7 @@ import Model.Notebook.Domain (_cells, _name, _path, notebookPath)
 import Model.Notebook.Menu (DropdownItem(), MenuElement(), MenuInsertSignal(..))
 import Model.Path ((<./>), encodeURIPath)
 import Model.Resource (Resource(), resourcePath)
-import Optic.Core 
+import Optic.Core
 import Optic.Fold ((^?))
 import Optic.Index (ix)
 import View.Common
@@ -124,19 +124,19 @@ cells state = [ H.div [ A.classes [ Vc.notebookContent ] ]
 
 newCellMenu :: forall e. State -> Array (HTML e)
 newCellMenu state =
-  [ H.ul [ A.classes [ Vc.newCellMenu ] ] $ 
+  [ H.ul [ A.classes [ Vc.newCellMenu ] ] $
     [ H.li_ [ H.button [ A.classes [ B.btnLg, B.btnLink ]
                        , E.onClick (E.input_ $ WithState (_addingCell %~ not))
                        , A.title "Insert new cell"
-                       ] 
+                       ]
 
               [ glyph $ if state ^. _addingCell
                         then B.glyphiconMinus
                         else B.glyphiconPlus
               ]
-                
+
             ]
-    ] <> listElements 
+    ] <> listElements
    ]
   where
   listElements :: Array (HTML e)
@@ -147,7 +147,7 @@ newCellMenu state =
     , li "Search" SearchInsert B.glyphiconSearch
     ]
 
-   
+
   li :: String -> MenuInsertSignal -> A.ClassName -> HTML e
   li title inp cls =
     H.li_

--- a/src/View/Notebook/Cell.purs
+++ b/src/View/Notebook/Cell.purs
@@ -33,7 +33,7 @@ import Model.Notebook
 import Model.Notebook.Cell
 import Model.Notebook.Port (Port(..))
 import Model.Resource (resourceName)
-import Optic.Core 
+import Optic.Core
 import View.Common
 import View.Notebook.Cell.Ace (aceEditor)
 import View.Notebook.Cell.Explore (exploreEditor, exploreOutput)

--- a/src/View/Notebook/Cell/Ace.purs
+++ b/src/View/Notebook/Cell/Ace.purs
@@ -23,7 +23,7 @@ import qualified Halogen.HTML as H
 import qualified Halogen.HTML.Attributes as A
 
 import View.Common (fadeWhen, row)
-import qualified View.Css as VC 
+import qualified View.Css as VC
 import View.Notebook.Common (HTML(), dataCellId, dataCellType)
 import Model.Notebook.Cell (Cell(), CellContent(), _hiddenEditor, _cellId, _content, cellContentType)
 

--- a/src/View/Notebook/Cell/Explore.purs
+++ b/src/View/Notebook/Cell/Explore.purs
@@ -16,10 +16,10 @@ limitations under the License.
 
 module View.Notebook.Cell.Explore (exploreEditor, exploreOutput) where
 
-import Prelude 
+import Prelude
 import Controller.Notebook.Cell.Explore (runExplore)
 import Model.Notebook.Cell (Cell(), _FileInput, _JTableContent, _content, _input, _output)
-import Optic.Core 
+import Optic.Core
 import View.Notebook.Cell.FileInput (fileInput)
 import View.Notebook.Cell.JTableCell (renderJTableOutput)
 import View.Notebook.Common (HTML())

--- a/src/View/Notebook/Cell/JTableCell.purs
+++ b/src/View/Notebook/Cell/JTableCell.purs
@@ -30,7 +30,7 @@ import Data.These (These(), these, theseRight)
 import Data.Void (absurd)
 import Model.Notebook.Cell (Cell())
 import Model.Notebook.Cell.JTableContent (JTableContent(), _result, _page, _perPage, _values, _totalPages)
-import Optic.Core 
+import Optic.Core
 import Optic.Extended (TraversalP(), (^?))
 import Optic.Refractor.Prism (_Just)
 import View.Common (glyph)
@@ -132,7 +132,7 @@ renderJTableOutput lens run cell = fromMaybe [] $ do
       let sizeValues = show <$> [10, 25, 50, 100]
       in (option <$> sizeValues)
          ++ [ H.option [ A.disabled true ] [ H.text $ fromChar $ fromCharCode 8212 ] ]
-         ++ (if isJust $ elemIndex pageSizeValue sizeValues 
+         ++ (if isJust $ elemIndex pageSizeValue sizeValues
              then [ H.option [ A.selected true ]
                              [ H.text pageSizeValue ]
                   ]

--- a/src/View/Notebook/Cell/Search.purs
+++ b/src/View/Notebook/Cell/Search.purs
@@ -29,7 +29,7 @@ import Model.Notebook (_notebook)
 import Model.Notebook.Cell (Cell(), RunState(..), _FileInput, _JTableContent, _content, _Search, _cellId, _runState, _input)
 import Model.Notebook.Cell.Search (_buffer)
 import Model.Notebook.Domain (_activeCellId, Notebook())
-import Optic.Core 
+import Optic.Core
 import Optic.Extended (TraversalP())
 import View.Common (glyph)
 import View.Notebook.Cell.FileInput (fileInput)

--- a/src/View/Notebook/Cell/Viz.purs
+++ b/src/View/Notebook/Cell/Viz.purs
@@ -20,8 +20,8 @@ import Prelude
 import Control.Plus (empty)
 import Data.Maybe (Maybe(..), maybe, fromMaybe)
 
-import qualified Data.StrMap as M 
-import Optic.Core 
+import qualified Data.StrMap as M
+import Optic.Core
 import Optic.Fold ((^?))
 import Data.Selection
 import Optic.Extended (TraversalP())
@@ -52,7 +52,7 @@ import Model.Notebook.Cell (Cell(), _cellId, _content, _Visualize, _runState, Ru
 
 import Controller.Notebook.Common (I())
 import View.Common (row, row')
-import qualified View.Css as VC 
+import qualified View.Css as VC
 import View.Notebook.Common (HTML(), dataCellId, dataCellType, dataEChartsId)
 import Data.Foreign.Class ()
 import Utils.Halide (max, min, step)
@@ -65,7 +65,7 @@ import Utils (s2i)
 
 vizChoices :: forall e. Cell -> HTML e
 vizChoices cell =
-  H.div_ 
+  H.div_
   case cell ^. _runState of
     RunningSince _ -> loading
     _ -> case cell ^. _err of
@@ -77,7 +77,7 @@ correct cell =
   maybe [ ] go $ (cell ^? _content.._Visualize)
   where
   go :: VizRec -> Array (HTML e)
-  go r = 
+  go r =
     [H.div [ A.classes [ VC.vizCellEditor ] ] $
      (chartTypeSelector cell r) <>
      (chartConfiguration cell r)
@@ -87,7 +87,7 @@ chartTypeSelector :: forall e. Cell -> VizRec -> Array (HTML e)
 chartTypeSelector cell r =
   [H.div [ A.classes [ VC.vizChartTypeSelector ] ]
    (img <$> (L.fromList $ S.toList  (r ^._availableChartTypes)))
-  ] 
+  ]
   where
   img :: ChartType -> HTML e
   img ct =
@@ -106,8 +106,8 @@ chartTypeSelector cell r =
 chartConfiguration :: forall e. Cell -> VizRec -> Array (HTML e)
 chartConfiguration cell r =
   [H.div [ A.classes [ VC.vizChartConfiguration ] ]
-   [ pieConfiguration cell r (ct == Pie) 
-   , lineConfiguration cell r (ct == Line) 
+   [ pieConfiguration cell r (ct == Pie)
+   , lineConfiguration cell r (ct == Line)
    , barConfiguration cell r (ct == Bar)
    , row
      [ H.form [ A.classes [ B.colXs4, VC.chartConfigureForm ] ]
@@ -122,14 +122,14 @@ chartConfiguration cell r =
      , H.form [ A.classes [ B.colXs4, VC.chartConfigureForm ] ]
        [ label "Width"
        , H.input [ A.value (if zero == (r ^._chartWidth)
-                            then "" 
+                            then ""
                             else show (r ^._chartWidth))
                  , A.classes [ B.formControl, VC.chartConfigureWidth ]
                  , E.onInput (\v -> pure $ setChartWidth cell v)
                  ] [ ]
        ]
      ]
-   ] 
+   ]
   ]
   where ct = r ^._chartType
 
@@ -143,12 +143,12 @@ pieConfiguration cell r visible =
       ]
     , H.form [ A.classes [ B.colXs4, VC.chartConfigureForm, VC.withAggregation ] ]
       [ measureLabel
-      , primaryOptions cell r (_pieConfiguration .. _firstMeasures) 
+      , primaryOptions cell r (_pieConfiguration .. _firstMeasures)
       , aggSelect cell r (_pieConfiguration.._firstMeasures) (_pieConfiguration.._firstAggregation)
       ]
     , H.form [ A.classes [ B.colXs4, VC.chartConfigureForm ] ]
       [ seriesLabel
-      , secondaryOptions cell r (_pieConfiguration .. _firstSeries) 
+      , secondaryOptions cell r (_pieConfiguration .. _firstSeries)
       ]
     ]
   , row
@@ -156,7 +156,7 @@ pieConfiguration cell r visible =
       [ seriesLabel
       , secondaryOptions cell r (_pieConfiguration .. _secondSeries)
       ]
-    ] 
+    ]
   ]
 aggSelect :: forall e. Cell -> VizRec -> LensP VizRec JSelection -> LensP VizRec Aggregation -> HTML e
 aggSelect cell r _blocker _agg =
@@ -165,7 +165,7 @@ aggSelect cell r _blocker _agg =
              A.disabled (null (r ^._blocker.._variants))
            ]
   (aggOpt (r ^._agg) <$> allAggregations)
-  
+
 aggOpt :: forall e. Aggregation -> Aggregation -> HTML e
 aggOpt sel a =
   H.option [ A.value (aggregation2str a)
@@ -174,7 +174,7 @@ aggOpt sel a =
 
 option :: forall e. Maybe JCursor -> JCursor -> Int -> HTML e
 option selected cursor ix =
-  H.option [ A.selected (Just cursor == selected) 
+  H.option [ A.selected (Just cursor == selected)
            , A.value (show ix) ]
   [ H.text (show cursor) ]
 
@@ -185,7 +185,7 @@ defaultOption selected =
   [ H.text "Select axis source" ]
 
 options :: forall e. (Int -> Boolean) ->
-           (Int -> Boolean) -> 
+           (Int -> Boolean) ->
            Cell -> VizRec -> LensP VizRec JSelection -> HTML e
 options disableWhen defaultWhen cell r _sel =
   H.select [ A.classes [ B.formControl ]
@@ -220,9 +220,9 @@ primaryOptions = options (< 2) (> 1)
 -- secondaryOptions :: forall e. Cell -> VizRec -> LensP VizRec JSelection -> HTML e
 secondaryOptions = options (< 1) (const true)
 
-  
+
 barConfiguration :: forall e. Cell -> VizRec -> Boolean -> HTML e
-barConfiguration cell r visible = 
+barConfiguration cell r visible =
   H.div [ A.classes (if visible then [] else [B.hide]) ]
   [ row
     [ H.form [ A.classes [ B.colXs4, VC.chartConfigureForm] ]
@@ -244,9 +244,9 @@ barConfiguration cell r visible =
       [ seriesLabel
       , (secondaryOptions cell r (_barConfiguration.._secondSeries))
       ]
-    ] 
+    ]
   ]
- 
+
 lineConfiguration :: forall e. Cell -> VizRec -> Boolean -> HTML e
 lineConfiguration cell r visible =
   H.div [ A.classes (if visible then [] else [B.hide]) ]
@@ -274,8 +274,8 @@ lineConfiguration cell r visible =
     , H.form [ A.classes [ B.colXs4, VC.chartConfigureForm ] ]
       [ seriesLabel
       , (secondaryOptions cell r (_lineConfiguration.._secondSeries))
-      ] 
-    ] 
+      ]
+    ]
   ]
 
 seriesLabel :: forall e. HTML e
@@ -314,7 +314,7 @@ errored message =
          ]
    [ H.text message ]
   ]
-  
+
 
 vizOutput :: forall e. Cell -> Array (HTML e)
 vizOutput state =
@@ -344,7 +344,7 @@ chart = chart' []
 
 
 _viz :: TraversalP Cell VizRec
-_viz = _content .. _Visualize 
+_viz = _content .. _Visualize
 
 _err :: TraversalP Cell String
 _err = _viz .. _error

--- a/test/src/Test/Config.purs
+++ b/test/src/Test/Config.purs
@@ -190,7 +190,7 @@ type Config =
   , viz :: { heightInput :: String
            , widthInput :: String
            , canvas :: String
-           } 
+           }
   , version :: String
   }
 

--- a/test/src/Test/Selenium/Common.purs
+++ b/test/src/Test/Selenium/Common.purs
@@ -61,12 +61,12 @@ import Routing (matchHash)
 import Selenium.ActionSequence hiding (sequence)
 import Selenium.Key
 import Selenium.Types
-import Selenium.Monad 
-import qualified Selenium.Combinators as Sc 
+import Selenium.Monad
+import qualified Selenium.Combinators as Sc
 
 import Test.Platform
 import Test.Selenium.Log
-import Test.Selenium.Monad 
+import Test.Selenium.Monad
 
 import Utils (s2i)
 
@@ -83,12 +83,12 @@ assertBoolean err false = errorMsg err
 getElementByCss :: String -> String -> Check Element
 getElementByCss cls errorMessage =
   (attempt $ Sc.getElementByCss cls)
-    >>= either (const $ errorMsg errorMessage) pure 
+    >>= either (const $ errorMsg errorMessage) pure
 
 checkNotExists :: String -> String -> Check Unit
 checkNotExists css msg =
   (attempt $ Sc.checkNotExistsByCss css)
-    >>= either (const $ errorMsg msg) pure 
+    >>= either (const $ errorMsg msg) pure
 
 -- | Same as `waitExistentCss'` but wait time is setted to `config.selenium.waitTime`
 waitExistentCss :: String -> String -> Check Element
@@ -104,12 +104,12 @@ await' :: Int -> String -> Check Boolean -> Check Unit
 await' timeout msg check = do
   attempt (Sc.await timeout check)
     >>= either (const $ errorMsg msg) (const $ pure unit)
-    
+
 -- | Same as `await'` but max wait time is setted to `config.selenium.waitTime`
 await :: String -> Check Boolean -> Check Unit
 await msg check = do
   config <- getConfig
-  await' config.selenium.waitTime msg check 
+  await' config.selenium.waitTime msg check
 
 getHashFromURL :: String -> Check Routes
 getHashFromURL =
@@ -213,10 +213,10 @@ parseToInt str =
 
 filterByPairs :: List Element -> (Tuple Element String -> Boolean) ->
                    Check (List (Tuple Element String))
-filterByPairs els filterFn = 
+filterByPairs els filterFn =
   filter filterFn <$> traverse (\el -> Tuple el <$> getInnerHtml el) els
 
- 
+
 filterByContent :: List Element -> (String -> Boolean) -> Check (List Element)
 filterByContent els filterFn =
   (fst <$>) <$> (filterByPairs els (filterFn <<< snd))
@@ -224,5 +224,5 @@ filterByContent els filterFn =
 waitTime :: Int -> Check Unit
 waitTime t = do
   warnMsg "waitTime is used"
-  later t $ pure unit 
+  later t $ pure unit
 

--- a/test/src/Test/Selenium/File.purs
+++ b/test/src/Test/Selenium/File.purs
@@ -33,7 +33,7 @@ import Selenium.Types
 import Selenium.MouseButton
 import Selenium.ActionSequence hiding (sequence)
 import Selenium.Key
-import Selenium.Monad 
+import Selenium.Monad
 import Selenium.Combinators (checker, awaitUrlChanged, waitUntilJust)
 
 
@@ -256,7 +256,7 @@ checkConfigureMount = do
     sendUndo platform
 
   getElementByCss config.configureMount.saveButton "no save button"
-    >>= isEnabled 
+    >>= isEnabled
     >>= assertBoolean "save button should be enabled"
 
   where

--- a/test/src/Test/Selenium/Log.purs
+++ b/test/src/Test/Selenium/Log.purs
@@ -18,21 +18,21 @@ module Test.Selenium.Log where
 
 import Prelude
 import Text.Chalk (red, green, magenta, yellow)
-import Control.Monad.Trans (lift) 
-import Control.Monad.Aff.Console (log) 
-import Control.Monad.Eff.Exception (error) 
+import Control.Monad.Trans (lift)
+import Control.Monad.Aff.Console (log)
+import Control.Monad.Eff.Exception (error)
 import Control.Monad.Error.Class (throwError)
 import Test.Selenium.Monad (Check())
 
-successMsg :: String -> Check Unit 
+successMsg :: String -> Check Unit
 successMsg msg = void $ lift $ log $ green msg
 
-errorMsg :: forall a. String -> Check a 
+errorMsg :: forall a. String -> Check a
 errorMsg msg = do
-  lift $ log $ red msg 
+  lift $ log $ red msg
   throwError $ error msg
 
-sectionMsg :: String -> Check Unit 
+sectionMsg :: String -> Check Unit
 sectionMsg msg = void $ lift $ log $ magenta $ "\n" <> msg
 
 warnMsg :: String -> Check Unit

--- a/test/src/Test/Selenium/Monad.purs
+++ b/test/src/Test/Selenium/Monad.purs
@@ -21,9 +21,9 @@ import Data.List
 import Test.Config (Config())
 import Control.Monad.Reader.Trans
 import Control.Monad.Reader.Class
-import Selenium.Monad 
+import Selenium.Monad
 
-type Check a = Selenium () (config :: Config) a 
+type Check a = Selenium () (config :: Config) a
 
 
 -- READER

--- a/test/src/Test/Selenium/Notebook.purs
+++ b/test/src/Test/Selenium/Notebook.purs
@@ -20,7 +20,7 @@ import Prelude
 import Test.Selenium.Monad (Check())
 import Test.Selenium.Notebook.Contexts (setUp)
 import qualified Test.Selenium.Notebook.Explore as Explore
-import qualified Test.Selenium.Notebook.Search as Search 
+import qualified Test.Selenium.Notebook.Search as Search
 import qualified Test.Selenium.Notebook.Common as Common
 import qualified Test.Selenium.Notebook.Viz as Viz
 

--- a/test/src/Test/Selenium/Notebook/Common.purs
+++ b/test/src/Test/Selenium/Notebook/Common.purs
@@ -78,7 +78,7 @@ checkInitial custom = do
   if html /= ""
     then errorMsg "Status text should be empty"
     else successMsg "Ok, status text is empty"
-  custom 
+  custom
   value <- getElementByCss config.explore.input "there is no input"
            >>= flip getAttribute "value"
   if value /= ""
@@ -111,10 +111,10 @@ checkEmbedButton = do
   reloadAndSpyXHR
   where
   getModal = do
-    config <- getConfig 
+    config <- getConfig
     getElementByCss config.cell.embedBox "Embed box hidden"
   expectedValue = do
-    config <- getConfig 
+    config <- getConfig
     pure $ renderHTMLToString $
       H.iframe [ A.src $ url config
                , width' "100%"
@@ -154,7 +154,7 @@ checkHideShowGeneric find sel = do
               successMsg "Ok, hide/show button works"
 
 checkHideShow :: String -> Check Unit
-checkHideShow = checkHideShowGeneric findElement 
+checkHideShow = checkHideShowGeneric findElement
 
 checkHideShowCell :: Element -> String -> Check Unit
 checkHideShowCell cell = checkHideShowGeneric (findChild cell)
@@ -201,16 +201,16 @@ checkNewCellMenu = do
   vis <- newCellMenuExpanded
   if vis
     then errorMsg "At least one of new cell menu button is visible"
-    else pure unit 
+    else pure unit
   successMsg "Ok, initial new cell menu is collapsed"
   sequence $ leftClick expand
-  await "Expand/collapse button has not been changed" do 
+  await "Expand/collapse button has not been changed" do
     newHtml <- getInnerHtml expand
     pure $ newHtml /= html
   newVis <- newCellMenuExpanded
   if not newVis
     then errorMsg "At least one of new cell menu is not visible after expanding"
-    else pure unit 
+    else pure unit
   successMsg "Ok, expanded"
   -- checking collapse
   sequence $ leftClick expand
@@ -229,7 +229,7 @@ checkIncorrect btnCheck = do
   config <- getConfig
   sequence $ leftClick btn
   failures <- waitExistentCss config.cell.failures "There is no failures but should"
-  html <- getInnerHtml failures 
+  html <- getInnerHtml failures
   show <- getElementByCss config.cell.showMessages "There is no showMessages but should"
   sequence $ leftClick show
   await "There is no difference between hidden and shown failures" do
@@ -238,7 +238,7 @@ checkIncorrect btnCheck = do
   successMsg "Ok, shown failures is defferent with hidden"
   hide <- waitExistentCss config.cell.hideMessages "There is no hideMessages"
   sequence $ leftClick hide
-  await "Hidden failures are not equal with initial" do 
+  await "Hidden failures are not equal with initial" do
     hiddenHtml <- getInnerHtml failures
     pure $ hiddenHtml == html
   successMsg "Ok, hidden failures is equal with initial"

--- a/test/src/Test/Selenium/Notebook/Contexts.purs
+++ b/test/src/Test/Selenium/Notebook/Contexts.purs
@@ -50,7 +50,7 @@ reloadAndSpyXHR = do
   if not $ null stats
     then errorMsg $ "double slash requests were detected\nURLS:"
          <> foldl (\s a -> s <> "\n" <> a.url) "" stats
-    else pure unit 
+    else pure unit
   refresh
   startSpying
   where
@@ -67,20 +67,20 @@ setUp = void do
 
 makeCell :: String -> Check Unit
 makeCell sel = do
-  config <- getConfig 
+  config <- getConfig
   newCellMenu <- newCellMenuExpanded
   if newCellMenu
     then pure unit
     else do
     trigger <- getNewCellMenuTrigger
     sequence $ leftClick trigger
-  exploreBtn <- waitExistentCss sel 
+  exploreBtn <- waitExistentCss sel
                 "There is no explore buttton in new cell menu"
   count <- length <$> getCells
   sequence $ leftClick exploreBtn
   await "Cell has not been added" $ cellAdded count
   successMsg "Ok, cell has been added"
-  where 
+  where
   cellAdded old = do
     new <- length <$> getCells
     pure $ new == old + 1
@@ -115,7 +115,7 @@ deleteAllCells = do
     els <- byCss config.cell.trash >>= findElements
     if null els
       then pure unit
-      else do 
+      else do
       await "cell has not been deleted" do
         new <- length <$> getCells
         pure $ new == old - one
@@ -131,13 +131,13 @@ deleteCells cellsCheck = do
     Cons el _ -> do
       sequence $ leftClick el
       await "Cell has not been deleted (deleteCell)" do
-        count <- length <$> cellsCheck 
+        count <- length <$> cellsCheck
         pure $ length cells == count + one
       deleteCells cellsCheck
-  where 
-  traverseFn cell = do 
-    config <- getConfig 
-    byCss config.cell.trash >>= findChild cell 
+  where
+  traverseFn cell = do
+    config <- getConfig
+    byCss config.cell.trash >>= findChild cell
 
 
 withCell :: Check Unit -> Context
@@ -153,7 +153,7 @@ withSearchCell :: Context
 withSearchCell = withCell makeSearchCell
 
 withQueryCell :: Context
-withQueryCell = withCell makeQueryCell 
+withQueryCell = withCell makeQueryCell
 
 
 
@@ -162,7 +162,7 @@ cellHasRun = do
   statusText <- getStatusText >>= getInnerHtml
   embed <- attempt getEmbedButton
   pure (statusText /= "" && isRight embed)
-  
+
 fileOpened :: String -> Context
 fileOpened file action = do
   config <- getConfig
@@ -170,7 +170,7 @@ fileOpened file action = do
   play <- getPlayButton
   sequence do
     leftClick input
-    sendKeys file 
+    sendKeys file
     leftClick play
   await "error during opening file" cellHasRun
   action
@@ -189,7 +189,7 @@ queryEvaluated queryStr action = do
   where
   sendKeysFn "-" = sendKeys "\xE027"
   sendKeysFn a = sendKeys a
-  
+
 withFileOpened :: Context -> String -> Context
 withFileOpened context file action = context $ fileOpened file action
 
@@ -201,7 +201,7 @@ withFileOpenedExplore = withFileOpened withExploreCell
 fileSearched :: String -> String -> Context
 fileSearched file query action = do
   config <- getConfig
-  fl <- getSearchFileList 
+  fl <- getSearchFileList
   qu <- getSearchInput
   play <- getPlayButton
   sequence do
@@ -214,15 +214,15 @@ fileSearched file query action = do
   action
 
 
-  
+
 withFileSearched :: String -> String -> Context
 withFileSearched file query action = withSearchCell $ fileSearched file query action
-                                     
+
 withSmallZipsSearchedAll :: Context
 withSmallZipsSearchedAll action = do
   config <- getConfig
   withFileSearched config.explore.smallZips config.searchCell.allQuery action
-    
+
 withSmallZipsOpened :: Context
 withSmallZipsOpened action =
   getConfig >>= _.explore >>> _.smallZips >>> flip withFileOpenedExplore action
@@ -269,7 +269,7 @@ afterTableChanged action = do
   await "Table content has not been changed" $ tableChanged html
   pure res
 
-afterTableReload :: String -> Check Unit 
+afterTableReload :: String -> Check Unit
 afterTableReload html = do
   config <- getConfig
   wait (checker $ tableChanged html) (config.selenium.waitTime * 10)

--- a/test/src/Test/Selenium/Notebook/Explore.purs
+++ b/test/src/Test/Selenium/Notebook/Explore.purs
@@ -63,7 +63,7 @@ checkInitialExplore =
 checkEmptyInputErrors :: Check Unit
 checkEmptyInputErrors = do
   config <- getConfig
-  withExploreCell do 
+  withExploreCell do
     C.checkIncorrect getRefreshButton
   withExploreCell do
     C.checkIncorrect getPlayButton
@@ -98,7 +98,7 @@ checkDirectoryFailure =
 checkInexistentFileNotMounted :: Check Unit
 checkInexistentFileNotMounted =
   getConfig >>= _.explore >>> _.notMounted >>> checkFailure "(not mounted)"
-  
+
 checkInexistentFileMounted :: Check Unit
 checkInexistentFileMounted = withExploreCell do
   config <- getConfig
@@ -113,7 +113,7 @@ checkInexistentFileMounted = withExploreCell do
 
 checkStatus :: Check Unit
 checkStatus = withSmallZipsOpened do
-  config <- getConfig 
+  config <- getConfig
   refresh <- getRefreshButton
   wait (checker finished) config.selenium.waitTime
   successMsg "Ok, correct status text"
@@ -133,7 +133,7 @@ checkStatus = withSmallZipsOpened do
 
 checkOutputLabel :: Check Unit
 checkOutputLabel = do
-  config <- getConfig 
+  config <- getConfig
   withSmallZipsOpened do
     zipsLabel <- getElementByCss config.cell.cellOutputLabel "no output label"
                  >>= getInnerHtml
@@ -175,18 +175,18 @@ checkRowCount' :: (Int -> Int -> Boolean) -> Int -> Check Unit
 checkRowCount' assertFn expected = do
   {table: tableCount, pager: pagerCount} <- getRowCount
   if assertFn tableCount pagerCount
-    then successMsg "Ok, correct row count" 
+    then successMsg "Ok, correct row count"
     else errorMsg $ "Incorrect row count\n" <>
          "expected: " <> show expected <>
          "\nin table: " <> show tableCount <>
          "\nin pager: " <> show pagerCount
 
-  
+
 checkRowCount :: Int -> Check Unit
 checkRowCount expected =
   checkRowCount' (\tc pc -> tc == expected && pc == expected) expected
 
-         
+
 checkInitialRowCount :: Check Unit
 checkInitialRowCount = do
   config <- getConfig
@@ -195,7 +195,7 @@ checkInitialRowCount = do
 checkRowsPerPageSwitching :: Check Unit
 checkRowsPerPageSwitching = do
   checkRowsPerPageSelect
-  checkRowsPerPageCustom 
+  checkRowsPerPageCustom
 
 setPageSizeOption :: String -> Check Unit
 setPageSizeOption str = do
@@ -205,24 +205,24 @@ setPageSizeOption str = do
     leftClick select
     leftClick option
     sendEnter
-  where 
+  where
   getOption str = do
-    config <- getConfig 
+    config <- getConfig
     options <- byCss config.explore.option >>= findElements
-    filtered <- filterByContent options (\content -> content == str) 
+    filtered <- filterByContent options (\content -> content == str)
     case filtered of
       Nil -> errorMsg $ "There is no option with value " <> str
       Cons el _ -> pure el
 
 checkRowsPerPageSelect :: Check Unit
 checkRowsPerPageSelect = withSmallZipsOpened do
-  config <- getConfig 
+  config <- getConfig
   select <- getPageSizeSelect
   for_ (reverse $ toList config.explore.optionNums) traverseFn
   where
   traverseFn numStr = do
     config <- getConfig
-    tableHtml <- getTable >>= getInnerHtml 
+    tableHtml <- getTable >>= getInnerHtml
     setPageSizeOption numStr
     afterTableReload tableHtml
     count <- parseToInt numStr
@@ -239,7 +239,7 @@ checkRowsPerPageCustom = withSmallZipsOpened do
   input <- getPageSizeInput
   successMsg "Ok, input has been appeared"
   rnd <- getRandom 10
-  
+
   tableHtml <- getTable >>= getInnerHtml
   let platform = platformFromConfig config
   sequence do
@@ -319,7 +319,7 @@ checkPagination = withSmallZipsOpened do
   prenultPageER = EnabledRecord {ff: true, sf: true, fb: true, sb: true, value: "9"}
   customPageER num =
     EnabledRecord {ff: true, sf: true, fb: true, sb: true, value: num}
-  
+
   checkRowContent sel msg = do
     config <- getConfig
     correctRows <- byCss config.explore.row >>= findElements >>=
@@ -331,18 +331,18 @@ checkPagination = withSmallZipsOpened do
       _ -> errorMsg $ "There is row dublicates (" <> msg <> ")"
 
   checkRecord expected msg = do
-    emsg <- errMsg 
+    emsg <- errMsg
     await emsg do
       eq expected <$> getEnabledRecord
     successMsg $ "Ok, enabled records are equal (" <> msg <> ")"
     where
     errMsg = do
       actual <- getEnabledRecord
-      pure $ "Incorrect pagination buttons are enabled:\n" 
-        <> "case: " <> msg 
-        <> "\nexpected: " <> show expected 
+      pure $ "Incorrect pagination buttons are enabled:\n"
+        <> "case: " <> msg
+        <> "\nexpected: " <> show expected
         <> "\nactual: " <> show actual
-  
+
 
 checkColumns :: Check Unit
 checkColumns = do
@@ -360,9 +360,9 @@ checkColumns = do
   withNestedOpened do
     nestedColumns <- getJTableHeadContent
     if nestedColumns == config.explore.nestedHead ||
-       nestedColumns == config.explore.nestedHeadInversed 
+       nestedColumns == config.explore.nestedHeadInversed
       then successMsg "Ok, nested columns are correct"
-      else errorMsg $ "nested columns are incorrect" 
+      else errorMsg $ "nested columns are incorrect"
            <> "\nexpected: " <> config.explore.nestedHead
            <> "\nactual  : " <> nestedColumns
            <> "\nexpected attribute inversed: " <> config.explore.nestedHeadInversed
@@ -375,22 +375,22 @@ test = do
 
   sectionMsg "make explore cell check"
   C.checkMakeCell getExploreCells makeExploreCell
-  
+
   sectionMsg "check deleting explore cells"
   C.checkDeleting getExploreCells
-  
+
   sectionMsg "check show/hide explore editor"
   withExploreCell $ C.checkHideShow config.cell.exploreEditor
-  
+
   sectionMsg "File list in explore cell checking"
   FL.test withExploreCell
-  
+
   sectionMsg "check that embed button, next cell menu and result is not visible"
   checkInitialExplore
-  
+
   sectionMsg "check failures with empty input"
   checkEmptyInputErrors
-  
+
   sectionMsg "check incorrect inputs"
   checkIncorrectInputs
 
@@ -399,17 +399,17 @@ test = do
 
   sectionMsg "check status"
   checkStatus
-  
-  sectionMsg "check next cells"
-  withSmallZipsOpened $ C.checkNextCells config.cell.nextCellsForExplore 
 
-  
+  sectionMsg "check next cells"
+  withSmallZipsOpened $ C.checkNextCells config.cell.nextCellsForExplore
+
+
   sectionMsg "check output label"
   checkOutputLabel
 
   sectionMsg "check page count"
   checkPageCount
-  
+
   sectionMsg "check inital row count"
   checkInitialRowCount
 
@@ -418,7 +418,7 @@ test = do
 
 
   sectionMsg "check forward/backward/set page"
-  checkPagination 
+  checkPagination
 
   sectionMsg "check columns (most of this checks should be in jtable tests)"
-  checkColumns 
+  checkColumns

--- a/test/src/Test/Selenium/Notebook/FileList.purs
+++ b/test/src/Test/Selenium/Notebook/FileList.purs
@@ -82,7 +82,7 @@ checkHiddenItems ctx = withFileList ctx do
   xhrStopped = do
     stats <- filter (\{state: state} -> state == Opened) <$> getXHRStats
     pure $ null stats
-    
+
   filterFn (Tuple el html) =
     R.test (R.regex "/\\." R.noFlags) html
 
@@ -102,12 +102,12 @@ checkHiddenItems ctx = withFileList ctx do
         shwColor <- getCssValue shw "color"
         if hidColor == shwColor
           then errorMsg "hidden and not hidden items should have different colors in file list"
-          else pure unit 
+          else pure unit
     successMsg "Ok, hidden and not hidden items have different color"
     deleteAllCells
 
 
-test :: Context -> Check Unit 
+test :: Context -> Check Unit
 test context = context do
   sectionMsg "check file list hide/show"
   checkFileList context
@@ -118,4 +118,4 @@ test context = context do
   sectionMsg "check file list order"
   checkHiddenItems context
 
-  
+

--- a/test/src/Test/Selenium/Notebook/Getters.purs
+++ b/test/src/Test/Selenium/Notebook/Getters.purs
@@ -29,7 +29,7 @@ import Selenium.Types
 import Test.Selenium.Log
 import Test.Selenium.Monad
 import Test.Selenium.Common
-import Test.Selenium.Types 
+import Test.Selenium.Types
 import qualified Data.String.Regex as R
 import Selenium.Monad
 
@@ -37,8 +37,8 @@ import Selenium.Monad
 newCellMenuExpanded :: Check Boolean
 newCellMenuExpanded = do
   config <- getConfig
-  btns <- traverse getEl $ toList [ Tuple config.newCellMenu.queryButton "query" 
-                                  , Tuple config.newCellMenu.mdButton "markdown" 
+  btns <- traverse getEl $ toList [ Tuple config.newCellMenu.queryButton "query"
+                                  , Tuple config.newCellMenu.mdButton "markdown"
                                   , Tuple config.newCellMenu.exploreButton "explore"
                                   , Tuple config.newCellMenu.searchButton "search"
                                   ]
@@ -55,7 +55,7 @@ newCellMenuExpanded = do
   getEl :: Tuple String String -> Check Element
   getEl (Tuple selector msg) =
     getElementByCss selector $ msg <> " not found in new cell menu"
-    
+
 
 
 getNewCellMenuTrigger :: Check Element
@@ -114,10 +114,10 @@ waitNextVizCell = do
 waitCanvas :: Check Element
 waitCanvas = do
   getConfig >>= _.viz >>> _.canvas >>>
-  flip waitExistentCss "There is no canvas" 
+  flip waitExistentCss "There is no canvas"
 
 fileListVisible :: Check Boolean
-fileListVisible = 
+fileListVisible =
   getConfig
     >>= (_.explore >>> _.list >>> flip getElementByCss "file list not found")
     >>= isDisplayed
@@ -174,7 +174,7 @@ getPageSizeInput =
 
 getTableRows :: Check (List Element)
 getTableRows =
-  getConfig >>= (_.explore >>> _.row >>> byCss) >>= findElements 
+  getConfig >>= (_.explore >>> _.row >>> byCss) >>= findElements
 
 getTable :: Check Element
 getTable =
@@ -182,15 +182,15 @@ getTable =
   flip getElementByCss "There is no result table"
 
 getFastForward :: Check Element
-getFastForward = 
+getFastForward =
   getConfig >>= _.explore >>> _.paginationFastForwardContent >>> getPaginationButton
 
 getStepForward :: Check Element
-getStepForward = 
+getStepForward =
   getConfig >>= _.explore >>> _.paginationStepForwardContent >>> getPaginationButton
 
 getFastBackward :: Check Element
-getFastBackward = 
+getFastBackward =
   getConfig >>= _.explore >>> _.paginationFastBackwardContent >>> getPaginationButton
 
 getStepBackward :: Check Element
@@ -251,15 +251,15 @@ getPager :: Check Element
 getPager = getConfig >>= _.explore >>> _.pager >>>
            flip getElementByCss "There is no pager"
 
-getPageCount :: Check Int 
+getPageCount :: Check Int
 getPageCount = do
   getPager >>= getInnerHtml >>= extract
   where
   extract html =
     let countStr = R.replace (R.regex "\\D+(\\d+)" R.noFlags) "$1" html
     in parseToInt countStr
-  
-getRowCount :: Check RowCount 
+
+getRowCount :: Check RowCount
 getRowCount = do
   tc <- length <$> getTableRows
   pc <- getPageSizeSelect >>= flip getAttribute "value" >>= parseToInt
@@ -267,7 +267,7 @@ getRowCount = do
 
 import Utils.Log
 
-getEnabledRecord :: Check EnabledRecord 
+getEnabledRecord :: Check EnabledRecord
 getEnabledRecord = do
     ff <- getFastForward
     sf <- getStepForward

--- a/test/src/Test/Selenium/Notebook/Search.purs
+++ b/test/src/Test/Selenium/Notebook/Search.purs
@@ -99,7 +99,7 @@ checkSearchEmpty btnCheck = do
     config <- getConfig
     input <- getSearchFileList
     sequence do
-      leftClick input 
+      leftClick input
       sendKeys config.explore.smallZips
     C.checkIncorrect btnCheck
   successMsg "Ok, expected behaviour when search input is empty"
@@ -159,20 +159,20 @@ checkSearchClear :: Check Unit
 checkSearchClear = withSearchCell do
   clear <- getSearchClear
   ip <- getSearchInput
-  sequence do 
+  sequence do
     leftClick ip
     sendKeys "foo bar baz"
   await "value of search input has not been setted" do
-    (== "foo bar baz") <$> getAttribute ip "value" 
+    (== "foo bar baz") <$> getAttribute ip "value"
 
   successMsg "Ok, correct value in search input"
-  
+
   sequence $ leftClick clear
   await "value of search input has not been cleared" do
     (== "") <$> getAttribute ip "value"
 
   successMsg "Ok, value has been cleared"
-  
+
 checkSearchStop :: Check Unit
 checkSearchStop = withSearchCell do
   config <- getConfig
@@ -205,7 +205,7 @@ checkOutputLabel = do
   replicateM dummy makeMarkdownCell
   makeSearchCell
   deleteCells getMdCells
-  fileSearched config.explore.smallZips config.searchCell.allQuery do 
+  fileSearched config.explore.smallZips config.searchCell.allQuery do
     label <- waitOutputLabel >>= getInnerHtml
     if extracted label /= ("out" <> show dummy)
       then errorMsg "Incorrect output"
@@ -239,8 +239,8 @@ checkQuery conf = withSmallZipsSearchedAll do
   config <- getConfig
   ip <- getSearchInput
   btn <- getPlayButton
-  
-  fbEnabled <- (_.fb <<< runEnabledRecord) <$> getEnabledRecord 
+
+  fbEnabled <- (_.fb <<< runEnabledRecord) <$> getEnabledRecord
   if not fbEnabled
     then pure unit
     else do
@@ -251,16 +251,16 @@ checkQuery conf = withSmallZipsSearchedAll do
     leftClick ip
     sendSelectAll platform
     sendDelete
-    sendKeys conf.query 
+    sendKeys conf.query
     leftClick btn
-  
+
   ffEnabled <- (_.ff <<< runEnabledRecord) <$> getEnabledRecord
   if not ffEnabled
     then pure unit
     else do
     afterTableChanged (getFastForward >>= sequence <<< leftClick)
 
-    
+
   {table: tableCount, pager: pagerCount} <- getRowCount
   if tableCount == conf.rows
      && pagerCount == 10
@@ -270,15 +270,15 @@ checkQuery conf = withSmallZipsSearchedAll do
          <> "\nin pager: " <> show pagerCount
          <> "\nshould be in table: " <> show conf.rows
          <> "\nshould be in pager: 10"
-         
+
   count <- getPageCount
   if count == conf.pages
     then successMsg "Ok, correct page count"
     else errorMsg "Incorrect page count"
 
 checkQueries :: Check Unit
-checkQueries = 
-  getConfig >>= _.searchQueries >>> traverse_ checkQuery 
+checkQueries =
+  getConfig >>= _.searchQueries >>> traverse_ checkQuery
 
 
 
@@ -291,10 +291,10 @@ test = do
 
   sectionMsg "check make search cell"
   C.checkMakeCell getSearchCells makeSearchCell
-  
+
   sectionMsg "check deleting search cells"
   C.checkDeleting getSearchCells
-  
+
   sectionMsg "check file list in search cell"
   FL.test withSearchCell
 
@@ -305,7 +305,7 @@ test = do
   checkIncorrectInputs
 
   sectionMsg "check embed inputs"
-  withSmallZipsSearchedAll C.checkEmbedButton 
+  withSmallZipsSearchedAll C.checkEmbedButton
 
   sectionMsg "check value clear"
   checkSearchClear
@@ -314,14 +314,14 @@ test = do
   checkSearchStop
 
   sectionMsg "check output label"
-  checkOutputLabel 
+  checkOutputLabel
 
   sectionMsg "check next search cell (explore)"
-  withSmallZipsOpened $ checkNextSearchCell config.explore.smallZips 
+  withSmallZipsOpened $ checkNextSearchCell config.explore.smallZips
 
   sectionMsg "check next search cell (search)"
   withSmallZipsSearchedAll $ checkNextSearchCell
-    $  "/" <> config.mount.name 
+    $  "/" <> config.mount.name
     <> "/" <> config.database.name
     <> "/" <> Config.newNotebookName
     <> "." <> Config.notebookExtension

--- a/test/src/Test/Selenium/Notebook/Viz.purs
+++ b/test/src/Test/Selenium/Notebook/Viz.purs
@@ -72,11 +72,11 @@ checkSetHeightWidth = withSmallZipsAllChart do
 
   where
   getDims = do
-    canvas <- waitCanvas 
+    canvas <- waitCanvas
     { w: _, h: _ }
       <$> (s2i <$> getCssValue canvas "width")
       <*> (s2i <$> getCssValue canvas "height")
-  
+
 test :: Check Unit
 test = do
   config <- getConfig
@@ -97,7 +97,7 @@ test = do
 
   sectionMsg "check hide/show"
   withSmallZipsAllChart do
-    config <- getConfig 
+    config <- getConfig
     cell <- getCell 1
     C.checkHideShowCell cell config.cell.vizEditor
-  
+

--- a/test/src/Test/Selenium/Types.purs
+++ b/test/src/Test/Selenium/Types.purs
@@ -23,7 +23,7 @@ newtype EnabledRecord =
                 , sf :: Boolean
                 , fb :: Boolean
                 , sb :: Boolean
-                , value :: String 
+                , value :: String
                 }
 
 runEnabledRecord :: EnabledRecord -> { ff :: Boolean
@@ -40,7 +40,7 @@ instance eqEnabledRecord :: Eq EnabledRecord where
     r.sf == r'.sf &&
     r.fb == r'.fb &&
     r.sb == r'.sb &&
-    r.value == r'.value 
+    r.value == r'.value
 
 instance showEnabledRecord :: Show EnabledRecord where
   show (EnabledRecord r) =
@@ -48,8 +48,8 @@ instance showEnabledRecord :: Show EnabledRecord where
     ", sf = " <> show r.sf <>
     ", fb = " <> show r.fb <>
     ", sb = " <> show r.sb <>
-    ", value = " <> show r.value <> 
+    ", value = " <> show r.value <>
     "})"
 
-    
+
 type RowCount = {table :: Int, pager :: Int}

--- a/test/src/Text/Chalk.purs
+++ b/test/src/Text/Chalk.purs
@@ -19,4 +19,4 @@ module Text.Chalk where
 foreign import green :: String -> String
 foreign import red :: String -> String
 foreign import magenta :: String -> String
-foreign import yellow :: String -> String 
+foreign import yellow :: String -> String


### PR DESCRIPTION
*This is just an idea, so if anyone doesn't like it, feel free to close this.*

I've just been noticing that a lot of our source code has trailing whitespace in it---I have my editor set up to remove it automatically, but when I do so, it seems to get re-introduced with some regularity. Not to mention, frequent whitespace-adjustment passes can lead to difficult to read diffs (and difficult merges), whereas if the invariant is maintained automatically over time, this won't be a problem.

Adding the removal of trailing whitespace to the build would kind of solve this for everyone, and nobody would have to make any adjustment to their editor or be especially careful when preparing a commit.