### PR TITLE
Contains -> glob, Like -> regex

### DIFF
--- a/test/config.json
+++ b/test/config.json
@@ -184,7 +184,7 @@
         "searchInput": ".search-cell-input",
         "searchButton": ".search-cell-button",
         "searchClear": ".search-clear",
-        "allQuery": "~*",
+        "allQuery": "*",
         "incorrectQuery": "::"
     },
     "explore": {
@@ -253,7 +253,7 @@
             "rows": 9
         },
         {
-            "query": "pop:>10000 city:~b*",
+            "query": "pop:>10000 city:~\"^b.*\"",
             "pages": 1,
             "rows": 1
         }


### PR DESCRIPTION
Notebook app. Search cell. 

* __Contains__ query now works as glob search. If there is no special chars in __contains__ query it uses old semantic (i.e. `foo -> *foo*`)
* __Like__ query now takes regexps. (Most of regexp special chars are reserved, so it almost always will appear between `"` e.g. `foo:"^trololo\d+"`)
* changed queries in tests config. 

@jonsterling please review