### PR TITLE
[SD-1311] Add SetupCell to CellEvalQuery, initialise search cells with resource from parent cell

### DIFF
--- a/src/Notebook/Cell/API/Component.purs
+++ b/src/Notebook/Cell/API/Component.purs
@@ -118,6 +118,8 @@ eval q =
             # MT.lift
             >>= M.maybe (EC.throwError "Error querying FormBuilder") pure
         pure $ Port.VarMap $ compileVarMap fields info.globalVarMap
+    NC.SetupCell _ next ->
+      pure next
     NC.NotifyRunCell next ->
       pure next
     NC.Save k ->

--- a/src/Notebook/Cell/APIResults/Component.purs
+++ b/src/Notebook/Cell/APIResults/Component.purs
@@ -92,6 +92,8 @@ evalCell q =
             MT.lift $ modify (_ { varMap = varMap })
             pure $ Port.VarMap varMap
           M.Nothing -> EC.throwError "expected VarMap input"
+    NC.SetupCell _ next ->
+      pure next
     NC.NotifyRunCell next ->
       pure next
     NC.Save k ->

--- a/src/Notebook/Cell/Ace/Component.purs
+++ b/src/Notebook/Cell/Ace/Component.purs
@@ -83,6 +83,7 @@ aceComponent cellType run = makeEditorCellComponent
     content <- fromMaybe "" <$> query unit (request GetText)
     result <- liftAff $ run info content
     pure $ k result
+  eval (SetupCell _ next) = pure next
   eval (Save k) = do
     content <- fromMaybe "" <$> query unit (request GetText)
     pure $ k (encodeJson content)

--- a/src/Notebook/Cell/Chart/Component.purs
+++ b/src/Notebook/Cell/Chart/Component.purs
@@ -89,7 +89,7 @@ eval (Ec.EvalCell value continue) =
         { output: Nothing
         , messages: [Left "Expected ChartOptions input"]
         }
-
+eval (Ec.SetupCell _ next) = pure next
 -- No state needs loading/saving for the chart cell, as it is fully populated
 -- by its input, and will be restored by the parent `Viz` cell running when
 -- the notebook is restored

--- a/src/Notebook/Cell/Common/EvalQuery.purs
+++ b/src/Notebook/Cell/Common/EvalQuery.purs
@@ -98,10 +98,16 @@ temporaryOutputResource info =
 -- | - `EvalCell` is a command sent from the notebook that runs the cell. An
 -- |   optional input value (the output from another cell) is provided, and a
 -- |   continuation for the evaluation result to be returned to.
+-- | - `SetupCell` is will be called when the cell is being added as a linked
+-- |   cell from another, passing through the current input port value so the
+-- |   current cell can set its state based on that. Used to pull a VarMap
+-- |   through for autocomplete purposes, or for the search cell to be able to
+-- |   auto-select the parent cell's result set as the resource, etc.
 -- | - `NotifyRunCell` allows the cell to notify the notebook that it should be
 -- |   run - the cell cannot run itself directly.
 data CellEvalQuery a
   = EvalCell CellEvalInput (CellEvalResult -> a)
+  | SetupCell Port a
   | NotifyRunCell a
   | Save (Json -> a)
   | Load Json a

--- a/src/Notebook/Cell/Explore/Component.purs
+++ b/src/Notebook/Cell/Explore/Component.purs
@@ -72,6 +72,7 @@ eval (NC.EvalCell info k) =
         # MT.lift
         >>= maybe (EC.throwError "No file selected") pure
     pure $ Port.Resource resource
+eval (NC.SetupCell _ next) = pure next
 eval (NC.Save k) = do
   file <- query unit (request FI.GetSelectedFile)
   pure $ k $ encodeJson (join file)

--- a/src/Notebook/Cell/JTable/Component.purs
+++ b/src/Notebook/Cell/JTable/Component.purs
@@ -88,6 +88,7 @@ evalCell (EvalCell value k) =
     { output: Nothing
     , messages: [Left $ "An internal error occurred: " ++ msg]
     }
+evalCell (SetupCell _ next) = pure next
 evalCell (Save k) =
   pure <<< k =<< gets (Model.encode <<< toModel)
 evalCell (Load json next) = do

--- a/src/Notebook/Cell/Markdown/Component.purs
+++ b/src/Notebook/Cell/Markdown/Component.purs
@@ -110,6 +110,7 @@ eval (EvalCell value k) =
         Nothing -> error "GetFormState query returned Nothing"
         Just st -> { output: Just (Port.VarMap $ formStateToVarMap st), messages: [] }
     Nothing -> pure $ k (error "expected SlamDown input")
+eval (SetupCell _ next) = pure next
 eval (Save k) = do
   input <- fromMaybe mempty <$> get
   state <- fromMaybe SM.empty <$> query unit (request MD.GetFormState)

--- a/src/Notebook/Cell/Search/Component.purs
+++ b/src/Notebook/Cell/Search/Component.purs
@@ -29,9 +29,10 @@ import Control.Monad.Writer.Class as WC
 
 import Data.Either (Either(..), either)
 import Data.Foldable as F
+import Data.Functor (($>))
 import Data.Functor.Aff (liftAff)
 import Data.Functor.Coproduct
-import Data.Lens ((.~))
+import Data.Lens ((.~), preview)
 import Data.Maybe as M
 import Data.StrMap as SM
 
@@ -142,6 +143,11 @@ cellEval q =
           WC.tell ["Plan: " <> p]
 
         pure $ Port.Resource outputResource
+
+    NC.SetupCell input next -> do
+      case preview Port._Resource input of
+        M.Just res -> query unit (action (FI.SelectFile res)) $> next
+        M.Nothing -> pure next
 
     NC.NotifyRunCell next ->
       pure next

--- a/src/Notebook/Cell/Viz/Component.purs
+++ b/src/Notebook/Cell/Viz/Component.purs
@@ -268,6 +268,7 @@ cellEval (EvalCell info continue) = do
     modify $ _loading .~ false
     modify $ _needToUpdate .~ true
     pure a
+cellEval (SetupCell _ next) = pure next
 cellEval (NotifyRunCell next) = pure next
 cellEval (Save k) = do
   st <- get

--- a/src/Notebook/Component.purs
+++ b/src/Notebook/Component.purs
@@ -235,6 +235,12 @@ peekCell cellId q = case q of
     Tuple st newCellId <- gets $ addCell' cellType (Just cellId)
     set st
     forceRerender'
+    input <- map join $ query (CellSlot cellId) $ left (request GetOutput)
+    case input of
+      Just input' ->
+        void $ query (CellSlot newCellId)
+          $ right $ ChildF unit $ left $ action (SetupCell input')
+      Nothing -> pure unit
     when (autorun cellType) $ runCell newCellId
   ShareCell _ -> pure unit
   _ -> pure unit

--- a/src/Notebook/Component/State.purs
+++ b/src/Notebook/Component/State.purs
@@ -207,7 +207,10 @@ addCell cellType parent st = fst $ addCellChain cellType (maybe [] pure parent) 
 -- | parent cell ID and returns the modified notebook state and the new cell ID.
 addCell' :: CellType -> Maybe CellId -> NotebookState -> Tuple NotebookState CellId
 addCell' cellType parent st =
-  U.head <$> addCellChain cellType (maybe [] pure parent) st
+  extractNewId <$> addCellChain cellType (maybe [] pure parent) st
+  where
+  extractNewId :: forall a. Array a -> a
+  extractNewId = flip U.unsafeIndex (maybe 0 (const 1) parent)
 
 addCellChain :: CellType -> Array CellId -> NotebookState -> Tuple NotebookState (Array CellId)
 addCellChain cellType parents st =
@@ -356,7 +359,7 @@ fromModel
 fromModel browserFeatures path name { cells, dependencies } =
   Tuple
     cells
-    ({ fresh: maybe 0 runCellId $ (map (+ one) <<< maximum) $ map _.cellId cells
+    ({ fresh: maybe 0 (+ 1) $ maximum $ map (runCellId <<< _.cellId) cells
     , accessType: ReadOnly
     , cells: foldr (Cons <<< cellDefFromModel) Nil cells
     , dependencies


### PR DESCRIPTION
This is a mechanism for when we want to use the `output` of a parent cell to set some initial state of a child cell. It's intentionally restricted compared to `EvalCell`, as it's not intended for the newly added cell to go off running queries and doing other async things. Example use cases:

- using the output resource from a parent cell to auto-populate the selected resource in a search cell (included in this PR)
- taking the `VarMap` from a markdown cell to populate the autocomplete list for a query cell (I've not done anything with this, as @cryogenian was working on it).

I didn't want to use the `autorun` behaviour we already have, as it would result in a bunch of branching code in the `EvalCell` cases to see whether we _really_ want the cell to run or not, as in both the above cases we definitely do not want the cell to run immediately, as an empty search is pointless, and evaluating an empty query probably results in an error.

@jonsterling to review please, since I've already tried to explain my intentions here over Slack :wink: