### PR TITLE
[SD-1310] Restore cell status/failure messages

### DIFF
--- a/less/main.less
+++ b/less/main.less
@@ -425,24 +425,35 @@ ol.breadcrumb {
     .cell-failures, .cell-messages {
         padding-left: 10px;
         line-height: 30px;
+        margin-left: 61px;
         > div:first-child {
             margin-left: 4px;
             display: inline-block;
         }
-        > div:nth-child(2), > pre {
-            background: #fff;
-            padding: 8px 0 8px 10px;
+        > pre {
+            background: none;
+            clear: left;
+            line-height: 30px;
+            padding: 0 10px;
+            margin: 0;
             margin-left: -10px;
+            margin-top: -1px;
             border: 0;
-            border-left: 61px solid #ddd;
+            border-top: 1px dashed #ddd;
+            border-radius: 0;
+            font-size: 85%
         }
         &.collapsed {
             border: none;
         }
+        background: #eee;
+        border-bottom: 1px solid #ddd;
     }
 
     .cell-failures {
-        background: #FAA;
+        background: #faa;
+        > pre { border-top: 1px dashed #ff7878; }
+        border-bottom: 1px solid #ff7878;
     }
 
     button.play-button, button.stop-button {

--- a/less/markdown-output.less
+++ b/less/markdown-output.less
@@ -2,9 +2,7 @@
 
     margin-left: 1em;
 
-    &.fade.in {
-        padding-top: 10px;
-    }
+    padding-top: 10px;
 
     span.slamdown-field {
       > label {

--- a/src/Notebook/Cell/Component.purs
+++ b/src/Notebook/Cell/Component.purs
@@ -246,6 +246,7 @@ makeCellComponentPart def render =
     modify
       $ (_runState %~ finishRun)
       <<< (_output .~ (_.output =<< result))
+      <<< (_messages .~ (maybe [] _.messages result))
     maybe (liftF HaltHF) (pure <<< k <<< _.output) result
   eval (RefreshCell next) = pure next
   eval (TrashCell next) = pure next


### PR DESCRIPTION
I restyled the message area a little to make it look somewhat connected to the run bar too.

Always uses `<pre>` for the messages now too, previously that only applied when the message had a linebreak in it, but I think these messages should be displayed consistently instead. The monospace font gives them more of an "output/status message" feel too...

I also tweaked the order of icons in the status bar a bit, I think it makes sense to have the show/hide messages button first in that list. The "refresh cell" button only appears when the current cell has successfully run and has some content too, as there's no point refreshing the parents leading down to this cell if there is a problem with the cell anyway.

@jonsterling to review please, since you were asking about the status of this feature :smile: :ramen: