### PR TITLE
Ace editor setup correctly

### DIFF
--- a/wip/bower.json
+++ b/wip/bower.json
@@ -14,7 +14,7 @@
     "tests"
   ],
   "dependencies": {
-    "purescript-ace-halogen": "^0.1.0",
+    "purescript-ace-halogen": "^0.2.0",
     "purescript-affjax": "^0.8.0",
     "purescript-argonaut": "^0.10.0",
     "purescript-css": "^0.4.0",

--- a/wip/src/Entry/Dashboard.purs
+++ b/wip/src/Entry/Dashboard.purs
@@ -27,6 +27,8 @@ import DOM.BrowserFeatures.Detectors (detectBrowserFeatures)
 import Halogen (runUI, installedState)
 import Halogen.Util (appendToBody, onLoad)
 
+import Ace.Config as AceConfig
+
 import Dashboard.Component (comp, initialState)
 import Dashboard.Routing (routeSignal)
 import Dashboard.Autosave (autoSaveSignal)
@@ -34,6 +36,7 @@ import Notebook.Effects (NotebookEffects())
 
 main :: Eff NotebookEffects Unit
 main = do
+  AceConfig.set AceConfig.basePath (Config.baseUrl ++ "js/ace")
   browserFeatures <- detectBrowserFeatures
   runAff throwException (const (pure unit)) $ do
     app <- runUI comp $ installedState $ initialState browserFeatures

--- a/wip/src/Notebook/Cell/CellType.purs
+++ b/wip/src/Notebook/Cell/CellType.purs
@@ -14,7 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -}
 
-module Notebook.Cell.CellType (CellType(..)) where
+module Notebook.Cell.CellType (CellType(..), cellName, cellGlyph) where
+
+import Halogen.HTML (ClassName())
+import Halogen.Themes.Bootstrap3 as B
 
 data CellType
   = Explore
@@ -22,3 +25,17 @@ data CellType
   | Query
   | Search
   | Viz
+
+cellName :: CellType -> String
+cellName Explore = "Explore"
+cellName Markdown = "Markdown"
+cellName Query = "Query"
+cellName Search = "Search"
+cellName Viz = "Visualize"
+
+cellGlyph :: CellType -> ClassName
+cellGlyph Explore = B.glyphiconEyeOpen
+cellGlyph Markdown = B.glyphiconEdit
+cellGlyph Query = B.glyphiconHdd
+cellGlyph Search = B.glyphiconSearch
+cellGlyph Viz = B.glyphiconPicture

--- a/wip/src/Notebook/Cell/Markdown/Component.purs
+++ b/wip/src/Notebook/Cell/Markdown/Component.purs
@@ -24,6 +24,7 @@ import Prelude
 
 import Control.Bind ((=<<))
 
+import Data.BrowserFeatures (BrowserFeatures())
 import Data.Either (Either(..))
 import Data.Lens (preview)
 import Data.Maybe (Maybe(..))
@@ -37,6 +38,7 @@ import Text.Markdown.SlamDown.Html (SlamDownConfig(), SlamDownState(), SlamDownQ
 
 import Render.CssClasses as CSS
 
+import Notebook.Cell.CellId (CellId(), runCellId)
 import Notebook.Cell.Component (CellQueryP(), CellStateP(), makeResultsCellComponent, makeQueryPrism, _MarkdownState, _MarkdownQuery)
 import Notebook.Cell.Common.EvalQuery (CellEvalQuery(..))
 import Notebook.Cell.Markdown.Component.Query
@@ -44,13 +46,19 @@ import Notebook.Cell.Markdown.Component.State
 import Notebook.Cell.Port (Port(..), _SlamDown)
 import Notebook.Common (Slam())
 
-markdownComponent :: SlamDownConfig -> Component CellStateP CellQueryP Slam
-markdownComponent config = makeResultsCellComponent
+markdownComponent :: CellId -> BrowserFeatures -> Component CellStateP CellQueryP Slam
+markdownComponent cellId browserFeatures = makeResultsCellComponent
   { component: parentComponent render eval
   , initialState: installedState config
   , _State: _MarkdownState
   , _Query: makeQueryPrism _MarkdownQuery
   }
+  where
+  config :: SlamDownConfig
+  config =
+    { formName: "cell-" ++ show (runCellId cellId)
+    , browserFeatures: browserFeatures
+    }
 
 render :: SlamDownConfig -> ParentHTML SlamDownState CellEvalQuery SlamDownQuery Slam Unit
 render config =

--- a/wip/src/Notebook/Cell/Markdown/Eval.purs
+++ b/wip/src/Notebook/Cell/Markdown/Eval.purs
@@ -1,0 +1,32 @@
+{-
+Copyright 2015 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
+module Notebook.Cell.Markdown.Eval where
+
+import Prelude
+
+import Data.Maybe (Maybe(..))
+
+import Text.Markdown.SlamDown.Parser (parseMd)
+
+import Notebook.Cell.Common.EvalQuery (CellEvalResult())
+import Notebook.Cell.Port (Port(..))
+
+markdownEval :: String -> CellEvalResult
+markdownEval s =
+  { messages: []
+  , output: Just $ SlamDown (parseMd s)
+  }

--- a/wip/src/Notebook/Component.purs
+++ b/wip/src/Notebook/Component.purs
@@ -44,7 +44,7 @@ import Halogen.Themes.Bootstrap3 as B
 import Render.Common (glyph, fadeWhen)
 import Render.CssClasses as CSS
 
-import Notebook.Cell.CellType (CellType(..))
+import Notebook.Cell.CellType (CellType(..), cellName, cellGlyph)
 import Notebook.Cell.Component (CellQuery(..), CellQueryP(), CellStateP())
 import Notebook.Cell.Port (Port(..))
 import Notebook.CellSlot (CellSlot(..), CellId())
@@ -89,23 +89,22 @@ newCellMenu state =
                 else B.glyphiconPlus
             ]
         ]
-    , insertMenuItem "Query" Query B.glyphiconHdd
-    , insertMenuItem "Markdown" Markdown B.glyphiconEdit
-    , insertMenuItem "Explore" Explore B.glyphiconEyeOpen
-    , insertMenuItem "Search" Search B.glyphiconSearch
+    , insertMenuItem Query
+    , insertMenuItem Markdown
+    , insertMenuItem Explore
+    , insertMenuItem Search
     ]
   where
-  insertMenuItem :: String -> CellType -> H.ClassName -> NotebookHTML
-  insertMenuItem title cellType cls =
+  insertMenuItem :: CellType -> NotebookHTML
+  insertMenuItem cellType =
     H.li_
       [ H.button
-          [ P.title title
+          [ P.title (cellName cellType)
           , E.onClick $ E.input_ (AddCell cellType)
           , P.classes (fadeWhen $ not (state.isAddingCell))
           ]
-          [ glyph cls ]
+          [ glyph (cellGlyph cellType) ]
       ]
-
 
 eval :: Natural NotebookQuery NotebookDSL
 eval (AddCell cellType next) = modify (addCell cellType Nothing) $> next

--- a/wip/src/Notebook/Component/State.purs
+++ b/wip/src/Notebook/Component/State.purs
@@ -44,10 +44,11 @@ import Halogen
 
 import Notebook.AccessType (AccessType(..))
 import Notebook.Cell.Ace.Component (aceComponent)
-import Notebook.Cell.CellId (CellId(..), runCellId)
+import Notebook.Cell.CellId (CellId(..))
 import Notebook.Cell.CellType (CellType(..))
 import Notebook.Cell.Component
 import Notebook.Cell.Markdown.Component (markdownComponent)
+import Notebook.Cell.Markdown.Eval (markdownEval)
 import Notebook.Cell.Port (Port())
 import Notebook.CellSlot (CellSlot(..))
 import Notebook.Common (Slam())
@@ -88,7 +89,7 @@ type CellDef =
 initialNotebook :: BrowserFeatures -> NotebookState
 initialNotebook fs =
   { fresh: 0
-  , accessType: ReadOnly
+  , accessType: Editable
   , cells: mempty
   , dependencies: M.empty
   , values: M.empty
@@ -108,13 +109,11 @@ addCell cellType parent st =
   let editorId = CellId st.fresh
       resultsId = CellId $ st.fresh + 1
       editor = case cellType of
-        -- Markdown -> { component: markdownComponent newId st.browserFeatures, initialState: installedState initCellState }
-        _ -> { component: aceComponent
+        _ -> { component: aceComponent Markdown markdownEval "ace/mode/markdown"
              , initialState: installedState (initEditorCellState st.accessType Visible)
              }
       results = case cellType of
-        -- Markdown -> { component: markdownComponent newId st.browserFeatures, initialState: installedState initCellState }
-        _ -> { component: markdownComponent { formName: "cell-" ++ (show $ runCellId resultsId), browserFeatures: st.browserFeatures }
+        _ -> { component: markdownComponent resultsId st.browserFeatures
              , initialState: installedState (initResultsCellState st.accessType Visible)
              }
       dependencies = M.insert resultsId editorId st.dependencies


### PR DESCRIPTION
Ace is now configured to autosize and has the appropriate theme and mode applied.

The component constructor was enhanced to include the cell type so the correct heading/glyphicon can be displayed, and the eval behaviour is passed in rather than being locked to markdown evaluation.