### PR TITLE
SD-1200: Fix gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,9 +8,10 @@
 /test/jars/quasar.jar
 jars
 public/js/*.js
-public/js/!ace*
+!public/js/ace*
+!public/js/echarts-all.js
 public/css/*.css
-public/css/!bootstrap*.css
+!public/css/bootstrap*.css
 .psci_modules
 .psci
 phantomjsdriver.log


### PR DESCRIPTION
- The `.gitignore` has incorrect syntax (huge thanks to @beckyconning for catching this and saving me a few hours!); or at least, syntax that `npm` didn't understand.

- We probably also need to not ignore `echarts-all.js`

The reason it matters whether we ignore things, even if they are already checked in, is that `npm` will ignore anything in the `.gitignore` as well, regardless of whether it is checked into git. So, when someone tries to fetch SlamData using `npm`, they'll end up missing certain important files.

This will resolve SD-1200.