### PR TITLE
Sd 1172

### DIFF
--- a/wip/bower.json
+++ b/wip/bower.json
@@ -28,12 +28,12 @@
     "purescript-pathy": "^0.3.0",
     "purescript-profunctor-lenses": "^0.3.3",
     "purescript-routing": "^0.2.0",
-    "purescript-search": "^0.5.0",
     "purescript-these": "^0.3.0",
     "purescript-timers": "~1.0.0",
     "purescript-uri": "^0.2.0",
     "purescript-zclipboard": "^0.3.0",
-    "purescript-halogen-echarts": "~0.1.0"
+    "purescript-halogen-echarts": "^0.1.0",
+    "purescript-search": "^0.6.0"
   },
   "devDependencies": {
     "purescript-debug": "^0.1.2"

--- a/wip/src/FileSystem/Routing/Search.purs
+++ b/wip/src/FileSystem/Routing/Search.purs
@@ -57,12 +57,10 @@ check p prj =
     -- `Like` predicate works exactly like `Contains` if we
     -- replace `% -> *` and `_ -> ?`
     S.Like s -> match $ like2glob s
-    S.Contains (S.Range str str') ->
+    S.Range val val' ->
       let c = flip check prj in
-      (c (S.Gte (S.Text str)) && c (S.Lte (S.Text str'))) ||
-      (c (S.Lte (S.Text str)) && c (S.Gte (S.Text str')))
-    -- filters only when it means something. S.Eq S.Range - meaningless
-    -- searching by tag in this context has no meaning too
+      (c (S.Gte val) && c (S.Lte val')) ||
+      (c (S.Lte val) && c (S.Gte val'))
     _ -> true
   where escapeGlob str = Str.replace "*" "\\*" $ Str.replace "?" "\\?" str
         percentRgx = Rgx.regex "%" flags

--- a/wip/src/Notebook/Cell/Search/Component.purs
+++ b/wip/src/Notebook/Cell/Search/Component.purs
@@ -122,7 +122,7 @@ eval = coproduct cellEval searchEval
                 # MT.lift
                 >>= M.maybe (EC.throwError "No file selected") pure
             query <-
-              get <#> _.searchString >>> S.toLower >>> SS.mkQuery
+              get <#> _.searchString >>> SS.mkQuery
                 # MT.lift
                 >>= either (\_ -> EC.throwError "Incorrect query string") pure
 


### PR DESCRIPTION
fixes https://slamdata.atlassian.net/browse/SD-1172
and https://slamdata.atlassian.net/browse/SD-1081

+ fields are filtered with `ignoreCase` flag --> you can match `city` field with `City:foo` query
+ `toLowerCase` was removed from request generation because ^ and switching to `~*` that is ignore case regex match

Now one can search something like `"A0.11"` but not `A0.11` all dots should live in enquoted fragments
Note that to search by regex it's necessary to use double back slash (e.g. `\\d{2}`) 

@jonsterling Please review