### PR TITLE
WIP: Autocomplete

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -41,8 +41,8 @@
     "purescript-halogen-menu": "^0.4.0",
     "purescript-dom": "^v0.2.15",
     "purescript-dom-keyboard": "^0.3.1",
-    "purescript-maps": "~0.5.4",
-    "purescript-tuples": "~0.4.0"
+    "purescript-maps": "^0.5.4",
+    "purescript-tuples": "^0.4.0"
   },
   "devDependencies": {
     "purescript-strongcheck": "^0.14.7",

--- a/less/main.less
+++ b/less/main.less
@@ -32,7 +32,7 @@ body {
     padding: 0;
     font-family: Ubuntu, Arial, Helvetica, sans-serif;
     height: 100%;
-    > div {
+    div.filesystem, div.dashboard {
         min-height: 100%;
     }
 }

--- a/src/Dashboard/Component.purs
+++ b/src/Dashboard/Component.purs
@@ -222,7 +222,7 @@ render state =
   where
   classes = if isReadOnly (state ^. _accessType)
             then [ Rc.notebookViewHack ]
-            else [ ]
+            else [ Rc.dashboard ]
 
   renderHeader :: Maybe String -> DashboardHTML
   renderHeader version =

--- a/src/FileSystem.purs
+++ b/src/FileSystem.purs
@@ -88,7 +88,8 @@ comp = parentComponent' render eval peek
 
 render :: RenderParent State ChildState Query ChildQuery Slam ChildSlot
 render state@(State r) =
-  H.div_ [ navbar
+  H.div [P.classes [ Rc.filesystem ] ]
+         [ navbar
            [  H.div [ P.classes [ Rc.header, B.clearfix ] ]
               [ icon B.glyphiconFolderOpen Config.homeHash
               , logo (state ^. _version)

--- a/src/Notebook/Cell/Ace/Component.purs
+++ b/src/Notebook/Cell/Ace/Component.purs
@@ -17,43 +17,62 @@ limitations under the License.
 module Notebook.Cell.Ace.Component
   ( aceComponent
   , AceEvaluator()
+  , AceDSL()
+  , AceHTML()
+  , AceSetup()
   , module Notebook.Cell.Ace.Component.Query
   , module Notebook.Cell.Ace.Component.State
   ) where
 
 import Prelude
 
+import Ace.EditSession as Session
+import Ace.Editor as Editor
+import Ace.Halogen.Component
+  ( AceQuery(SetText, GetText), AceState(), Autocomplete(..)
+  , aceConstructor)
+import Ace.Types (Editor())
 import Data.Argonaut (encodeJson, decodeJson)
 import Data.Either (either)
-import Data.Functor.Aff (liftAff)
+import Data.Functor (($>))
 import Data.Functor.Eff (liftEff)
 import Data.Maybe (Maybe(..), fromMaybe)
-
 import Halogen
 import Halogen.HTML.Indexed as H
 import Halogen.HTML.Properties.Indexed as P
-
-import Ace.Types (Editor())
-import Ace.Editor as Editor
-import Ace.EditSession as Session
-import Ace.Halogen.Component (AceQuery(..), AceState(), aceConstructor)
-
-import Render.CssClasses as CSS
-
-import Notebook.Cell.CellType (AceMode(), aceMode, aceCellName, aceCellGlyph)
-
 import Notebook.Cell.Ace.Component.Query
 import Notebook.Cell.Ace.Component.State
-import Notebook.Cell.Common.EvalQuery (CellEvalQuery(..), CellEvalResult(), CellEvalInput())
-import Notebook.Cell.Component (CellStateP(), CellQueryP(), makeEditorCellComponent, makeQueryPrism, _AceState, _AceQuery)
+import Notebook.Cell.CellType (AceMode(), aceMode, aceCellName, aceCellGlyph)
+import Notebook.Cell.Common.EvalQuery
+  (CellEvalQuery(..), CellEvalResult(), CellEvalInput())
+import Notebook.Cell.Component
+  ( CellStateP(), CellQueryP(), makeEditorCellComponent, makeQueryPrism
+  , _AceState, _AceQuery)
+import Notebook.Cell.Port as P
 import Notebook.Common (Slam())
+import Render.CssClasses as CSS
 
-type AceEvaluator = CellEvalInput -> String -> Slam CellEvalResult
+type AceDSL =
+  ParentDSL Unit AceState CellEvalQuery AceQuery Slam Unit
+type AceHTML =
+  ParentHTML AceState CellEvalQuery AceQuery Slam Unit
+type AceEvaluator =
+  CellEvalInput -> String -> AceDSL CellEvalResult
+type AceSetup =
+  P.Port -> AceDSL Unit
 
-aceComponent :: AceMode -> AceEvaluator -> Component CellStateP CellQueryP Slam
-aceComponent cellType run = makeEditorCellComponent
-  { name: aceCellName cellType
-  , glyph: aceCellGlyph cellType
+type AceConfig =
+  { mode :: AceMode
+  , evaluator :: AceEvaluator
+  , setup :: AceSetup
+  }
+
+
+aceComponent
+  :: AceConfig -> Component CellStateP CellQueryP Slam
+aceComponent {mode, evaluator, setup} = makeEditorCellComponent
+  { name: aceCellName mode
+  , glyph: aceCellGlyph mode
   , component: parentComponent render eval
   , initialState: installedState unit
   , _State: _AceState
@@ -61,12 +80,12 @@ aceComponent cellType run = makeEditorCellComponent
   }
 
   where
-
-  render :: Unit -> ParentHTML AceState CellEvalQuery AceQuery Slam Unit
+  render :: Unit -> AceHTML
   render _ =
     H.div
-      [ P.classes [CSS.cellInput, CSS.aceContainer] ]
-      [ H.Slot (aceConstructor unit aceSetup Nothing) ]
+      [ P.classes [CSS.cellInput, CSS.aceContainer]
+      ]
+      [ H.Slot (aceConstructor unit aceSetup (Just Live) ) ]
 
   aceSetup :: Editor -> Slam Unit
   aceSetup editor = liftEff do
@@ -74,16 +93,19 @@ aceComponent cellType run = makeEditorCellComponent
     Editor.setMaxLines 10000 editor
     Editor.setAutoScrollEditorIntoView true editor
     Editor.setTheme "ace/theme/chrome" editor
+    Editor.setEnableLiveAutocompletion true editor
+    Editor.setEnableBasicAutocompletion true editor
     session <- Editor.getSession editor
-    Session.setMode (aceMode cellType) session
+    Session.setMode (aceMode mode) session
 
-  eval :: Natural CellEvalQuery (ParentDSL Unit AceState CellEvalQuery AceQuery Slam Unit)
+
+  eval :: Natural CellEvalQuery AceDSL
   eval (NotifyRunCell next) = pure next
   eval (EvalCell info k) = do
     content <- fromMaybe "" <$> query unit (request GetText)
-    result <- liftAff $ run info content
+    result <- evaluator info content
     pure $ k result
-  eval (SetupCell _ next) = pure next
+  eval (SetupCell port next) = setup port $> next
   eval (Save k) = do
     content <- fromMaybe "" <$> query unit (request GetText)
     pure $ k (encodeJson content)

--- a/src/Notebook/Cell/Ace/Component/Query.purs
+++ b/src/Notebook/Cell/Ace/Component/Query.purs
@@ -19,11 +19,8 @@ module Notebook.Cell.Ace.Component.Query (QueryP()) where
 import Prelude
 
 import Data.Functor.Coproduct (Coproduct())
-
 import Halogen (ChildF())
-
-import Ace.Halogen.Component (AceQuery())
-
+import Ace.Halogen.Component  as Ace
 import Notebook.Cell.Common.EvalQuery (CellEvalQuery())
 
-type QueryP = Coproduct CellEvalQuery (ChildF Unit AceQuery)
+type QueryP = Coproduct CellEvalQuery (ChildF Unit Ace.AceQuery)

--- a/src/Notebook/Cell/Ace/Component/State.purs
+++ b/src/Notebook/Cell/Ace/Component/State.purs
@@ -18,10 +18,8 @@ module Notebook.Cell.Ace.Component.State (StateP()) where
 
 import Prelude
 
-import Halogen (InstalledState())
-
 import Ace.Halogen.Component (AceQuery(), AceState())
-
+import Halogen (InstalledState())
 import Notebook.Cell.Common.EvalQuery (CellEvalQuery())
 import Notebook.Common (Slam())
 

--- a/src/Notebook/Cell/Query/Eval.purs
+++ b/src/Notebook/Cell/Query/Eval.purs
@@ -16,39 +16,39 @@ limitations under the License.
 
 module Notebook.Cell.Query.Eval
   ( queryEval
+  , querySetup
   ) where
 
 import Prelude
+
+import Ace.Halogen.Component as Ace
+import Ace.Types (Completion())
 import Control.Monad.Error.Class as EC
 import Control.Monad.Trans as MT
 import Control.Monad.Writer.Class as WC
-
 import Data.Either as E
 import Data.Foldable as F
+import Data.Functor.Aff (liftAff)
 import Data.Lens as L
 import Data.Maybe as M
+import Data.Maybe (Maybe(..))
 import Data.StrMap as SM
-
+import Halogen (query, action)
 import Model.Resource as R
-import Notebook.Cell.Port as Port
+import Notebook.Cell.Ace.Component (AceDSL())
 import Notebook.Cell.Common.EvalQuery as CEQ
-import Notebook.Common (Slam())
-
+import Notebook.Cell.Port as Port
 import Quasar.Aff as Quasar
+import Utils.Completions (mkCompletion, pathCompletions)
 
-queryEval :: CEQ.CellEvalInput -> String -> Slam CEQ.CellEvalResult
-queryEval info sql =
-  CEQ.runCellEvalT $ do
-    let
-      varMap =
-        info.inputPort
-          >>= L.preview Port._VarMap
-            # M.maybe SM.empty (map Port.renderVarMapValue)
-      tempOutputResource = CEQ.temporaryOutputResource info
-      inputResource = R.parent tempOutputResource -- TODO: make sure that this is actually still correct
 
+queryEval :: CEQ.CellEvalInput -> String -> AceDSL CEQ.CellEvalResult
+queryEval info sql = do
+  addCompletions varMap
+  liftAff $ CEQ.runCellEvalT $ do
     { plan: plan, outputResource: outputResource } <-
-      Quasar.executeQuery sql (M.fromMaybe false info.cachingEnabled) varMap inputResource tempOutputResource
+      Quasar.executeQuery sql
+        (M.fromMaybe false info.cachingEnabled) varMap inputResource tempOutputResource
         # MT.lift
         >>= E.either EC.throwError pure
 
@@ -56,3 +56,28 @@ queryEval info sql =
       WC.tell ["Plan: " <> p]
 
     pure $ Port.Resource outputResource
+  where
+  varMap :: SM.StrMap String
+  varMap =
+    info.inputPort
+    >>= L.preview Port._VarMap
+    # M.maybe SM.empty (map Port.renderVarMapValue)
+
+  tempOutputResource = CEQ.temporaryOutputResource info
+  inputResource = R.parent tempOutputResource -- TODO: make sure that this is actually still correct
+
+querySetup :: Port.Port -> AceDSL Unit
+querySetup (Port.VarMap varMap) = addCompletions varMap
+querySetup _ = pure unit
+
+addCompletions :: forall a. SM.StrMap a -> AceDSL Unit
+addCompletions vm =
+  void $ query unit $ action $ Ace.SetCompleteFn \_ _ _ inp -> do
+    let compl = varMapCompletions vm
+    paths <- pathCompletions
+    pure $ compl <> paths
+
+  where
+  varMapCompletions :: SM.StrMap a -> Array Completion
+  varMapCompletions strMap =
+    SM.keys strMap <#> mkCompletion "variable" (Just <<< append ":")

--- a/src/Notebook/Component.purs
+++ b/src/Notebook/Component.purs
@@ -269,17 +269,20 @@ queryShouldRun (APIQuery q) = APIC.queryShouldRun q
 queryShouldRun _ = false
 
 queryShouldSave  :: forall a. AnyCellQuery a -> Boolean
-queryShouldSave (AceQuery q) = coproduct evalQueryShouldSave aceQueryShouldSave q
+queryShouldSave (AceQuery q) =
+  coproduct evalQueryShouldSave aceQueryShouldSave q
 queryShouldSave _ = true
 
 evalQueryShouldSave :: forall a. CellEvalQuery a -> Boolean
 evalQueryShouldSave _ = true
 
-aceQueryShouldSave :: forall p a. ChildF p Ace.AceQuery a -> Boolean
+aceQueryShouldSave
+  :: forall p a. ChildF p Ace.AceQuery a -> Boolean
 aceQueryShouldSave (ChildF _ q) =
   case q of
     Ace.TextChanged _ -> true
     _ -> false
+
 
 -- | Runs all cell that are present in the set of pending cells.
 runPendingCells :: Unit -> NotebookDSL Unit

--- a/src/Notebook/Component/State.purs
+++ b/src/Notebook/Component/State.purs
@@ -75,14 +75,14 @@ import Notebook.Cell.Model as Cell
 import Notebook.Model as M
 
 import Notebook.Component.Query (NotebookQuery())
-import Notebook.Cell.Ace.Component (AceEvaluator(), aceComponent)
+import Notebook.Cell.Ace.Component (AceEvaluator(), AceSetup(), aceComponent)
 import Notebook.Cell.Chart.Component (chartComponent)
 import Notebook.Cell.Component (CellComponent(), CellState(), CellStateP(), CellQueryP(), initEditorCellState, initResultsCellState)
 import Notebook.Cell.Explore.Component (exploreComponent)
 import Notebook.Cell.JTable.Component (jtableComponent)
 import Notebook.Cell.Markdown.Component (markdownComponent)
-import Notebook.Cell.Markdown.Eval (markdownEval)
-import Notebook.Cell.Query.Eval (queryEval)
+import Notebook.Cell.Markdown.Eval (markdownEval, markdownSetup)
+import Notebook.Cell.Query.Eval (queryEval, querySetup)
 import Notebook.Cell.Search.Component (searchComponent)
 import Notebook.Cell.Viz.Component (vizComponent)
 import Notebook.Cell.Download.Component (downloadComponent)
@@ -249,7 +249,10 @@ addCellChain cellType parents st =
        }
 
 cellTypeComponent :: CellType -> CellId -> BrowserFeatures -> CellComponent
-cellTypeComponent (Ace at) _ _ = aceComponent at (aceEvalMode at)
+cellTypeComponent (Ace mode) _ _ =
+  let evaluator = aceEvalMode mode
+      setup = aceSetupMode mode
+  in aceComponent { mode, evaluator, setup }
 cellTypeComponent Explore _ _ = exploreComponent
 cellTypeComponent Search _ _ = searchComponent
 cellTypeComponent Viz _ _ = vizComponent
@@ -277,6 +280,10 @@ cellTypeInitialState APIResults = initResultsCellState
 aceEvalMode :: AceMode -> AceEvaluator
 aceEvalMode MarkdownMode = markdownEval
 aceEvalMode SQLMode = queryEval
+
+aceSetupMode :: AceMode -> AceSetup
+aceSetupMode MarkdownMode = markdownSetup
+aceSetupMode SQLMode = querySetup
 
 -- | Removes a set of cells from the notebook. Any cells that depend on a cell
 -- | in the set of provided cells will also be removed.

--- a/src/Notebook/FileInput/Component.purs
+++ b/src/Notebook/FileInput/Component.purs
@@ -47,6 +47,8 @@ import Network.HTTP.Affjax (AJAX())
 import Render.CssClasses as CSS
 import Quasar.Aff as API
 
+import DOM (DOM())
+
 import Model.Resource as R
 
 type State =
@@ -74,6 +76,7 @@ type Effects e =
   API.RetryEffects
     ( ajax :: AJAX
     , err :: EXCEPTION
+    , dom :: DOM
     | e
     )
 

--- a/src/Render/CssClasses.purs
+++ b/src/Render/CssClasses.purs
@@ -18,6 +18,12 @@ module Render.CssClasses where
 
 import Halogen.HTML.Core (className, ClassName())
 
+filesystem :: ClassName
+filesystem = className "filesystem"
+
+dashboard :: ClassName
+dashboard = className "dashboard"
+
 version :: ClassName
 version = className "version"
 

--- a/src/Utils/Completions.purs
+++ b/src/Utils/Completions.purs
@@ -1,0 +1,81 @@
+{-
+Copyright 2015 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
+module Utils.Completions where
+
+import Prelude
+
+import Ace.Types (Completion())
+import Ace.Halogen.Component (AceEffects())
+import Control.Monad.Aff (Aff())
+import Data.Array as Arr
+import Data.Maybe (Maybe(..), fromMaybe)
+import Data.Either (Either(..), either)
+import Data.Tuple (Tuple(..))
+import Data.Path.Pathy as P
+import Data.String as S
+import DOM (DOM())
+import Model.Resource as R
+import Utils.LocalStorage (getLocalStorage, setLocalStorage)
+import Utils.Path as PU
+
+
+pathCompletions :: forall e. Aff (AceEffects e) (Array Completion)
+pathCompletions = do
+  paths <- getLocalStorage "paths" <#> either (const []) id
+  pure $ paths <#> S.drop 1 >>> mkCompletion "path" mkCaption
+  where
+  mkCaption :: String -> Maybe String
+  mkCaption val =
+    pure $  "/" <> if S.length val > 30
+                   then S.take 28 val <> "…"
+                   else val
+
+
+mkCompletion :: String -> (String -> Maybe String) -> String -> Completion
+mkCompletion meta f val =
+  { value: val
+  , score: 200.0
+  , meta: meta
+  , caption: f val
+  }
+
+
+memoizeCompletionStrs
+  :: forall e. PU.DirPath -> Array R.Resource -> Aff (dom :: DOM | e) Unit
+memoizeCompletionStrs dir arr = do
+  alreadyMemoized <- getLocalStorage "paths" <#> either (const []) id
+  setLocalStorage "paths"
+    $ Arr.sort $ newSiblings <> filterSiblings alreadyMemoized
+  where
+  parentPath :: String
+  parentPath = P.printPath dir
+
+  filterSiblings :: Array String -> Array String
+  filterSiblings =
+    Arr.filter
+    $ fromMaybe true
+    <<< map (S.contains "/")
+    <<< S.stripPrefix parentPath
+
+  newSiblings :: Array String
+  newSiblings = Arr.catMaybes $ map (resToMbPath) arr
+
+  resToMbPath :: R.Resource -> Maybe String
+  resToMbPath (R.File p) = case P.peel p of
+    Just (Tuple _ (Right (P.FileName f))) | f /= ".folder" -> pure $ P.printPath p
+    _ -> Nothing
+  resToMbPath _ = Nothing

--- a/src/Utils/DOM.purs
+++ b/src/Utils/DOM.purs
@@ -16,20 +16,19 @@ limitations under the License.
 
 module Utils.DOM where
 
-import Prelude
+import Control.Bind ((=<<))
 import Control.Monad.Aff (Aff())
 import Control.Monad.Eff (Eff())
-import Control.Bind ((=<<))
 import DOM (DOM())
+import DOM.Event.Types (EventTarget())
 import DOM.HTML (window)
 import DOM.HTML.Types (HTMLElement(), htmlElementToElement, htmlDocumentToDocument)
-import DOM.HTML.Window (document, navigator)
-import DOM.HTML.Navigator (platform)
+import DOM.HTML.Window (document)
 import DOM.Node.ParentNode as P
 import DOM.Node.Types (elementToParentNode, Element(), documentToEventTarget)
 import Data.Maybe (Maybe())
 import Data.Nullable (toMaybe)
-import Data.String (take)
+import Prelude
 import Unsafe.Coerce (unsafeCoerce)
 
 elementToHTMLElement :: Element -> HTMLElement
@@ -41,7 +40,7 @@ querySelector str htmlEl =
   map (toMaybe >>> map elementToHTMLElement)
   $ P.querySelector str $ elementToParentNode $ htmlElementToElement htmlEl
 
-documentTarget :: _
+documentTarget :: forall e. Eff (dom :: DOM|e) EventTarget
 documentTarget = htmlDocumentToEventTarget <$> (document =<< window)
   where
   htmlDocumentToEventTarget = documentToEventTarget <<< htmlDocumentToDocument

--- a/src/Utils/Debounced.purs
+++ b/src/Utils/Debounced.purs
@@ -21,10 +21,9 @@ import Prelude
 import Control.Bind ((=<<))
 import Control.Coroutine.Aff (produce)
 import Control.Coroutine.Stalling (producerToStallingProducer)
-import Control.Monad.Aff (Aff(), forkAff, later', cancel)
+import Control.Monad.Aff (Aff())
 import Control.Monad.Aff.AVar (AVAR())
 import Control.Monad.Eff (Eff())
-import Control.Monad.Eff.Exception (error)
 import Control.Monad.Eff.Ref (REF(), newRef, readRef, writeRef)
 
 import Data.Either (Either(..))

--- a/src/Utils/LocalStorage.js
+++ b/src/Utils/LocalStorage.js
@@ -1,0 +1,19 @@
+// module Utils.LocalStorage
+
+exports.setLocalStorageImpl = function(key, value) {
+    return function() {
+        localStorage.setItem(key, value);
+    };
+};
+
+exports.getLocalStorageImpl = function(Nothing, Just, key) {
+    return function() {
+        var result = localStorage[key];
+        if (typeof result === "undefined") {
+            return Nothing;
+        }
+        else {
+            return Just(result);
+        }
+    };
+};

--- a/src/Utils/LocalStorage.purs
+++ b/src/Utils/LocalStorage.purs
@@ -1,0 +1,48 @@
+{-
+Copyright 2015 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
+module Utils.LocalStorage (getLocalStorage, setLocalStorage)  where
+
+import Prelude
+
+import Control.Bind ((>=>))
+import Control.Monad.Eff (Eff())
+import Control.Monad.Eff.Class (liftEff, MonadEff)
+import Data.Argonaut
+import Data.Either (Either(..))
+import Data.Maybe (Maybe(..), maybe)
+import Data.Function
+import DOM (DOM())
+
+foreign import setLocalStorageImpl
+  :: forall e. Fn2 String String (Eff (dom :: DOM|e) Unit)
+foreign import getLocalStorageImpl
+  :: forall e a
+   . Fn3 (Maybe a) (a -> Maybe a) String (Eff (dom :: DOM|e) (Maybe String))
+
+setLocalStorage
+  :: forall a e g
+   . (EncodeJson a, MonadEff (dom :: DOM|e) g) => String -> a -> g Unit
+setLocalStorage  key val =
+  liftEff $ runFn2 setLocalStorageImpl key $ printJson $ encodeJson val
+
+getLocalStorage
+  :: forall a e g
+   . (DecodeJson a, MonadEff (dom :: DOM|e) g) => String -> g (Either String a)
+getLocalStorage key =
+  liftEff
+  $ maybe (Left $ "There is no value in key " <> key) (jsonParser >=> decodeJson)
+  <$> runFn3 getLocalStorageImpl Nothing Just key

--- a/src/Utils/Path.purs
+++ b/src/Utils/Path.purs
@@ -32,6 +32,7 @@ import Data.String
 import Data.String.Regex as Rgx
 import Data.Tuple (snd, fst)
 
+
 import Text.SlamSearch.Parser.Tokens (keyChars)
 
 import Config (notebookExtension)

--- a/test/src/Test/Config.purs
+++ b/test/src/Test/Config.purs
@@ -25,12 +25,10 @@ module Test.Config
 
 import Prelude
 
-import Control.Alt ((<|>))
 import Data.StrMap
-import Data.Maybe (Maybe(..), fromMaybe)
+import Data.Maybe (Maybe())
 import Data.Function (on)
 import Selenium.Types
-import Data.String.Regex as R
 import Data.Array as A
 
 type SearchQueryConfig =


### PR DESCRIPTION
This depends on slamdata/purescript-ace-halogen#3

It solves SD-1186 and SD-151 and partialliy SD-152. 

I'm not sure about two things 
+ I use `localStorage` to avoid calling `children`. This could be removed if `/metadata/fs` would return a tree with all files. 
+ Currently cells get parent output port only after parent run and have no idea what is parent output during creation. So, here I need markdown's `VarMap` right after cell creation. What's the best way to provide it? My idea is to add `Init (Maybe Port) a` to `CellQuery` and call it instead of `when (autocomplete cellType) $ blablabla updateCell`. 

What do you think? Is this somehow related with #562? 

 