### PR TITLE
SD-1166

### DIFF
--- a/less/main.less
+++ b/less/main.less
@@ -562,16 +562,20 @@ ol.breadcrumb {
         width: 200px;
     }
 }
-
-form.chart-configure-form {
+.chart-configuration(@label-width) {
     padding-bottom: 10px;
     label.control-label {
-        width: 75px;
+        width: @label-width;
     }
     select.form-control, input.form-control {
-        width: ~"calc(100% - 75px)";
+        width: calc(~"100% - " @label-width);
         display: inline-block;
     }
+}
+
+
+form.chart-configure-form {
+    .chart-configuration(@label-width: 75px);
     &.with-aggregation {
         div {
             width: ~"calc(100% - 75px)";
@@ -585,6 +589,12 @@ form.chart-configure-form {
             }
         }
     }
+}
+form.chart-size-param {
+    .chart-configuration(75px);
+}
+form.axis-label-param {
+    .chart-configuration(120px);
 }
 
 div.loading-message.alert.alert-info {

--- a/wip/src/Form/SelectPair/Component.purs
+++ b/wip/src/Form/SelectPair/Component.purs
@@ -64,6 +64,7 @@ type QueryP a b = Coproduct (Query a) (ChildF Unit (Query b))
 type PairConfig a r =
   { disableWhen :: Int -> Boolean
   , defaultWhen :: Int -> Boolean
+  , ariaLabel :: Maybe String
   , mainState :: Select a
   , classes :: Array H.ClassName
   | r

--- a/wip/src/Halogen/CustomProps/Indexed.purs
+++ b/wip/src/Halogen/CustomProps/Indexed.purs
@@ -35,3 +35,9 @@ mbValueInput
   :: forall i r
    . (String -> EventHandler (Maybe i)) -> IProp (value :: I, onInput :: I | r) i
 mbValueInput = unsafeCoerce Cp.mbValueInput
+
+nonSubmit :: forall i r . IProp (onSubmit :: I | r) i
+nonSubmit = unsafeCoerce Cp.nonSubmit
+
+ariaLabel :: forall i r. String -> IProp (|r) i
+ariaLabel = unsafeCoerce Cp.ariaLabel

--- a/wip/src/Model/ChartConfiguration.purs
+++ b/wip/src/Model/ChartConfiguration.purs
@@ -20,9 +20,11 @@ import Prelude
 
 import Data.Argonaut
   (JCursor(), EncodeJson, DecodeJson, (:=), (~>), (.?), decodeJson, jsonEmptyObject)
-import Data.Array (filter)
+import Data.Array (filter, cons)
+import Data.Foldable (any)
 import Data.Lens (LensP(), lens, (^.))
 import Data.Maybe (maybe)
+import Data.Monoid (mempty)
 import Model.Aggregation (Aggregation())
 import Model.ChartAxis (dependsOn)
 import Model.Select (Select(), _value)
@@ -34,6 +36,9 @@ depends sel lst = maybe lst go (sel ^. _value)
   where
   go y = filter (dependsOn y) lst
 
+dependsOnArr :: Array JCursor -> Array JCursor -> Array JCursor
+dependsOnArr dependency arr =
+  filter (flip any dependency <<< dependsOn) arr
 
 type ChartConfigurationR =
  { series :: Array JSelect

--- a/wip/src/Model/ChartOptions.purs
+++ b/wip/src/Model/ChartOptions.purs
@@ -28,10 +28,31 @@ import Model.ChartOptions.Pie (buildPie)
 import Model.ChartOptions.Bar (buildBar)
 import Model.ChartOptions.Line (buildLine)
 
-buildOptions :: ChartType -> JArray -> ChartConfiguration -> Option
-buildOptions ty jarr conf = buildOptions_ ty (analyzeJArray jarr) conf
+type BuildOptions o =
+  { chartType :: ChartType
+  , records :: JArray
+  , axisLabelAngle :: Int
+  , axisLabelFontSize :: Int
+  | o }
 
-buildOptions_ :: ChartType -> M.Map JCursor Axis -> ChartConfiguration -> Option
-buildOptions_ Pie mp conf = buildPie mp conf
-buildOptions_ Bar mp conf = buildBar mp conf
-buildOptions_ Line mp conf = buildLine mp conf
+buildOptions
+  :: forall o
+   . BuildOptions o -> ChartConfiguration -> Option
+buildOptions args conf =
+  buildOptions_
+  args.chartType
+  (analyzeJArray args.records)
+  args.axisLabelAngle
+  args.axisLabelFontSize
+  conf
+
+buildOptions_
+  :: ChartType
+  -> M.Map JCursor Axis
+  -> Int
+  -> Int
+  -> ChartConfiguration
+  -> Option
+buildOptions_ Pie mp _ _ conf = buildPie mp conf
+buildOptions_ Bar mp angle size conf = buildBar mp angle size conf
+buildOptions_ Line mp angle size conf = buildLine mp angle size conf

--- a/wip/src/Model/ChartOptions/Bar.purs
+++ b/wip/src/Model/ChartOptions/Bar.purs
@@ -33,14 +33,19 @@ import Model.ChartAxis as Ax
 import Model.ChartConfiguration (ChartConfiguration())
 import Model.ChartOptions.Common
 
-buildBar :: M.Map JCursor Ax.Axis -> ChartConfiguration -> Option
-buildBar axises conf = case axisSeriesPair of
-  Tuple xAxis series ->
+buildBar
+  :: M.Map JCursor Ax.Axis -> Int -> Int -> ChartConfiguration -> Option
+buildBar axises angle size conf = case axisSeriesPair of
+  Tuple xAxisR series ->
     Option optionDefault { series = Just $ map Just series
-                         , xAxis = Just xAxis
+                         , xAxis = Just $ OneAxis $ Axis
+                                   $ mixAxisLabelAngleAndFontSize angle size xAxisR
                          , yAxis = Just yAxis
                          , tooltip = Just tooltip
                          , legend = Just $ mkLegend series
+                         , grid = Just $ Grid gridDefault
+                           { y2 = Just $ Percent 15.0
+                           }
                          }
   where
   tooltip :: Tooltip
@@ -57,7 +62,7 @@ buildBar axises conf = case axisSeriesPair of
   extractName (BarSeries r) = r.common.name
   extractName _ = Nothing
 
-  axisSeriesPair :: Tuple Axises (Array Series)
+  axisSeriesPair :: Tuple AxisRec (Array Series)
   axisSeriesPair = mkSeries extracted
 
   extracted :: PieBarData
@@ -66,13 +71,15 @@ buildBar axises conf = case axisSeriesPair of
   yAxis :: Axises
   yAxis = OneAxis $ Axis $ axisDefault { "type" = Just ValueAxis }
 
-mkSeries :: PieBarData -> Tuple Axises (Array Series)
+mkSeries :: PieBarData -> Tuple AxisRec (Array Series)
 mkSeries pbData = Tuple xAxis series
   where
-  xAxis :: Axises
-  xAxis = OneAxis $ Axis
-          axisDefault { "type" = Just CategoryAxis
+  xAxis :: AxisRec
+  xAxis = axisDefault { "type" = Just CategoryAxis
                       , "data" = Just $ map CommonAxisData catVals
+                      , axisTick = Just $ AxisTick axisTickDefault
+                        { interval = Just $ Custom zero
+                        }
                       }
 
   keysArray :: Array Key

--- a/wip/src/Model/ChartOptions/Common.purs
+++ b/wip/src/Model/ChartOptions/Common.purs
@@ -24,12 +24,14 @@ import Data.Array (catMaybes, cons, (!!))
 import Data.Array as A
 import Data.Bifunctor (lmap)
 import Data.Foldable (foldl)
+import Data.Int (toNumber)
 import Data.Lens (view)
 import Data.List (List(..), replicate, length)
 import Data.List as L
 import Data.Maybe (fromMaybe, maybe, Maybe(..))
 import Data.Map (Map())
 import Data.Map as M
+import ECharts
 import Model.ChartConfiguration (ChartConfiguration(..), JSelect())
 import Model.ChartSemantics (Semantics(), printSemantics, semanticsToNumber)
 import Model.Aggregation (Aggregation(..), runAggregation)
@@ -173,3 +175,13 @@ commonNameMap fn catVals = mapByCategories <<< fn <<< groupByCategories
 
   alterNamed :: Number -> Maybe (Array Number) -> Maybe (Array Number)
   alterNamed n ns = Just $ A.cons n $ fromMaybe [] ns
+
+mixAxisLabelAngleAndFontSize :: Int -> Int -> AxisRec -> AxisRec
+mixAxisLabelAngleAndFontSize angle size r =
+  r { axisLabel = Just $ AxisLabel axisLabelDefault
+      { rotate = Just $ toNumber angle
+      , textStyle = Just $ TextStyle textStyleDefault
+        { fontSize = Just $ toNumber size
+        }
+      }
+    }

--- a/wip/src/Model/ChartType.purs
+++ b/wip/src/Model/ChartType.purs
@@ -24,6 +24,18 @@ import Data.Either (Either(..))
 
 data ChartType = Pie | Line | Bar
 
+isPie :: ChartType -> Boolean
+isPie Pie = true
+isPie _ = false
+
+isLine :: ChartType -> Boolean
+isLine Line = true
+isLine _ = false
+
+isBar :: ChartType -> Boolean
+isBar Bar = true
+isBar _ = false
+
 parseChartType :: String -> Either String ChartType
 parseChartType "pie" = pure Pie
 parseChartType "line" = pure Line

--- a/wip/src/Notebook/Cell/Viz/Component/Query.purs
+++ b/wip/src/Notebook/Cell/Viz/Component/Query.purs
@@ -31,6 +31,8 @@ data VizQuery a
   | SetWidth Int a
   | SetAvailableChartTypes (Set ChartType) a
   | SetChartType ChartType a
+  | RotateAxisLabel Int a
+  | SetAxisFontSize Int a
 
 type VizQueryP =
   Coproduct

--- a/wip/src/Notebook/Cell/Viz/Component/State.purs
+++ b/wip/src/Notebook/Cell/Viz/Component/State.purs
@@ -25,6 +25,8 @@ module Notebook.Cell.Viz.Component.State
   , _sample
   , _records
   , _needToUpdate
+  , _axisLabelAngle
+  , _axisLabelFontSize
   ) where
 
 import Prelude
@@ -51,6 +53,8 @@ type VizState =
   , loading :: Boolean
   , records :: JArray
   , needToUpdate :: Boolean
+  , axisLabelFontSize :: Int
+  , axisLabelAngle :: Int
   }
 
 _width :: forall a r. LensP {width :: a |r} a
@@ -76,6 +80,12 @@ _records = lens _.records _{records = _}
 
 _needToUpdate :: forall a r. LensP {needToUpdate :: a | r} a
 _needToUpdate = lens _.needToUpdate _{needToUpdate = _}
+
+_axisLabelFontSize :: forall a r. LensP {axisLabelFontSize :: a | r} a
+_axisLabelFontSize = lens _.axisLabelFontSize _{axisLabelFontSize = _}
+
+_axisLabelAngle :: forall a r. LensP {axisLabelAngle :: a | r} a
+_axisLabelAngle = lens _.axisLabelAngle _{axisLabelAngle = _}
 
 type VizStateP =
   InstalledState VizState Form.StateP

--- a/wip/src/Notebook/Cell/Viz/Form/Component.purs
+++ b/wip/src/Notebook/Cell/Viz/Form/Component.purs
@@ -186,7 +186,7 @@ render (ChartConfiguration conf) =
   renderDimension clss ix sel =
     [ H.form [ P.classes $ clss <> [ Rc.chartConfigureForm, Rc.chartDimension ] ]
       [ dimensionLabel
-      , H.slot' cpDimension ix \_ -> { component: S.primarySelect
+      , H.slot' cpDimension ix \_ -> { component: S.primarySelect (pure "Dimension")
                                      , initialState: sel
                                      }
       ]
@@ -215,6 +215,7 @@ render (ChartConfiguration conf) =
              ]
       [ seriesLabel
       , H.slot' cpSeries ix \_ -> { component: S.secondarySelect
+                                    $ renderLabel ix "Series"
                                   , initialState: sel
                                   }
       ]
@@ -227,7 +228,7 @@ render (ChartConfiguration conf) =
                                    ]
              ]
       [ categoryLabel
-      , H.slot' cpSeries ix \_ -> { component: S.primarySelect
+      , H.slot' cpSeries ix \_ -> { component: S.primarySelect $ pure "Category"
                                   , initialState: sel
                                   }
       ]
@@ -239,11 +240,13 @@ render (ChartConfiguration conf) =
       then { disableWhen: (< 2)
            , defaultWhen: (> 1)
            , mainState: sel
+           , ariaLabel: renderLabel i "Measure"
            , classes: [Rc.aggregation, B.btnPrimary]
            }
       else { disableWhen: (< 1)
            , defaultWhen: (const true)
            , mainState: sel
+           , ariaLabel: renderLabel i "Measure"
            , classes: [Rc.aggregation, B.btnPrimary]
            }
 
@@ -267,6 +270,12 @@ render (ChartConfiguration conf) =
 
   seriesLabel :: FormHTML
   seriesLabel = label "Series"
+
+  renderLabel :: Int -> String -> Maybe String
+  renderLabel 0 str = pure $ "First " <> str
+  renderLabel 1 str = pure $ "Second " <> str
+  renderLabel 2 str = pure $ "Third " <> str
+  renderLabel n str = pure $ show n <> "th " <> str
 
 eval :: EvalParent Query State ChildState Query ChildQuery Slam ChildSlot
 eval (SetConfiguration c@(ChartConfiguration conf) next) = do

--- a/wip/src/Notebook/Component.purs
+++ b/wip/src/Notebook/Component.purs
@@ -160,7 +160,7 @@ peekEvalCell _ _ = pure unit
 
 peekAnyCell :: forall a. CellId -> AnyCellQuery a -> NotebookDSL Unit
 peekAnyCell cellId (VizQuery q) =
-  coproduct (const $ pure unit) (const $ runCell cellId) q
+  coproduct (const $ runCell cellId) (const $ runCell cellId) q
 peekAnyCell _ _ = pure unit
 
 -- | Runs the cell with the specified ID and then runs any cells that depend on

--- a/wip/src/Render/CssClasses.purs
+++ b/wip/src/Render/CssClasses.purs
@@ -325,3 +325,9 @@ chartEditor = className "chart-editor"
 
 chartOutput :: ClassName
 chartOutput = className "chart-output"
+
+axisLabelParam :: ClassName
+axisLabelParam = className "axis-label-param"
+
+chartSizeParam :: ClassName
+chartSizeParam = className "chart-size-param"


### PR DESCRIPTION
+ Added two inputs to viz cell: axisLabelAngle and axisLabelFontSize
+ Added `aria-label`s 
+ Viz cell rerun when width/height/axisLabelAngle/axisLabelFontSize changed (w/o sampling resource) 
+ Same 15% of total chart height allocated for axis label

Some screenshots 
<img width="1280" alt="2015-12-01 22 42 13" src="https://cloud.githubusercontent.com/assets/10245930/11511950/db1e79cc-987c-11e5-9cb6-9cc35924cd6a.png">
<img width="1280" alt="2015-12-01 22 41 56" src="https://cloud.githubusercontent.com/assets/10245930/11511953/e1249176-987c-11e5-84af-300c54971b06.png">
<img width="1280" alt="2015-12-01 22 41 26" src="https://cloud.githubusercontent.com/assets/10245930/11511958/e56087ea-987c-11e5-98ba-e26e2419b3a1.png">

Unfortunately I couldn't force __echarts__ to render every label although I specified this option. @jdegoes How does this look? 