### PR TITLE
Update to latest argonaut

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "purescript-ace-halogen": "^0.4.0",
     "purescript-affjax": "^0.10.0",
-    "purescript-argonaut": "^0.11.0",
+    "purescript-argonaut": "^0.12.0",
     "purescript-css": "^0.4.0",
     "purescript-datetime": "~0.9.1",
     "purescript-generics": "^0.7.0",
@@ -55,6 +55,8 @@
     "purescript-node-process": "~0.1.1"
   },
   "resolutions": {
-    "purescript-argonaut-codecs": "^0.5.0"
+    "purescript-argonaut-codecs": "^0.5.0",
+    "purescript-argonaut": "^0.12.0",
+    "purescript-argonaut-traversals": "^0.7.0"
   }
 }


### PR DESCRIPTION
This changes the default encoding for `Either`s, so we’ll want to get this in before any `new-halogen` notebooks are saved by users, in case we rely on `Either` encoding somewhere in the models.