### PR TITLE
[SD-1144] Update Quasar jar to 2.2.3 [failing]

### DIFF
--- a/src/Api/Common.purs
+++ b/src/Api/Common.purs
@@ -46,6 +46,9 @@ import qualified Data.String as S
 successStatus :: StatusCode
 successStatus = StatusCode 200
 
+notFoundStatus :: StatusCode
+notFoundStatus = StatusCode 404
+
 succeeded :: StatusCode -> Boolean
 succeeded (StatusCode int) =
   200 <= code && code < 300
@@ -63,6 +66,7 @@ retryGet =
                 , delayCurve: const 1000
                 , timeout: Just 30000
                 }
+
 getOnce :: forall e a fd. (Respondable a) => Path Abs fd Sandboxed -> Affjax (RetryEffects e) a
 getOnce = getWithPolicy defaultRetryPolicy
 

--- a/src/Api/Fs.purs
+++ b/src/Api/Fs.purs
@@ -17,34 +17,44 @@ limitations under the License.
 module Api.Fs where
 
 import Prelude
-import Api.Common (RetryEffects(), succeeded, getResponse, retryGet, retryDelete, retryPut, slamjax, getOnce, ldJSON)
+
+import Api.Common (RetryEffects(), succeeded, notFoundStatus, getWithPolicy, getResponse, retryGet, retryDelete, retryPut, slamjax, getOnce, ldJSON)
+
 import Control.Apply ((*>))
 import Control.Bind ((>=>))
-import Control.Monad.Aff (Aff())
+import Control.Monad.Aff (Aff(), attempt)
 import Control.Monad.Eff.Exception (error)
 import Control.Monad.Error.Class (throwError)
+
 import Data.Argonaut.Core (Json())
 import Data.Argonaut.Decode (decodeJson)
 import Data.Argonaut.Parser (jsonParser)
+
 import Data.Array (head, tail, findIndex, filter, elemIndex, (:))
 import Data.Bifunctor (bimap)
 import Data.Either (Either(..), either)
+
 import Data.Foreign (Foreign(), F(), parseJSON)
-import Data.Foreign.Index (prop)
 import Data.Foreign.Class (readProp, read, IsForeign)
+import Data.Foreign.Index (prop)
+import Data.Foreign.NullOrUndefined
+
 import Data.Maybe
 import Data.Path.Pathy
 import Data.These (These(..), theseLeft, theseRight)
 import Data.Tuple (Tuple(..))
+
 import Model.Path
 import Model.Notebook.Cell
 import Model.Notebook.Port
+
 import Network.HTTP.Affjax (Affjax(), AJAX(), affjax, defaultRequest)
 import Network.HTTP.Affjax.Response (Respondable, ResponseType(JSONResponse))
 import Network.HTTP.Method (Method(..))
 import Network.HTTP.RequestHeader (RequestHeader(..))
 import Network.HTTP.MimeType (MimeType())
 import Network.HTTP.MimeType.Common (applicationJSON)
+
 import Optic.Core
 
 import qualified Data.Maybe.Unsafe as U
@@ -61,7 +71,9 @@ runListing :: Listing -> Array R.Resource
 runListing (Listing rs) = rs
 
 instance listingIsForeign :: IsForeign Listing where
-  read f = Listing <$> readProp "children" f
+  read f = do
+    children <- runNullOrUndefined <$> readProp "children" f
+    pure $ Listing $ fromMaybe [] children
 
 instance listingRespondable :: Respondable Listing where
   responseType = JSONResponse
@@ -78,10 +90,16 @@ children' p = runListing <$> (getResponse msg $ listing p)
   msg = "error getting resource children"
 
 listing :: forall e. DirPath -> Affjax (RetryEffects e) Listing
-listing p = maybe
-              (throwError $ error "incorrect path")
-              (\p -> retryGet $ (Config.metadataUrl </> p))
-              $ relativeTo p rootDir
+listing p =
+  case relativeTo p rootDir of
+    Nothing -> throwError $ error "incorrect path"
+    Just p ->
+      getWithPolicy
+        { shouldRetryWithStatusCode: \c -> not (succeeded c || c == notFoundStatus)
+        , delayCurve: const 1000
+        , timeout: Just 10000
+        }
+        (Config.metadataUrl </> p)
 
 makeFile :: forall e. FilePath -> MimeType -> String -> Aff (RetryEffects (ajax :: AJAX | e)) Unit
 makeFile path mime content =
@@ -182,7 +200,7 @@ saveNotebook notebook = case notebook ^. N._name of
 -- | the end of the name.
 getNewName :: forall e. DirPath -> String -> Aff (RetryEffects (ajax :: AJAX | e)) String
 getNewName parent name = do
-  items <- children' parent
+  items <- attempt (children' parent) <#> either (const []) id
   pure if exists' name items then getNewName' items 1 else name
   where
   getNewName' items i =

--- a/test/config.json
+++ b/test/config.json
@@ -430,5 +430,5 @@
     },
     "collectingScreenshots": false,
     "tmpFileForScreenshots": "image/tmp.png",
-    "version": "2.2.2"
+    "version": "2.2.3"
 }


### PR DESCRIPTION
For some reason, the tests fail in `move delete file`. Here's what happens:

1. The file is found & renamed
2. The renamed item is found and its delete button is pressed

Now, at this point, the file should disappear, having been deleted. But it does not, and so the tests eventually bail out.

***Here's the spooky part: If I manually intervene and click the delete button myself at this point, it works fine. What gives?*** It sounds like some stupid webdriver issue, but I honestly have no idea.

@beckyconning or @cryogenian Do you have any idea what's going on? This is blocking my main PR, #534 / [SD-980](https://slamdata.atlassian.net/browse/SD-980).