### PR TITLE
Clear the pending cells after running

### DIFF
--- a/src/Notebook/Component.purs
+++ b/src/Notebook/Component.purs
@@ -277,7 +277,10 @@ aceQueryShouldSave (ChildF _ q) =
 
 -- | Runs all cell that are present in the set of pending cells.
 runPendingCells :: Unit -> NotebookDSL Unit
-runPendingCells _ = traverse_ runCell' =<< gets _.pendingCells
+runPendingCells _ = do
+  cells <- gets _.pendingCells
+  modify (_pendingCells .~ S.empty)
+  traverse_ runCell' cells
   where
   runCell' :: CellId -> NotebookDSL Unit
   runCell' cellId = do

--- a/src/Notebook/Component/State.purs
+++ b/src/Notebook/Component/State.purs
@@ -31,8 +31,9 @@ module Notebook.Component.State
   , _viewingCell
   , _path
   , _saveTrigger
-  , _globalVarMap
   , _runTrigger
+  , _globalVarMap
+  , _pendingCells
   , addCell
   , addCell'
   , removeCells
@@ -187,12 +188,17 @@ _viewingCell = lens _.viewingCell _{viewingCell = _}
 _saveTrigger :: LensP NotebookState (Maybe DebounceTrigger)
 _saveTrigger = lens _.saveTrigger _{saveTrigger = _}
 
-_globalVarMap :: LensP NotebookState Port.VarMap
-_globalVarMap = lens _.globalVarMap _{globalVarMap = _}
-
 -- | The debounced trigger for running all cells that are pending.
 _runTrigger :: LensP NotebookState (Maybe DebounceTrigger)
 _runTrigger = lens _.runTrigger _{runTrigger = _}
+
+-- | The global `VarMap`, passed through to the notebook via the URL.
+_globalVarMap :: LensP NotebookState Port.VarMap
+_globalVarMap = lens _.globalVarMap _{globalVarMap = _}
+
+-- | The cells that have been enqueued to run.
+_pendingCells :: LensP NotebookState (S.Set CellId)
+_pendingCells = lens _.pendingCells _{pendingCells = _}
 
 -- | Adds a new cell to the notebook.
 -- |


### PR DESCRIPTION
Currently once a cell has been run, triggering any other cell to run will mean that they both run. This means if you load a notebook, since cells autorun on load, running any cell re-runs the entire notebook. Oops.

Strictly speaking this doesn't reset the pending cells "after" they have been run, but I think in the unlikely case another cell is enqueued while the current set is running, it would be better to have it still run rather than the request to go missing entirely once these cells have been run. 