### PR TITLE
Use Quasar 2.2 in tests; ensure that SD-425 is fixed

### DIFF
--- a/test/config.json
+++ b/test/config.json
@@ -430,5 +430,5 @@
     },
     "collectingScreenshots": false,
     "tmpFileForScreenshots": "image/tmp.png",
-    "version": "2.1.11"
+    "version": "2.2.0"
 }

--- a/test/index.js
+++ b/test/index.js
@@ -47,7 +47,8 @@ var url = "mongodb://" + config.mongodb.host + ":" + config.mongodb.port + "/" +
     quasarArgs = [
         "-jar", path.resolve(config.quasar.jar),
         "-c", quasarConfigPath,
-        "-C", "."
+        "-C", "./slamdata",
+        "-L", "/slamdata"
     ],
     seleniumArgs = ["-jar", path.resolve(config.selenium.jar)],
     mongoArgs = ["--port", config.mongodb.port, "--dbpath", "data"];

--- a/test/src/Test/Selenium/File.purs
+++ b/test/src/Test/Selenium/File.purs
@@ -149,8 +149,6 @@ mountDatabaseWithMountConfig mountConfig = do
     ++ mountConfig.host
     ++ ":"
     ++ show mountConfig.port
-    ++ "/"
-    ++ config.database.name
 
   fieldByField :: Check Unit
   fieldByField = do


### PR DESCRIPTION
- [x] switch to Quasar 2.2 jar
- [x] adapt to changes in behavior of Quasar's command line options
- [x] ensure that SD-425 is fixed by not providing the database name in the mount url in the tests