### PR TITLE
[travis] Switch to java build w/ Ubuntu Trusty Tahr environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,17 @@
-language: node_js
-sudo: false
-node_js:
-  - 0.12.4
+language: java
+sudo: required
+dist: trusty
+jdk:
+  - oraclejdk8
 install:
+  - sudo apt-get update
+  - sudo apt-get install -y nodejs
+  - sudo apt-get install -y npm
+
+  - sudo apt-get install imagemagick
+  - convert -version
+
+  - java -version
   - mkdir $HOME/bin
   - curl -O https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-3.0.6.tgz
   - tar -zxvf mongodb-linux-x86_64-3.0.6.tgz


### PR DESCRIPTION
Switching to the Java build because this seems to be the easiest way to get JDK 8 installed, in order to unblock #492. If someone can figure out how to install it by hand w/ curl, I'm happy to use that approach as well, but I just have no idea how.

The switch to the "trusty" environment is to be able to easily install nodejs and npm with apt-get. Additionally, apparently this environment has 7.5 Gb RAM instead of 3Gb, so we may be able to use this to unblock #491.