### PR TITLE
Resolve SD-948 by giving proper path for mount

### DIFF
--- a/src/Model/Path.purs
+++ b/src/Model/Path.purs
@@ -91,3 +91,4 @@ hidePath path input =
   trim $
   replace ("+path:\"" <> path <> "\"") "" $
   replace ("+path:" <> path) "" input
+

--- a/src/Model/Resource.purs
+++ b/src/Model/Resource.purs
@@ -78,6 +78,14 @@ data Resource
   | Directory DirPath
   | Database DirPath
 
+instance showResource :: Show Resource where
+  show r =
+    case r of
+      File fp -> "File " ++ show fp
+      Notebook dp -> "Notebook " ++ show dp
+      Directory dp -> "Directory " ++ show dp
+      Database dp -> "Database " ++ show dp
+
 _tempFile :: LensP Resource Resource
 _tempFile = lens id \r s -> case r of
   File p ->


### PR DESCRIPTION
Rather than building a new path from scratch by reading stuff out of the `Resource` object (which led to us giving a file path instead of a directory path where we needed it), it seems as though we can just transplant the resource's path into the correct neighborhood.

 #done SD-948

https://slamdata.atlassian.net/browse/SD-948