### PR TITLE
Fix markdown dependency hash

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -37,7 +37,7 @@
     "purescript-lazy": "~0.4.0",
     "purescript-lens": "~0.8.0",
     "purescript-maps": "~0.4.0",
-    "purescript-markdown": "garyb/purescript-markdown#963fadd71113b1cb5ee8a8e590983c2e871df800",
+    "purescript-markdown": "garyb/purescript-markdown#021749b26d4a6683514d39110779938b7ff8df7e",
     "purescript-markdown-halogen": "^0.5.0",
     "purescript-minimatch": "~0.2.0",
     "purescript-nonempty": "~0.1.1",
@@ -70,7 +70,7 @@
     "purescript-transformers": "^0.6.1",
     "purescript-aff": "^0.11.3",
     "purescript-halogen": "pre-component",
-    "purescript-markdown": "963fadd71113b1cb5ee8a8e590983c2e871df800",
+    "purescript-markdown": "021749b26d4a6683514d39110779938b7ff8df7e",
     "purescript-strongcheck": "^0.13.0",
     "purescript-free": "^0.9.0"
   },


### PR DESCRIPTION
I had to rebase to fix slamdata/purescript-markdown#42, doing so changed the commit hash we were depending on. 

/cc @damonLL - once this is merged it should fix the problem you were having, sorry about that!