### PR TITLE
Add key for cells to aid virtual-dom patching

### DIFF
--- a/wip/src/Notebook/Cell/Ace/Component.purs
+++ b/wip/src/Notebook/Cell/Ace/Component.purs
@@ -39,6 +39,7 @@ import Ace.Halogen.Component (AceQuery(..), AceState(), aceConstructor)
 import Render.CssClasses as CSS
 
 import Model.CellType (CellType(), cellName, cellGlyph)
+
 import Notebook.Cell.Ace.Component.Query
 import Notebook.Cell.Ace.Component.State
 import Notebook.Cell.Common.EvalQuery (CellEvalQuery(..), CellEvalResult(), CellEvalInput())

--- a/wip/src/Notebook/Cell/Search/Component.purs
+++ b/wip/src/Notebook/Cell/Search/Component.purs
@@ -44,7 +44,6 @@ import Render.CssClasses as CSS
 import Render.Common as RC
 
 import Model.CellType as CT
-import Model.CellId as CID
 import Model.Notebook.Search as Search
 import Model.Port as Port
 
@@ -61,8 +60,8 @@ import Quasar.Aff as Quasar
 
 type Query = Coproduct NC.CellEvalQuery SearchQuery
 
-searchComponent :: CID.CellId -> Component NC.CellStateP NC.CellQueryP Slam
-searchComponent cellId =
+searchComponent :: Component NC.CellStateP NC.CellQueryP Slam
+searchComponent =
   NC.makeEditorCellComponent
     { name: CT.cellName CT.Search
     , glyph: CT.cellGlyph CT.Search

--- a/wip/src/Notebook/Component.purs
+++ b/wip/src/Notebook/Component.purs
@@ -48,7 +48,7 @@ import Render.Common (glyph, fadeWhen)
 import Render.CssClasses as CSS
 
 import Model.AccessType (isEditable)
-import Model.CellId (CellId())
+import Model.CellId (CellId(), cellIdToString)
 import Model.CellType (CellType(..), cellName, cellGlyph, autorun)
 import Model.Port (Port())
 import Model.Resource as R
@@ -81,8 +81,13 @@ notebookComponent = parentComponent' render eval peek
 render :: NotebookState -> NotebookHTML
 render state =
   H.div_
-    $ fromList (map (H.Slot <<< _.ctor) state.cells)
+    $ fromList (map renderCell state.cells)
    <> if isEditable state.accessType then [newCellMenu state] else []
+  where
+  renderCell cellDef =
+    H.div
+      [ P.key ("cell" <> cellIdToString cellDef.id) ]
+      [ H.Slot cellDef.ctor ]
 
 newCellMenu :: NotebookState -> NotebookHTML
 newCellMenu state =

--- a/wip/src/Notebook/Component/State.purs
+++ b/wip/src/Notebook/Component/State.purs
@@ -203,7 +203,7 @@ addCell cellType parent st =
   editor :: CellType -> CellId -> CellComponent
   editor Markdown _ = aceComponent Markdown markdownEval "ace/mode/markdown"
   editor Explore _ = exploreComponent
-  editor Search cellId = searchComponent cellId
+  editor Search _ = searchComponent
   editor Query _ = aceComponent Query queryEval "ace/mode/sql"
   editor Viz _ = vizComponent
 


### PR DESCRIPTION
@cryogenian this fixes the "Ace cell forgets its contents" bug, I would propose that it's very much preferrable to what you had to do in slamdata/purescript-ace-halogen#3 :wink:

Thoughts? If you're happy with doing it this way, would you mind re-looking at that PR too, to just add the autocomplete stuff?