### PR TITLE
"Resolve" SD-1073 by fixing specific version of selenium-webdriver

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "minimist": "^1.1.2",
     "mongodb": "^2.0.39",
     "rimraf": "^2.4.2",
-    "selenium-webdriver": "^2.46.1",
+    "selenium-webdriver": "2.46.1",
     "webpack-stream": "^2.1.0"
   }
 }


### PR DESCRIPTION
It seems that they released a patch version of `selenium-webdriver` that uses the fat-arrow syntax extension to javascript, which our version of node apparently doesn't support. This cause our tests to fail to start, if you first wipe out `node_modules`. (:heart: "semantic versioning")

If there are no suggestions for improvement, let's merge this one quick so that I can get some other PRs unblocked. thanks!

https://slamdata.atlassian.net/browse/SD-1073