### PR TITLE
[SD-1092] Markdown autorun

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -47,16 +47,9 @@ gulp.task("clean", function () {
 
 gulp.task("make", function() {
   return purescript.psc({
-    src: sources,
+    src: testSources,
     ffi: foreigns
   });
-});
-
-gulp.task("test-make", function() {
-    return purescript.psc({
-        src: testSources,
-        ffi: foreigns
-    });
 });
 
 gulp.task("add-headers", function () {
@@ -121,7 +114,7 @@ gulp.task("bundle", [
 gulp.task("bundle-test",
           ["bundle"],
            function() {
-    sequence("less", "test-make", function() {
+    sequence("less", "make", function() {
         return purescript.pscBundle({
             src: "output/**/*.js",
             output: "test/index.js",
@@ -131,7 +124,7 @@ gulp.task("bundle-test",
     });
 });
 
-gulp.task("bundle-property-tests", ["test-make"], function() {
+gulp.task("bundle-property-tests", ["make"], function() {
     return purescript.pscBundle({
       src: "output/**/*.js",
       output: "tmp/js/property-tests.js",
@@ -164,4 +157,4 @@ gulp.task("less", function() {
 mkWatch("watch-less", "less", ["less/**/*.less"]);
 
 // gulp.task("default", ["add-headers", "trim-whitespace", "less", "bundle"]);
-gulp.task("default", ["less", "property-tests", "bundle"]);
+gulp.task("default", ["less", "make", "property-tests", "bundle"]);

--- a/src/Dashboard/Menu/Component/State.purs
+++ b/src/Dashboard/Menu/Component/State.purs
@@ -19,12 +19,11 @@ module Dashboard.Menu.Component.State where
 import Prelude
 
 import Data.Maybe (Maybe(..))
-import Halogen.Menu.Component as HalogenMenu
-import Halogen.Menu.Component.State as HalogenMenu
 import Data.StrMap as StrMap
 
-import Notebook.Cell.CellType (CellType(..))
-import Notebook.Component as Notebook
+import Halogen.Menu.Component as HalogenMenu
+import Halogen.Menu.Component.State as HalogenMenu
+
 import Dashboard.Component.State (NotebookShortcut())
 import Dashboard.Menu.Component.Query
 import Dashboard.Rename.Component as Rename

--- a/src/Notebook/Cell/Markdown/Component.purs
+++ b/src/Notebook/Cell/Markdown/Component.purs
@@ -16,6 +16,7 @@ limitations under the License.
 
 module Notebook.Cell.Markdown.Component
   ( markdownComponent
+  , queryShouldRun
   , module Notebook.Cell.Markdown.Component.Query
   , module Notebook.Cell.Markdown.Component.State
   ) where
@@ -26,6 +27,7 @@ import Control.Bind ((=<<))
 
 import Data.BrowserFeatures (BrowserFeatures())
 import Data.Either (Either(..))
+import Data.Functor.Coproduct (coproduct)
 import Data.Lens (preview)
 import Data.Maybe (Maybe(..), fromMaybe)
 import Data.Monoid (mempty)
@@ -64,6 +66,13 @@ markdownComponent cellId browserFeatures = makeResultsCellComponent
     { formName: "cell-" ++ show (runCellId cellId)
     , browserFeatures
     }
+
+queryShouldRun :: forall a. QueryP a -> Boolean
+queryShouldRun = coproduct (const false) (\(ChildF _ q) -> pred q)
+  where
+  pred (TextChanged _ _ _ _) = true
+  pred (CheckBoxChanged _ _ _ _) = true
+  pred _ = false
 
 render
   :: forall a

--- a/src/Notebook/Component/Query.purs
+++ b/src/Notebook/Component/Query.purs
@@ -33,6 +33,7 @@ import Utils.Path (FilePath(), DirPath())
 data NotebookQuery a
   = AddCell CellType a
   | RunActiveCell a
+  | RunPendingCells a
   | ToggleAddCellMenu a
   | GetNameToSave (Maybe DirName -> a)
   | GetPath (Maybe DirPath -> a)


### PR DESCRIPTION
This adds the behaviour so that changing values in a rendered markdown form causes the cell to run and therefore pass on the updated `VarMap` to follow-on query cells.

This also debounces the running of all cells, as it seemed simplest to implement it that way, but maybe directly pressing the play button of a cell should evaluate the cell immediately instead?

@jonsterling to review please!