### PR TITLE
SD-1202: SlamData title should reflect its own version

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,7 +9,8 @@ var gulp = require("gulp"),
     fs = require("fs"),
     trimlines = require("gulp-trimlines"),
     less = require("gulp-less"),
-    sequence = require("run-sequence");
+    sequence = require("run-sequence"),
+    path = require("path");
 
 var slamDataSources = [
   "src/**/*.purs",
@@ -86,19 +87,27 @@ var mkBundleTask = function (name, main) {
   gulp.task("prebundle-" + name, ["make"], function() {
     return purescript.pscBundle({
       src: "output/**/*.js",
-      output: "tmp/js/" + name + ".js",
+      output: "tmp/" + name + ".js",
       module: main,
       main: main
     });
   });
 
   gulp.task("bundle-" + name, ["prebundle-" + name], function () {
-    return gulp.src("tmp/js/" + name + ".js")
-      .pipe(webpack({
-        resolve: { modulesDirectories: ["node_modules"] },
-        output: { filename: name + ".js" }
-      }))
-      .pipe(gulp.dest("public/js"));
+    return gulp.src("tmp/" + name + ".js")
+          .pipe(webpack({
+              resolve: {
+                  modulesDirectories: ["node_modules"]
+
+              },
+              output: { filename: name + ".js" },
+              module: {
+                  loaders: [{
+                      include: /\.json$/,
+                      loaders: ["json-loader"]
+                  }]
+              }
+          })).pipe(gulp.dest("public/js"));
   });
 
   return "bundle-" + name;

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "type": "git",
     "url": "https://github.com/slamdata/slamdata"
   },
+  "version": "v2.4.0",
   "contributors": [
     "Maxim Zimaliev <zimaliev@yandex.ru>",
     "Gary Burgess <gary@slamdata.com>",
@@ -43,6 +44,7 @@
     "image-diff": "^1.3.0",
     "minimatch": "^3.0.0",
     "virtual-dom": "^2.1.1",
-    "zeroclipboard": "^2.2.0"
+    "zeroclipboard": "^2.2.0",
+    "json-loader": "^0.5.4"
   }
 }

--- a/src/Config/Version.js
+++ b/src/Config/Version.js
@@ -1,0 +1,5 @@
+// module Config.Version
+
+var packageInfo = require("../package.json");
+
+exports.slamDataVersion = packageInfo.version;

--- a/src/Config/Version.purs
+++ b/src/Config/Version.purs
@@ -14,26 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -}
 
-module FileSystem.Query where
+module Config.Version
+  ( slamDataVersion
+  ) where
 
-import DOM.HTML.Types (HTMLElement())
-import Model.Salt (Salt())
-import Model.Sort (Sort())
-import Utils.Path (DirPath())
-
-data Query a
-  = Resort a
-  | SetPath DirPath a
-  | SetSort Sort a
-  | SetSalt Salt a
-  | SetIsMount Boolean a
-  | Configure a
-  | ShowHiddenFiles a
-  | HideHiddenFiles a
-  | Download a
-  | MakeMount a
-  | MakeFolder a
-  | MakeNotebook a
-  | UploadFile HTMLElement a
-  | FileListChanged HTMLElement a
-  | SetVersion String a
+foreign import slamDataVersion :: String

--- a/src/Entry/FileSystem.purs
+++ b/src/Entry/FileSystem.purs
@@ -24,7 +24,6 @@ import Control.Monad.Eff.Class (liftEff)
 import Control.Monad.Eff.Exception (throwException)
 import Control.UI.Browser (setTitle)
 import Data.Functor.Coproduct (left)
-import Data.Maybe (Maybe(), maybe)
 import DOM (DOM())
 import FileSystem (comp, initialState, Query(..))
 import FileSystem.Effects (FileSystemEffects())
@@ -33,18 +32,17 @@ import Halogen.Component (installedState)
 import Halogen.Driver (runUI)
 import Halogen.Query (action)
 import Halogen.Util (appendToBody, onLoad)
-import Quasar.Aff (getVersion)
 
-setSlamDataTitle :: forall e. Maybe String -> Aff (dom :: DOM|e) Unit
-setSlamDataTitle mbVersion = do
-  liftEff $ setTitle $ "SlamData" <> maybe "" (" " <>) mbVersion
+setSlamDataTitle :: forall e. String -> Aff (dom :: DOM|e) Unit
+setSlamDataTitle version =
+  liftEff $ setTitle $ "SlamData " <> version
 
 main :: Eff FileSystemEffects Unit
 main = runAff throwException (const (pure unit)) do
   halogen <- runUI comp (installedState initialState)
   onLoad (appendToBody halogen.node)
   forkAff do
-    version <- getVersion
+    let version = Config.Version.slamDataVersion
     setSlamDataTitle version
     halogen.driver (left $ action $ SetVersion version)
   forkAff $ routeSignal halogen.driver

--- a/src/FileSystem.purs
+++ b/src/FileSystem.purs
@@ -227,7 +227,7 @@ eval (Download next) = do
   pure next
 
 eval (SetVersion version next) = do
-  modify (_version .~ version)
+  modify (_version .~ Just version)
   pure next
 
 peek :: forall a. ChildF ChildSlot ChildQuery a -> Algebra Unit

--- a/test/config.json
+++ b/test/config.json
@@ -431,6 +431,5 @@
         "values": ["10", "5", "30"]
     },
     "collectingScreenshots": false,
-    "tmpFileForScreenshots": "image/tmp.png",
-    "version": "2.3.3"
+    "tmpFileForScreenshots": "image/tmp.png"
 }

--- a/test/src/Test/Config.purs
+++ b/test/src/Test/Config.purs
@@ -300,7 +300,6 @@ type Config =
   , complex :: { inputSelector :: String
                , values :: Array String
                }
-  , version :: String
   , collectingScreenshots :: Boolean
   , tmpFileForScreenshots :: String
   }

--- a/test/src/Test/Selenium/File.purs
+++ b/test/src/Test/Selenium/File.purs
@@ -698,13 +698,10 @@ createNotebook = do
 
 checkTitle :: Check Unit
 checkTitle = do
-  driver <- getDriver
-  config <- getConfig
   windowTitle <- getTitle
-  if Str.contains config.version windowTitle
+  if Str.contains Config.Version.slamDataVersion windowTitle
     then successMsg "Title contains version"
     else errorMsg $ "Title (" ++ windowTitle ++ ") doesn't contain version"
-
 
 moveDelete :: String -> Check Unit -> String -> String -> Check Unit
 moveDelete msg setUp src tgt = do


### PR DESCRIPTION
Previously, the title displayed Quasar's version (which was got by querying Quasar). This changes it so that the title reflects SlamData's version, as listed in `package.json`.

Now, I had to do something I don't really understand, namely add this `json-loader` dependency, and use `json!` in the `require` expression when I read `package.json`, but after I did this, everything seemed to work all right. Now, I have no idea what any of that is, but I suspect @beckyconning would know what that means, and is probably best placed to review this.

https://slamdata.atlassian.net/browse/SD-1202