### PR TITLE
Lift the eval/run for Markdown cells into Slam

### DIFF
--- a/wip/src/Notebook/Cell/Ace/Component.purs
+++ b/wip/src/Notebook/Cell/Ace/Component.purs
@@ -44,7 +44,7 @@ import Notebook.Cell.Common.EvalQuery (CellEvalQuery(..), CellEvalResult())
 import Notebook.Cell.Component (CellStateP(), CellQueryP(), makeEditorCellComponent, makeQueryPrism, _AceState, _AceQuery)
 import Notebook.Common (Slam())
 
-aceComponent :: CellType -> (String -> CellEvalResult) -> String -> Component CellStateP CellQueryP Slam
+aceComponent :: CellType -> (String -> Slam CellEvalResult) -> String -> Component CellStateP CellQueryP Slam
 aceComponent cellType run mode = makeEditorCellComponent
   { name: cellName cellType
   , glyph: cellGlyph cellType
@@ -74,4 +74,5 @@ aceComponent cellType run mode = makeEditorCellComponent
   eval :: Natural CellEvalQuery (ParentDSL Unit AceState CellEvalQuery AceQuery Slam Unit)
   eval (EvalCell _ k) = do
     content <- fromMaybe "" <$> query unit (request GetText)
-    pure $ k (run content)
+    result <- liftH $ liftAff' $ run content
+    pure $ k result

--- a/wip/src/Notebook/Cell/Component.purs
+++ b/wip/src/Notebook/Cell/Component.purs
@@ -15,7 +15,8 @@ limitations under the License.
 -}
 
 module Notebook.Cell.Component
-  ( makeEditorCellComponent
+  ( CellComponent()
+  , makeEditorCellComponent
   , makeResultsCellComponent
   , module Notebook.Cell.Component.Def
   , module Notebook.Cell.Component.Query
@@ -49,11 +50,14 @@ import Notebook.Cell.Component.Render (CellHTML(), header, statusBar)
 import Notebook.Cell.Component.State
 import Notebook.Common (Slam())
 
+-- | Type synonym for the full type of a cell component.
+type CellComponent = Component CellStateP CellQueryP Slam
+
 -- | Constructs a cell component for an editor-style cell.
 makeEditorCellComponent
   :: forall s f
    . EditorCellDef s f
-  -> Component CellStateP CellQueryP Slam
+  -> CellComponent
 makeEditorCellComponent def = makeCellComponentPart def render
   where
   render :: Component AnyCellState InnerCellQuery Slam -> AnyCellState -> CellState -> CellHTML
@@ -74,7 +78,7 @@ makeEditorCellComponent def = makeCellComponentPart def render
 makeResultsCellComponent
   :: forall s f
    . ResultsCellDef s f
-  -> Component CellStateP CellQueryP Slam
+  -> CellComponent
 makeResultsCellComponent def = makeCellComponentPart def render
   where
   render :: Component AnyCellState InnerCellQuery Slam -> AnyCellState -> CellState -> CellHTML
@@ -103,7 +107,7 @@ makeCellComponentPart
   :: forall s f r
    . Object (CellDefProps s f r)
   -> (Component AnyCellState InnerCellQuery Slam -> AnyCellState -> CellState -> CellHTML)
-  -> Component CellStateP CellQueryP Slam
+  -> CellComponent
 makeCellComponentPart def render =
   parentComponent (render component initialState) eval
   where

--- a/wip/src/Notebook/Cell/Component/State.purs
+++ b/wip/src/Notebook/Cell/Component/State.purs
@@ -43,7 +43,7 @@ import Notebook.Cell.Ace.Component.State
 import Notebook.Cell.Component.Query
 import Notebook.Cell.Explore.State
 import Notebook.Cell.Markdown.Component.State
-import Notebook.Cell.Query.State
+import Notebook.Cell.Query.Component.State
 import Notebook.Cell.Search.State
 import Notebook.Cell.Viz.State
 import Notebook.Common (Slam())

--- a/wip/src/Notebook/Cell/Markdown/Eval.purs
+++ b/wip/src/Notebook/Cell/Markdown/Eval.purs
@@ -24,9 +24,10 @@ import Text.Markdown.SlamDown.Parser (parseMd)
 
 import Notebook.Cell.Common.EvalQuery (CellEvalResult())
 import Notebook.Cell.Port (Port(..))
+import Notebook.Common (Slam())
 
-markdownEval :: String -> CellEvalResult
-markdownEval s =
+markdownEval :: String -> Slam CellEvalResult
+markdownEval s = pure
   { messages: []
   , output: Just $ SlamDown (parseMd s)
   }

--- a/wip/src/Notebook/Cell/Query/Eval.purs
+++ b/wip/src/Notebook/Cell/Query/Eval.purs
@@ -14,6 +14,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -}
 
-module Notebook.Cell.Query.Component.State (QueryState()) where
+module Notebook.Cell.Query.Eval where
 
-type QueryState = {}
+import Prelude
+
+import Data.Either (Either(..))
+import Data.Maybe (Maybe(..))
+
+import Notebook.Cell.Common.EvalQuery (CellEvalResult())
+import Notebook.Cell.Port (Port(..))
+import Notebook.Common (Slam())
+
+queryEval :: String -> Slam CellEvalResult
+queryEval s = pure
+  { messages: [Left "The query cell has not been implemented yet"]
+  , output: Nothing
+  }


### PR DESCRIPTION
It occurred to me that we can't have this as a pure function, as the query cell will need to do Quasar-things to produce a resource to pass on to the jtable results view.