### PR TITLE
Fix numerous compiler warnings

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -73,7 +73,7 @@
   "devDependencies": {
     "purescript-node-fs-aff": "~0.1.2",
     "purescript-platform": "^0.3.0",
-    "purescript-webdriver": "~0.11.1",
+    "purescript-webdriver": "^0.11.2",
     "purescript-easyimage": "~0.1.0"
   }
 }

--- a/src/Api/Common.purs
+++ b/src/Api/Common.purs
@@ -72,9 +72,8 @@ getWithPolicy policy u = do
   nocache <- liftEff $ nowEpochMilliseconds
   let url = printPath u
       symbol = if S.contains "?" url then "&" else "?"
-  slamjax defaultRequest { url = url ++ symbol ++ "nocache=" ++ pretty nocache }
+  retry policy affjax defaultRequest { url = url ++ symbol ++ "nocache=" ++ pretty nocache }
   where
-  slamjax = retry policy affjax
   pretty (Milliseconds ms) =
     let s = show ms
     in fromMaybe s (S.stripSuffix ".0" s)

--- a/src/Controller/Notebook/Cell/Viz/Bar.purs
+++ b/src/Controller/Notebook/Cell/Viz/Bar.purs
@@ -136,11 +136,11 @@ mkSeries acc =
                       , "data" = Just $ CommonAxisData <$> catVals
                       }
 
-  ks :: Array Key
-  ks = L.fromList $ keys acc
+  keysArray :: Array Key
+  keysArray = L.fromList $ keys acc
 
   catVals :: Array String
-  catVals = nub $ keyCategory <$> ks
+  catVals = nub $ keyCategory <$> keysArray
 
   nameMap :: Array (Tuple Key Number) -> Map String (Array Number)
   nameMap = named'' <<< filled <<< named'

--- a/src/Controller/Notebook/Cell/Viz/Bar.purs
+++ b/src/Controller/Notebook/Cell/Viz/Bar.purs
@@ -64,7 +64,7 @@ extractData r conf =
   where
   cats :: L.List (Maybe String)
   cats =
-    map (flip bind Me.catFromSemanthic)
+    map (flip bind Me.catFromSemantics)
     $ maybe L.Nil Me.runAxis
     $ (conf ^._cats.._selection)
     >>= (flip lookup (r ^._all))
@@ -72,7 +72,7 @@ extractData r conf =
 
   vals :: L.List (Maybe Number)
   vals =
-    map (flip bind Me.valFromSemanthic)
+    map (flip bind Me.valFromSemantics)
     $ maybe L.Nil Me.runAxis
     $ (conf ^._firstMeasures.._selection)
     >>= flip lookup (r ^._all)
@@ -85,7 +85,7 @@ extractData r conf =
 
   sers1 :: L.List (Maybe String)
   sers1 =
-    map (flip bind Me.catFromSemanthic)
+    map (flip bind Me.catFromSemantics)
     $ maybe nothings Me.runAxis
     $ (conf ^._firstSeries.._selection)
     >>= flip lookup (r ^. _all)
@@ -93,7 +93,7 @@ extractData r conf =
 
   sers2 :: L.List (Maybe String)
   sers2 =
-    map (flip bind Me.catFromSemanthic)
+    map (flip bind Me.catFromSemantics)
     $ maybe nothings Me.runAxis
     $ (conf ^._secondSeries.._selection)
     >>= flip lookup (r ^. _all)

--- a/src/Controller/Notebook/Cell/Viz/Line.purs
+++ b/src/Controller/Notebook/Cell/Viz/Line.purs
@@ -63,21 +63,21 @@ extractData r conf =
   where
   dims :: L.List (Maybe String)
   dims =
-    map (flip bind Me.catFromSemanthic)
+    map (flip bind Me.catFromSemantics)
     $ maybe L.Nil Me.runAxis
     $ (conf ^._dims.._selection)
     >>= flip lookup (r ^. _all)
 
   vals1 :: L.List (Maybe Number)
   vals1 =
-    map (flip bind Me.valFromSemanthic)
+    map (flip bind Me.valFromSemantics)
     $ maybe L.Nil Me.runAxis
     $ (conf ^._firstMeasures.._selection)
     >>= flip lookup (r ^. _all)
 
   vals2 :: L.List (Maybe Number)
   vals2 =
-    map (flip bind Me.valFromSemanthic)
+    map (flip bind Me.valFromSemantics)
     $ maybe nothings Me.runAxis
     $ (conf ^._secondMeasures.._selection)
     >>= flip lookup (r ^. _all)
@@ -91,14 +91,14 @@ extractData r conf =
 
   sers1 :: L.List (Maybe String)
   sers1 =
-    map (flip bind Me.catFromSemanthic)
+    map (flip bind Me.catFromSemantics)
     $ maybe nothings Me.runAxis
     $ (conf ^._firstSeries.._selection)
     >>= flip lookup (r ^. _all)
 
   sers2 :: L.List (Maybe String)
   sers2 =
-    map (flip bind Me.catFromSemanthic)
+    map (flip bind Me.catFromSemantics)
     $ maybe nothings Me.runAxis
     $ (conf ^._secondSeries.._selection)
     >>= flip lookup (r ^. _all)

--- a/src/Controller/Notebook/Cell/Viz/Line.purs
+++ b/src/Controller/Notebook/Cell/Viz/Line.purs
@@ -149,8 +149,8 @@ mkSeries :: Boolean -> AxisType -> AggregatedAccum -> Tuple Axises (Array Series
 mkSeries needTwoAxis ty acc =
   Tuple xAxis series
   where
-  ks :: Array Key
-  ks = L.fromList $ keys acc
+  keysArray :: Array Key
+  keysArray = L.fromList $ keys acc
 
   series :: Array Series
   series =
@@ -163,7 +163,7 @@ mkSeries needTwoAxis ty acc =
          else L.Nil)
 
   catVals :: Array String
-  catVals = nub $ keyCategory <$> ks
+  catVals = nub $ keyCategory <$> keysArray
 
   xAxis = OneAxis $ Axis
           axisDefault { "type" = Just ty

--- a/src/Driver/Notebook.purs
+++ b/src/Driver/Notebook.purs
@@ -81,11 +81,11 @@ driver ref k =
         let newNotebook = emptyNotebook # _path .~ resourceDir res
             newCell = Explore (initialExploreRec # _input .. _file .~ Right res)
         case addCell newCell newNotebook of
-          Tuple notebook cell -> do
+          Tuple nb cell -> do
             update $ (_editable .~ true)
                   .. (_loaded .~ true)
                   .. (_error .~ Nothing)
-                  .. (_notebook .~ notebook)
+                  .. (_notebook .~ nb)
             runEvent (runError "runExplore") k $ run cell `andThen` \_ -> runExplore cell
 
   where

--- a/src/Driver/Notebook/Cell.purs
+++ b/src/Driver/Notebook/Cell.purs
@@ -52,8 +52,6 @@ driveCellContent (ViewCellContent cell) driver =
     Visualize _ -> view cell driver
     Query _ -> view cell driver
     Markdown _ -> view cell driver
-    _ -> pure unit
-
 driveCellContent _ _ = pure unit
 
 runWith :: forall eff. Cell -> Driver Input (NotebookComponentEff eff) -> Eff (NotebookAppEff eff) Unit

--- a/src/Driver/Notebook/Routing.purs
+++ b/src/Driver/Notebook/Routing.purs
@@ -51,15 +51,15 @@ routing = ExploreRoute <$> (oneSlash *> lit "explore" *> (fileFromParts <$> list
   partsAndName = Tuple <$> (oneSlash *> (list notName)) <*> name
 
   notebookFromParts :: Tuple (List String) String -> Resource
-  notebookFromParts (Tuple ps name) =
-    Notebook $ foldl (</>) rootDir (dir <$> ps) </> dir name
+  notebookFromParts (Tuple ps nm) =
+    Notebook $ foldl (</>) rootDir (dir <$> ps) </> dir nm
 
   fileFromParts :: List String -> Resource
-  fileFromParts (Cons name Nil) = newFile # _filePath .~ rootDir </> file name
+  fileFromParts (Cons nm Nil) = newFile # _filePath .~ rootDir </> file nm
   fileFromParts ps =
-    let name = fromJust $ last ps
+    let nm = fromJust $ last ps
         ps' = fromJust $ init ps
-    in newFile # _filePath .~ foldl (</>) rootDir (dir <$> ps') </> file name
+    in newFile # _filePath .~ foldl (</>) rootDir (dir <$> ps') </> file nm
 
   notebook :: Match Resource
   notebook = notebookFromParts <$> partsAndName

--- a/src/Input/File/Item.purs
+++ b/src/Input/File/Item.purs
@@ -45,6 +45,9 @@ inputItem sort searching input items = case input of
   ItemSelect ix ->
     modify toggleItem items ix
 
+  Resort ->
+    resort sort searching items
+
 toggleItem :: Boolean -> Item -> Item
 toggleItem true (Item r) = SelectedItem r
 toggleItem false (SelectedItem r) = Item r

--- a/src/Input/Notebook.purs
+++ b/src/Input/Notebook.purs
@@ -234,13 +234,13 @@ setSlamDownStatus cell =
       message = ("Exported fields: " <>) <<< intercalate ", " <<< (fst <$>)
       initial md =
         let fields = slamDownFields md
-            updateState (SlamDownState s) = case initSlamDownState md of
+            updateSlamDownState (SlamDownState s) = case initSlamDownState md of
               SlamDownState s' ->
                 let prunedSM = foldl (flip SM.delete) s $ keysToPrune s $ SM.fromList fields
                     mergedSM = prunedSM `SM.union` s'
                 in SlamDownState mergedSM
         in cellUpdateVarMap (cell # _message .~ message fields
-                                  # _content .. _Markdown .. Ma._state %~ updateState)
+                                  # _content .. _Markdown .. Ma._state %~ updateSlamDownState)
   in maybe cell (initial <<< parseMd) input'
 
   where

--- a/src/Model/Notebook/Cell.purs
+++ b/src/Model/Notebook/Cell.purs
@@ -195,22 +195,22 @@ _Explore = prism' Explore $ \s -> case s of
 
 _Search :: PrismP CellContent Sr.SearchRec
 _Search = prism' Search $ \s -> case s of
-  Search s -> Just s
+  Search s' -> Just s'
   _ -> Nothing
 
 _Query :: PrismP CellContent Qu.QueryRec
 _Query = prism' Query $ \s -> case s of
-  Query s -> Just s
+  Query s' -> Just s'
   _ -> Nothing
 
 _Visualize :: PrismP CellContent Vz.VizRec
 _Visualize = prism' Visualize $ \s -> case s of
-  Visualize s -> Just s
+  Visualize s' -> Just s'
   _ -> Nothing
 
 _Markdown :: PrismP CellContent Ma.MarkdownRec
 _Markdown = prism' Markdown $ \s -> case s of
-  Markdown s -> Just s
+  Markdown s' -> Just s'
   _ -> Nothing
 
 _FileInput :: TraversalP CellContent FileInput

--- a/src/Model/Notebook/Cell/Viz.purs
+++ b/src/Model/Notebook/Cell/Viz.purs
@@ -24,7 +24,7 @@ import ECharts.Options
 
 import Data.Argonaut.JCursor (JCursor())
 import Data.Map (Map(), empty, keys)
-import Model.Notebook.ECharts (Semanthic(..), Axis(..), dependsOn)
+import Model.Notebook.ECharts (Semantics(..), Axis(..), dependsOn)
 import Data.Argonaut.JCursor (JCursor())
 import Optic.Core
 import qualified Data.Set as S

--- a/src/Model/Notebook/Domain.purs
+++ b/src/Model/Notebook/Domain.purs
@@ -182,7 +182,7 @@ insertCell' mbParent content oldNotebook@(Notebook n) = Tuple new cell
          ..(_parent .~ ((^. _cellId) <$> mbParent))
          # setPort
   setPort :: Cell -> Cell
-  setPort cell = cell # _output .~ (cellOut cell oldNotebook)
+  setPort c = c # _output .~ (cellOut c oldNotebook)
 
 cellOut :: Cell -> Notebook -> Port
 cellOut cell n = case cell ^._content of

--- a/src/Model/Notebook/ECharts.purs
+++ b/src/Model/Notebook/ECharts.purs
@@ -14,25 +14,25 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -}
 
-module Model.Notebook.ECharts (
-  analyzeJArray,
-  getPossibleDependencies,
-  dependsOn,
-  isComplement,
-  Axis(..),
-  Semanthic(..),
-  isValue,
-  isPercent,
-  isMoney,
-  isBool,
-  isTime,
-  isCategory,
-  isValAxis,
-  isCatAxis,
-  isTimeAxis,
-  runAxis,
-  catFromSemanthic,
-  valFromSemanthic
+module Model.Notebook.ECharts
+  ( analyzeJArray
+  , getPossibleDependencies
+  , dependsOn
+  , isComplement
+  , Axis(..)
+  , Semantics(..)
+  , isValue
+  , isPercent
+  , isMoney
+  , isBool
+  , isTime
+  , isCategory
+  , isValAxis
+  , isCatAxis
+  , isTimeAxis
+  , runAxis
+  , catFromSemantics
+  , valFromSemantics
   ) where
 
 import Prelude
@@ -75,7 +75,7 @@ dependsOn a b = a /= b &&
   dependsOn' _ _ = false
 
 
-data Semanthic
+data Semantics
   = Value Number
   | Percent Number
   | Money Number String
@@ -83,7 +83,7 @@ data Semanthic
   | Category String
   | Time String
 
-instance encodeJsonSemanthic :: EncodeJson Semanthic where
+instance encodeJsonSemantics :: EncodeJson Semantics where
   encodeJson (Value n) = "type" := "value"
                          ~> "value" := n
                          ~> jsonEmptyObject
@@ -109,7 +109,7 @@ instance encodeJsonSemanthic :: EncodeJson Semanthic where
                         ~> "value" := t
                         ~> jsonEmptyObject
 
-instance decodeJsonSemanthic :: DecodeJson Semanthic where
+instance decodeJsonSemantics :: DecodeJson Semantics where
   decodeJson json = do
     obj <- decodeJson json
     ty <- obj .? "type"
@@ -138,9 +138,9 @@ instance decodeJsonSemanthic :: DecodeJson Semanthic where
 
 
 data Axis
-  = ValAxis (L.List (Maybe Semanthic))
-  | CatAxis (L.List (Maybe Semanthic))
-  | TimeAxis (L.List (Maybe Semanthic))
+  = ValAxis (L.List (Maybe Semantics))
+  | CatAxis (L.List (Maybe Semantics))
+  | TimeAxis (L.List (Maybe Semantics))
 
 
 instance encodeJsonAxis :: EncodeJson Axis where
@@ -181,7 +181,7 @@ isTimeAxis :: Axis -> Boolean
 isTimeAxis (TimeAxis _) = true
 isTimeAxis _ = false
 
-runAxis :: Axis -> L.List (Maybe Semanthic)
+runAxis :: Axis -> L.List (Maybe Semantics)
 runAxis (ValAxis a) = a
 runAxis (CatAxis a) = a
 runAxis (TimeAxis a) = a
@@ -193,27 +193,27 @@ instance axisShow :: Show Axis where
   show (CatAxis vs) = "(CatAxis " <> show vs <> ")"
   show (TimeAxis vs) = "(TimeAxis " <> show vs <> ")"
 
-isValue :: Semanthic -> Boolean
+isValue :: Semantics -> Boolean
 isValue (Value _) = true
 isValue _ = false
 
-isPercent :: Semanthic -> Boolean
+isPercent :: Semantics -> Boolean
 isPercent (Percent _) = true
 isPercent _ = false
 
-isMoney :: Semanthic -> Boolean
+isMoney :: Semantics -> Boolean
 isMoney (Money _ _) = true
 isMoney _ = false
 
-isBool :: Semanthic -> Boolean
+isBool :: Semantics -> Boolean
 isBool (Bool _) = true
 isBool _ = false
 
-isCategory :: Semanthic -> Boolean
+isCategory :: Semantics -> Boolean
 isCategory (Category _) = true
 isCategory _ = false
 
-isTime :: Semanthic -> Boolean
+isTime :: Semantics -> Boolean
 isTime (Time _) = true
 isTime _ = false
 
@@ -222,8 +222,8 @@ isComplement (CatAxis _) (CatAxis _) = false
 isComplement (TimeAxis _) (TimeAxis _) = false
 isComplement _ _ = true
 
-catFromSemanthic :: Semanthic -> Maybe String
-catFromSemanthic v =
+catFromSemantics :: Semantics -> Maybe String
+catFromSemantics v =
   case v of
     Value v -> pure $ show v
     Percent v -> pure $ show v <> "%"
@@ -232,8 +232,8 @@ catFromSemanthic v =
     Time t -> pure t
     Bool b -> pure $ show b
 
-valFromSemanthic :: Semanthic -> Maybe Number
-valFromSemanthic v =
+valFromSemantics :: Semantics -> Maybe Number
+valFromSemantics v =
   case v of
     Value v -> pure v
     Money v _ -> pure v
@@ -241,8 +241,8 @@ valFromSemanthic v =
     _ -> Nothing
 
 
-checkSemanthics :: L.List (Maybe Semanthic) -> Maybe Axis
-checkSemanthics lst =
+checkSemantics :: L.List (Maybe Semantics) -> Maybe Axis
+checkSemantics lst =
   (ValAxis  <$> checkValues lst)   <|>
   (ValAxis  <$> checkMoney lst)    <|>
   (ValAxis  <$> checkPercent lst)  <|>
@@ -250,8 +250,8 @@ checkSemanthics lst =
   (TimeAxis <$> checkTime lst)     <|>
   (CatAxis  <$> checkCategory lst)
 
-checkPredicate :: (Semanthic -> Boolean) -> L.List (Maybe Semanthic) ->
-                  Maybe (L.List (Maybe Semanthic))
+checkPredicate :: (Semantics -> Boolean) -> L.List (Maybe Semantics) ->
+                  Maybe (L.List (Maybe Semantics))
 checkPredicate p lst =
   go 0 0 lst L.Nil
   where
@@ -272,32 +272,32 @@ checkPredicate p lst =
     -- It's incorrect. Increase incorrect counter, put nothing to accum
     | otherwise = go correct (incorrect + one) lst (L.Cons Nothing acc)
 
-  nothings :: Array Semanthic
+  nothings :: Array Semantics
   nothings = map Category [ "undefined"
                           , "null"
                           , "NA"
                           , "N/A"
                           ]
 
-checkValues :: L.List (Maybe Semanthic) -> Maybe (L.List (Maybe Semanthic))
+checkValues :: L.List (Maybe Semantics) -> Maybe (L.List (Maybe Semantics))
 checkValues = checkPredicate isValue
 
-checkMoney :: L.List (Maybe Semanthic) -> Maybe (L.List (Maybe Semanthic))
+checkMoney :: L.List (Maybe Semantics) -> Maybe (L.List (Maybe Semantics))
 checkMoney = checkPredicate isMoney
 
-checkPercent :: L.List (Maybe Semanthic) -> Maybe (L.List (Maybe Semanthic))
+checkPercent :: L.List (Maybe Semantics) -> Maybe (L.List (Maybe Semantics))
 checkPercent = checkPredicate isPercent
 
-checkBool :: L.List (Maybe Semanthic) -> Maybe (L.List (Maybe Semanthic))
+checkBool :: L.List (Maybe Semantics) -> Maybe (L.List (Maybe Semantics))
 checkBool = checkPredicate isBool
 
-checkTime :: L.List (Maybe Semanthic) -> Maybe (L.List (Maybe Semanthic))
+checkTime :: L.List (Maybe Semantics) -> Maybe (L.List (Maybe Semantics))
 checkTime = checkPredicate isTime
 
-checkCategory :: L.List (Maybe Semanthic) -> Maybe (L.List (Maybe Semanthic))
+checkCategory :: L.List (Maybe Semantics) -> Maybe (L.List (Maybe Semantics))
 checkCategory = checkPredicate isCategory
 
-instance semanthicShow :: Show Semanthic where
+instance semanthicShow :: Show Semantics where
   show (Value v) = "(Value " <> show v <> ")"
   show (Percent p) = "(Percent " <> show p <> ")"
   show (Money n s) = "(Money " <> show n <> s <> ")"
@@ -305,7 +305,7 @@ instance semanthicShow :: Show Semanthic where
   show (Category s) = "(Category " <> s <> ")"
   show (Time t) = "(Time " <> t <> ")"
 
-instance semanthicEq :: Eq Semanthic where
+instance semanthicEq :: Eq Semantics where
   eq (Value v) (Value v') = v == v'
   eq (Value v) _ = false
   eq (Percent p) (Percent p') = p == p'
@@ -319,7 +319,7 @@ instance semanthicEq :: Eq Semanthic where
   eq (Bool b) (Bool b') = b == b'
   eq (Bool _) _ = false
 
-instance semanthicOrd :: Ord Semanthic where
+instance semanthicOrd :: Ord Semantics where
   compare (Time t) (Time t') = compare t t'
   compare (Time _) _ = LT
   compare (Money v a) (Money v' a') =
@@ -339,14 +339,14 @@ instance semanthicOrd :: Ord Semanthic where
   compare (Bool _) _ = LT
 
 
-analyze :: JsonPrim -> Maybe Semanthic
+analyze :: JsonPrim -> Maybe Semantics
 analyze p = runJsonPrim p
             (const Nothing)
             (Just <<< Bool)
             (Just <<< Value)
             analyzeString
 
-analyzeString :: String -> Maybe Semanthic
+analyzeString :: String -> Maybe Semantics
 analyzeString str =
   (analyzeDate str) <|>
   (analyzeNumber str) <|>
@@ -354,7 +354,7 @@ analyzeString str =
   (analyzePercent str) <|>
   (Just $ Category str)
 
-analyzeNumber :: String -> Maybe Semanthic
+analyzeNumber :: String -> Maybe Semantics
 analyzeNumber s = do
   num <- s2n s
   i <- s2i s
@@ -362,7 +362,7 @@ analyzeNumber s = do
   pure $ Value num
 
 
-analyzePercent :: String -> Maybe Semanthic
+analyzePercent :: String -> Maybe Semantics
 analyzePercent input = do
   ms <- match rgx input
   s <- (ms !! 1)
@@ -373,7 +373,7 @@ analyzePercent input = do
 curSymbols :: String
 curSymbols = """[\$\u20A0-\u20CF\u00A2\u00A3\u00A4\u00A5\u058F\u060B\u09F2\u09F3\u09FB\u0AF1\u0BF9\u0E3F\u17DB\uA838\uFDFC\uFE69\uFF04\uFFE0\uFFE1\uFFE5\uFFE6]"""
 
-analyzeMoney :: String -> Maybe Semanthic
+analyzeMoney :: String -> Maybe Semantics
 analyzeMoney str = do
   ms <- match rgx str
   s <- (ms !! 1)
@@ -389,7 +389,7 @@ analyzeMoney str = do
   rgxStr = "^" <> curSymbols <> """?(([0-9]{1,3},([0-9]{3},)*[0-9]{3}|[0-9]+)(.[0-9][0-9])?)$"""
 
 
-analyzeDate :: String -> Maybe Semanthic
+analyzeDate :: String -> Maybe Semantics
 analyzeDate str =
   if test rgx str
   then Just $ Time str
@@ -398,15 +398,15 @@ analyzeDate str =
   rgxStr = "^(-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[0-1]|0[1-9]|[1-2][0-9]) (2[0-3]|[0-1][0-9]):([0-5][0-9]):([0-5][0-9])(\\.[0-9]+)?(Z|[+-](?:2[0-3]|[0-1][0-9]):[0-5][0-9])?$"
   rgx = regex rgxStr noFlags
 
-toSemanthic :: Json -> Map JCursor Semanthic
-toSemanthic j = fromList $ L.catMaybes ((traverse analyze) <$> toPrims j)
+toSemantics :: Json -> Map JCursor Semantics
+toSemantics j = fromList $ L.catMaybes ((traverse analyze) <$> toPrims j)
 
 
-toSemanthic' :: JArray -> Map JCursor (L.List (Maybe Semanthic))
-toSemanthic' arr =
+toSemantics' :: JArray -> Map JCursor (L.List (Maybe Semantics))
+toSemantics' arr =
   step initial mapLst
   where
-  mapArr = map toSemanthic $ reverse arr
+  mapArr = map toSemantics $ reverse arr
   mapLst = L.toList mapArr
   ks = L.toList $ nub $ concat $ map (L.fromList <<< keys) mapArr
   initial = fromList $ map (flip Tuple L.Nil) ks
@@ -426,10 +426,10 @@ analyzeJArray arr =
      arr !! 0
   -- If element returned transpose it else take initial array
   # maybe arr transpose
-  -- Produce map from JCursor to List of values (Maybe Semanthic) for every Json
-  # toSemanthic'
+  -- Produce map from JCursor to List of values (Maybe Semantics) for every Json
+  # toSemantics'
   -- Check if values of that map can be converted to axes (if can it will be Just)
-  # map checkSemanthics
+  # map checkSemantics
   -- Make list of Tuple JCursor (Maybe Axis)
   # toList
   -- lift Maybe to Tuple from Axis

--- a/src/Model/Notebook/Search.purs
+++ b/src/Model/Notebook/Search.purs
@@ -93,8 +93,6 @@ predicateToSQL (Contains (Text v)) s =
   render' v = [ "LOWER(" <> s <> ") = " <> v]
   render v = [s <> " = " <> v ]
 
-
-
 predicateToSQL (Contains (Tag v)) s = predicateToSQL (Contains (Text v)) (s <> "[*]")
 predicateToSQL (Eq v) s = qUnQ s "=" v
 predicateToSQL (Gt v) s = qUnQ s ">" v
@@ -103,7 +101,6 @@ predicateToSQL (Lt v) s = qUnQ s "<" v
 predicateToSQL (Lte v) s = qUnQ s "<=" v
 predicateToSQL (Ne v) s = qUnQ s "<>" v
 predicateToSQL (Like v) s = "LOWER( " <> s <> ")" <> " LIKE " <>  glob2like v
-predicateToSQL _ _ = ""
 
 range :: String -> String -> String -> String
 range v v' s =

--- a/src/Model/Resource.purs
+++ b/src/Model/Resource.purs
@@ -307,6 +307,7 @@ instance decodeJsonResource :: DecodeJson Resource where
       "notebook" -> parseDirPath "notebook" Notebook path
       "directory" -> parseDirPath "directory" Directory path
       "mount" -> parseDirPath "mount" Database path
+      _ -> Left "Unrecognized resource type"
     where
     parseDirPath :: String -> (DirPath -> Resource) -> String -> Either String Resource
     parseDirPath ty ctor s = maybe (Left $ "Invalid " ++ ty ++ " path") (Right <<< ctor) $ (rootDir </>) <$> (sandbox rootDir =<< parseAbsDir s)

--- a/src/View/File/Item.purs
+++ b/src/View/File/Item.purs
@@ -42,19 +42,19 @@ import qualified View.Css as Vc
 
 items :: forall e. State -> HTML e
 items state =
-  let items = state ^. _items
+  let xs = state ^. _items
   in H.div [ A.classes [B.listGroup, Vc.results] ]
-           $ zipWith (item state) (0 `range` length items) items
+           $ zipWith (item state) (0 `range` length xs) xs
 
 item :: forall e. State -> Int -> Item -> HTML e
-item state ix item =
-  case item of
+item state ix it =
+  case it of
     PhantomItem _ ->
       H.div [ A.classes [B.listGroupItem, Vc.phantom] ]
             [ H.div [ A.class_ B.row ]
                     [ H.div [ A.classes [B.colXs9, Vc.itemContent]]
                             [ H.span_ [ H.img [ A.src "img/spin.gif" ] []
-                                      , H.text $ itemName item
+                                      , H.text $ itemName it
                                       ]
                             ]
                     ]
@@ -68,19 +68,19 @@ item state ix item =
                        (if selected
                         then [B.listGroupItemInfo]
                         else []) ++
-                       (if hiddenTopLevel (itemResource item)
+                       (if hiddenTopLevel (itemResource it)
                         then if (state ^. _showHiddenFiles)
                              then [Vc.itemHidden]
                              else [B.hidden]
                         else []))
           , E.onClick (E.input_ $ inj $ ItemSelect ix)
-          , E.onDoubleClick (\_ -> pure $ openItem item (state ^. _sort) (state ^. _salt))
+          , E.onDoubleClick (\_ -> pure $ openItem it (state ^. _sort) (state ^. _salt))
           ]
           [ H.div [ A.class_ B.row ]
                   [ H.div [ A.classes [B.colXs9, Vc.itemContent] ]
-                          [ H.a [ A.href $ itemURL (state ^. _sort) (state ^. _salt) Edit item ]
-                                [ H.span_ [ H.i [ iconClasses item ] []
-                                          , H.text $ itemName item
+                          [ H.a [ A.href $ itemURL (state ^. _sort) (state ^. _salt) Edit it ]
+                                [ H.span_ [ H.i [ iconClasses it ] []
+                                          , H.text $ itemName it
                                           ]
                                 ]
                           ]
@@ -91,7 +91,7 @@ item state ix item =
                           [ H.ul [ A.classes ([B.listInline, B.pullRight])
                                  , CSS.style (marginBottom $ px 0.0)
                                  ]
-                                 $ showToolbar item state
+                                 $ showToolbar it state
                           ]
                   ]
           ]
@@ -100,7 +100,7 @@ item state ix item =
            | otherwise = resourceName <<< itemResource
 
 iconClasses :: forall i. Item -> A.Attr i
-iconClasses item = A.classes [B.glyphicon, Vc.itemIcon, iconClass $ itemResource item]
+iconClasses it = A.classes [B.glyphicon, Vc.itemIcon, iconClass $ itemResource it]
   where
   iconClass :: Resource -> A.ClassName
   iconClass (File _) = B.glyphiconFile
@@ -109,8 +109,8 @@ iconClasses item = A.classes [B.glyphicon, Vc.itemIcon, iconClass $ itemResource
   iconClass (Database _) = B.glyphiconHdd
 
 showToolbar :: forall e. Item -> State -> Array (HTML e)
-showToolbar item state =
-  let r = itemResource item
+showToolbar it state =
+  let r = itemResource it
       conf = if isDatabase r
              then [toolItem' handleConfigureItem "configure" B.glyphiconWrench]
              else []
@@ -122,4 +122,4 @@ showToolbar item state =
                   else []
   where
   toolItem' :: forall e. (Item -> Event e) -> String -> A.ClassName -> HTML e
-  toolItem' f = toolItem [] item f
+  toolItem' f = toolItem [] it f

--- a/src/View/Notebook.purs
+++ b/src/View/Notebook.purs
@@ -79,10 +79,10 @@ navigation state =
   else [ navbar [ H.div [ A.classes [Vc.header, B.clearfix] ]
                         [ icon B.glyphiconBook notebookHref
                         , logo (state ^. _version)
-                        , name state
+                        , notebookName state
                         ]
                    , H.ul [ A.classes [Vc.headerMenu] ]
-                          $ zipWith (li state) (range 0 (length state.dropdowns)) state.dropdowns
+                          $ zipWith (dropdownListItem state) (range 0 (length state.dropdowns)) state.dropdowns
                    ]
           ]
   where
@@ -142,15 +142,15 @@ newCellMenu state =
   where
   listElements :: Array (HTML e)
   listElements =
-    [ li "Query" QueryInsert B.glyphiconHdd
-    , li "Markdown" MarkdownInsert B.glyphiconEdit
-    , li "Explore" ExploreInsert B.glyphiconEyeOpen
-    , li "Search" SearchInsert B.glyphiconSearch
+    [ insertMenuItem "Query" QueryInsert B.glyphiconHdd
+    , insertMenuItem "Markdown" MarkdownInsert B.glyphiconEdit
+    , insertMenuItem "Explore" ExploreInsert B.glyphiconEyeOpen
+    , insertMenuItem "Search" SearchInsert B.glyphiconSearch
     ]
 
 
-  li :: String -> MenuInsertSignal -> A.ClassName -> HTML e
-  li title inp cls =
+  insertMenuItem :: String -> MenuInsertSignal -> A.ClassName -> HTML e
+  insertMenuItem title inp cls =
     H.li_
     [ H.button [ A.title title
                , E.onClick (\_ -> pure <<< handleMenuSignal state <<< inj $ inp)
@@ -165,8 +165,8 @@ txt :: forall e. Int -> String -> Array (HTML e)
 txt lvl text =
   [ H.text $ (joinWith "" $ replicate lvl "--") <> " " <> text ]
 
-li :: forall e. State -> Int ->  DropdownItem -> HTML e
-li state i {visible: visible, name: name, children: children} =
+dropdownListItem :: forall e. State -> Int ->  DropdownItem -> HTML e
+dropdownListItem state i {visible: visible, name: name, children: children} =
   H.li [ E.onClick (\ev -> do E.stopPropagation
                               E.input_ (Dropdown i) ev)
        , A.classes $ [ B.dropdown ] <>
@@ -194,8 +194,8 @@ menuItem state {name: name, message: mbMessage, lvl: lvl, shortcut: shortcut} =
                 | state ^. _platform == Mac = printKeyComboMac
                 | otherwise = printKeyComboLinux
 
-name :: forall e. State -> HTML e
-name state =
+notebookName :: forall e. State -> HTML e
+notebookName state =
   H.div [ A.classes [Vc.notebookName] ]
         [ H.input [ A.id_ Config.notebookNameEditorId
                   , E.onInput (pure <<< handleNameInput)


### PR DESCRIPTION
This PR fixes numerous instances of name-shadowing, and several pattern matching bugs. Partial resolution of SD-941.

I have not resolved any of the warnings for wildcard type expressions, since `psc` doesn't currently emit any source locations for these (see https://github.com/purescript/purescript/issues/1477).