### PR TITLE
Revert "Updated webdriver dep"

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,11 +36,11 @@
     "gulp-purescript": "^0.6.0",
     "gulp-run": "^1.6.10",
     "gulp-trimlines": "^1.0.0",
+    "platform": "^1.3.0",
     "minimist": "^1.1.2",
     "mongodb": "^2.0.39",
-    "platform": "^1.3.0",
     "rimraf": "^2.4.2",
-    "selenium-webdriver": "^2.48.2",
+    "selenium-webdriver": "2.46.1",
     "webpack-stream": "^2.1.0"
   }
 }


### PR DESCRIPTION
This reverts commit 8da3ea4ff8c78fbc2bbc3cc8da0b0927497ce820.

Sadly, I believe that this dependency change is causing instability in the tests, to the degree that I have been re-running the tests continuously on Travis for about four hours now without a single success; fwiw, they all pass locally on my machine.

I tried to simply excise the problematic tests, but when I went down that road, I found it was like pulling a thread from a sweater—each invalid test removed revealed another invalid test waiting in the wings. ("invalid" meant in the sense that it does not have a determinate meaning as a negative specification)

My usual preference is for us to be using the "tip" versions of whatever dependencies we rely on whenever possible, since really frustrating stuff happens when you get out of date, which can set us back quite a bit. But for the moment, I would suggest that we stick with what we know works, and then upgrade stuff when we have to rewrite all the tests anyway (for SlamData 3.0).

An alternative would be for someone more familiar with our tests than I to go and fix them to work reliably with this newer version of webdriver—but I need to be able to make progress on my actual work very soon, and I figured everyone is too busy for that.

This blocks #558 