### PR TITLE
[SD-940] Fix several pattern matching mistakes

### DIFF
--- a/src/Controller/Notebook/Cell/Viz/Pie.purs
+++ b/src/Controller/Notebook/Cell/Viz/Pie.purs
@@ -206,7 +206,7 @@ mkPie r conf =
 
   extractName :: Series -> Array (Maybe String)
   extractName (PieSeries r) = extractOneDatum <$> (fromMaybe [] r.pieSeries."data")
-  extractname _ = []
+  extractName _ = []
 
   extractOneDatum :: ItemData -> Maybe String
   extractOneDatum (Dat r) = r.name

--- a/src/Model/Notebook/Cell.purs
+++ b/src/Model/Notebook/Cell.purs
@@ -245,7 +245,6 @@ instance encodeJsonCellContent :: EncodeJson CellContent where
       Query rec -> encodeJson rec
       Markdown rec -> encodeJson rec
       Visualize rec -> encodeJson rec
-      _ -> jsonEmptyObject
 
 instance decodeJsonExploreRec :: DecodeJson CellContent where
   decodeJson json = do

--- a/src/Model/Notebook/Cell/Markdown.purs
+++ b/src/Model/Notebook/Cell/Markdown.purs
@@ -48,6 +48,7 @@ encodeTextBox PlainText = encodeJson "plainText"
 encodeTextBox Date = encodeJson "date"
 encodeTextBox Time = encodeJson "time"
 encodeTextBox DateTime = encodeJson "dateTime"
+encodeTextBox Numeric = encodeJson "numeric"
 
 decodeTextBox :: Json -> Either String TextBoxType
 decodeTextBox j = do
@@ -57,6 +58,7 @@ decodeTextBox j = do
     "date" -> pure Date
     "time" -> pure Time
     "dateTime" -> pure DateTime
+    "numeric" -> pure Numeric
     _ -> Left "incorrect textbox type"
 
 instance encodeEncFormField :: EncodeJson EncFormField where


### PR DESCRIPTION
- `{encode|decode}TextBox`: fix missing pattern match case (this is the cause of [SD-940](https://slamdata.atlassian.net/browse/SD-940))

- `Controller.Notebook.Cell.Viz.Pie.mkPie`: fix inexhaustive pattern match; this one was caused by a little typo that anyone could accidentally make.

- `Model.Notebook.Cell.encodeJsonCellContent`: fix redundant case in pattern match

I did not add any test for this, since the exhaustivity of the pattern match is probably evidence enough of its correctness.