### PR TITLE
grid percent, 30 degrees rotation in bar and line axis label

### DIFF
--- a/src/Controller/Notebook/Cell/Viz/Bar.purs
+++ b/src/Controller/Notebook/Cell/Viz/Bar.purs
@@ -131,10 +131,16 @@ mkSeries acc =
   Tuple xAxis series
   where
   xAxis :: Axises
-  xAxis = OneAxis $ Axis
-          axisDefault { "type" = Just CategoryAxis
-                      , "data" = Just $ CommonAxisData <$> catVals
-                      }
+  xAxis = OneAxis $ Axis axisDefault
+          { "type" = Just CategoryAxis
+          , "data" = Just $ CommonAxisData <$> catVals
+          , axisLabel = Just $ AxisLabel axisLabelDefault
+            { rotate = Just 30.0
+            }
+          , axisTick = Just $ AxisTick axisTickDefault
+            { interval = Just $ Custom zero
+            }
+          }
 
   keysArray :: Array Key
   keysArray = L.fromList $ keys acc
@@ -186,14 +192,15 @@ mkSeries acc =
 
   serie :: Tuple String (Array Number) -> Series
   serie (Tuple name nums) =
-  BarSeries { common: universalSeriesDefault { name = if name == ""
-                                                      then Nothing
-                                                      else Just name
-                                             }
-
-            , barSeries: barSeriesDefault { "data" = Just $ simpleData <$> (nums)
-                                          , stack = Just $ "total" <> stackFromName name
-                                          }
+  BarSeries { common: universalSeriesDefault
+                      { name = if name == ""
+                               then Nothing
+                               else Just name
+                      }
+            , barSeries: barSeriesDefault
+                         { "data" = Just $ simpleData <$> (nums)
+                         , stack = Just $ "total" <> stackFromName name
+                         }
             }
   stackFromName :: String -> String
   stackFromName str =
@@ -213,9 +220,13 @@ mkBar r conf =
       Option optionDefault { series = Just $ Just <$> series
                            , xAxis = Just xAxis
                            , yAxis = Just yAxis
-                           , tooltip = Just $ Tooltip $
-                                       tooltipDefault {trigger = Just TriggerAxis}
+                           , tooltip = Just $ Tooltip $ tooltipDefault
+                             { trigger = Just TriggerAxis
+                             }
                            , legend = Just $ mkLegend series
+                           , grid = Just $ Grid gridDefault
+                             { y2 = Just $ Percent 15.0
+                             }
                            }
 
   where

--- a/src/Controller/Notebook/Cell/Viz/Line.purs
+++ b/src/Controller/Notebook/Cell/Viz/Line.purs
@@ -165,19 +165,26 @@ mkSeries needTwoAxis ty acc =
   catVals :: Array String
   catVals = nub $ keyCategory <$> keysArray
 
-  xAxis = OneAxis $ Axis
-          axisDefault { "type" = Just ty
-                      , "data" = Just $ CommonAxisData <$> catVals
-                      }
+  xAxis = OneAxis $ Axis axisDefault
+          { "type" = Just ty
+          , "data" = Just $ CommonAxisData <$> catVals
+          , axisLabel = Just $ AxisLabel axisLabelDefault
+            { rotate = Just 30.0
+            }
+          , axisTick = Just $ AxisTick axisTickDefault
+            { interval = Just $ Custom zero
+            }
+          }
 
   serie :: Number -> Tuple String (Array Number) -> Series
   serie ix (Tuple name nums) =
     LineSeries { common: if name == ""
                          then universalSeriesDefault
                          else universalSeriesDefault { "name" = Just name }
-               , lineSeries: lineSeriesDefault { "data" = Just $ simpleData <$> (nums)
-                                               , yAxisIndex = Just ix
-                                               }
+               , lineSeries: lineSeriesDefault
+                 { "data" = Just $ simpleData <$> (nums)
+                 , yAxisIndex = Just ix
+                 }
                }
   firstSerie :: Tuple String (Array Number) -> Series
   firstSerie = serie 0.0
@@ -247,12 +254,15 @@ mkLine r conf =
       Option optionDefault { series = Just $ Just <$> series
                            , xAxis = Just xAxis
                            , yAxis = Just yAxis
-                           , tooltip = Just $ Tooltip $
-                                       tooltipDefault {trigger = Just TriggerItem}
+                           , tooltip = Just $ Tooltip $ tooltipDefault
+                             { trigger = Just TriggerItem
+                             }
                            , legend = Just $ mkLegend series
+                           , grid = Just $ Grid gridDefault
+                             { y2 = Just $ Percent 15.0
+                             }
                            }
   where
-
   mkLegend :: (Array Series) -> Legend
   mkLegend series =
     Legend legendDefault { "data" = Just $ legendItemDefault <$> extractNames series}


### PR DESCRIPTION
Screenshots for meaningless data 
<img width="557" alt="2015-11-30 13 40 37" src="https://cloud.githubusercontent.com/assets/10245930/11469532/07b0c988-9768-11e5-8981-ff748b5936ea.png">
<img width="739" alt="2015-11-30 13 28 28" src="https://cloud.githubusercontent.com/assets/10245930/11469534/0bc52226-9768-11e5-9264-1a601cb82b15.png">
<img width="725" alt="2015-11-30 13 27 16" src="https://cloud.githubusercontent.com/assets/10245930/11469535/10034b60-9768-11e5-9a1e-c5939e421234.png">

+ Axis label area height now is 15% of total height
+ Axis label texts is rotated by 30 degrees 

This allow users to see at least 15-20 labels by default and more if they enlarge chart. 

@jdegoes Is this ok? Unfortunately echarts doesn't provide api to get label height/width -- it really hard to say if 15%/30° is enough or too big for every situation. I suggest to add two more inputs to viz-form builder in __new-halogen__: one for label rotation and other for label text size (with default values 12pt and 30 degrees). But I'm not sure that such addition won't make form too complicated. Or try to find empirical rules of rotation and font decreasing.

Example of chart size change
<img width="755" alt="2015-11-30 13 47 13" src="https://cloud.githubusercontent.com/assets/10245930/11469643/e3a08488-9768-11e5-8349-05ada6e4f448.png">
<img width="545" alt="2015-11-30 13 47 03" src="https://cloud.githubusercontent.com/assets/10245930/11469648/e863fe5a-9768-11e5-8174-4a5442a3c029.png">

https://slamdata.atlassian.net/browse/SD-1166