### PR TITLE
added '' to list of string parsed to Nothing

### DIFF
--- a/src/Model/Notebook/ECharts.purs
+++ b/src/Model/Notebook/ECharts.purs
@@ -277,6 +277,7 @@ checkPredicate p lst =
                           , "null"
                           , "NA"
                           , "N/A"
+                          , ""
                           ]
 
 checkValues :: L.List (Maybe Semantics) -> Maybe (L.List (Maybe Semantics))


### PR DESCRIPTION
This should fix SD-1023. 
Empty string now don't count as category axis marker now. 