### PR TITLE
[SD-1314] Handle decode errors in notebooks

### DIFF
--- a/src/Dashboard/Component.purs
+++ b/src/Dashboard/Component.purs
@@ -100,13 +100,13 @@ type ChildQuery =
   Coproduct Rename.Query
   (Coproduct Menu.QueryP
    (Coproduct Dialog.QueryP
-    Notebook.NotebookQueryP))
+    Notebook.QueryP))
 
 type ChildState g =
   Either Rename.State
   (Either (Menu.StateP g)
    (Either Dialog.StateP
-    Notebook.NotebookStateP))
+    Notebook.StateP))
 
 cpRename
   :: forall g
@@ -127,8 +127,8 @@ cpDialog = cpR :> cpR :> cpL
 cpNotebook
   :: forall g
    . ChildPath
-       Notebook.NotebookStateP (ChildState g)
-       Notebook.NotebookQueryP ChildQuery
+       Notebook.StateP (ChildState g)
+       Notebook.QueryP ChildQuery
        NotebookSlot ChildSlot
 cpNotebook = cpR :> cpR :> cpR
 
@@ -147,7 +147,7 @@ fromDashboard
   :: forall a. (forall i. (a -> i) -> Query i) -> QueryP a
 fromDashboard r = left $ request r
 
-toNotebook :: (Unit -> Notebook.NotebookQuery Unit) -> QueryP Unit
+toNotebook :: (Unit -> Notebook.Query Unit) -> QueryP Unit
 toNotebook =
       right
   <<< ChildF (injSlot cpNotebook unit)
@@ -158,7 +158,7 @@ toNotebook =
   <<< action
 
 fromNotebook
-  :: forall a. (forall i. (a -> i) -> Notebook.NotebookQuery i) -> QueryP a
+  :: forall a. (forall i. (a -> i) -> Notebook.Query i) -> QueryP a
 fromNotebook r =
     right
   $ ChildF (injSlot cpNotebook unit)
@@ -322,7 +322,7 @@ dialogPeek :: forall a. Dialog.Query a -> DashboardDSL Unit
 dialogPeek (Dialog.Dismiss _) = activateKeyboardShortcuts
 dialogPeek (Dialog.Show _ _) = deactivateKeyboardShortcuts
 
-notebookPeek :: forall a. Notebook.NotebookQueryP a -> DashboardDSL Unit
+notebookPeek :: forall a. Notebook.QueryP a -> DashboardDSL Unit
 notebookPeek q = pure unit
 
 menuPeek :: forall a. Menu.QueryP a -> DashboardDSL Unit
@@ -351,7 +351,7 @@ submenuPeek (ChildF _ (HalogenMenu.SelectSubmenuItem v _)) =
 queryDialog :: Dialog.Query Unit -> DashboardDSL Unit
 queryDialog q = query' cpDialog unit (left q) *> pure unit
 
-queryNotebook :: Notebook.NotebookQuery Unit -> DashboardDSL Unit
+queryNotebook :: Notebook.Query Unit -> DashboardDSL Unit
 queryNotebook q = query' cpNotebook unit (left q) *> pure unit
 
 queryRename :: Rename.Query Unit -> DashboardDSL Unit

--- a/src/Dashboard/Menu/Component/Query.purs
+++ b/src/Dashboard/Menu/Component/Query.purs
@@ -29,7 +29,7 @@ import Dashboard.Rename.Component as Rename
 import Notebook.Component as Notebook
 
 type FromMenuQuery =
-  Coproduct Rename.Query (Coproduct Dialog.Query Notebook.NotebookQuery)
+  Coproduct Rename.Query (Coproduct Dialog.Query Notebook.Query)
 
 newtype HelpURI = HelpURI String
 
@@ -43,7 +43,7 @@ helpURIToValue = Left
 dialogQueryToValue :: Dialog.Query Unit -> Value
 dialogQueryToValue = left >>> right >>> Right
 
-notebookQueryToValue :: Notebook.NotebookQuery Unit -> Value
+notebookQueryToValue :: Notebook.Query Unit -> Value
 notebookQueryToValue = right >>> right >>> Right
 
 renameQueryToValue :: Rename.Query Unit -> Value

--- a/src/Notebook/Component/Query.purs
+++ b/src/Notebook/Component/Query.purs
@@ -15,7 +15,7 @@ limitations under the License.
 -}
 
 module Notebook.Component.Query
-  ( NotebookQuery(..)
+  ( Query(..)
   ) where
 
 import Data.BrowserFeatures as BF
@@ -31,7 +31,7 @@ import Utils.Path as UP
 
 -- | GetNameToSave returns name if it hasn't been saved.
 -- | If there is no need to saving notebook name returns `Nothing`
-data NotebookQuery a
+data Query a
   = AddCell CT.CellType a
   | RunActiveCell a
   | RunPendingCells a

--- a/src/Notebook/Effects.purs
+++ b/src/Notebook/Effects.purs
@@ -17,6 +17,7 @@ limitations under the License.
 module Notebook.Effects where
 
 import Ace.Types (ACE())
+import Control.Monad.Eff.Console (CONSOLE())
 import Control.Monad.Eff.Random (RANDOM())
 import Control.Monad.Eff.Ref (REF())
 import Control.Monad.Eff.Ref (REF())
@@ -43,4 +44,5 @@ type NotebookRawEffects =
   , random :: RANDOM
   , ref :: REF
   , timer :: Timer
+  , console :: CONSOLE
   )


### PR DESCRIPTION
This also restores the "loading" state while waiting to load/setup an existing notebook. It's a little ugly as we need to render the cells as hidden during loading otherwise the inner components won't initialise.

This only displays an error if the general notebook model fails to decode, if individual cells fail to decode they will still appear in the restored notebook, just with their default state. Since this shouldn't happen anyway unless we: get the codecs wrong / change the codecs without supporting the old format / someone manipulates the data manually, I don't think this is a huge problem, and it's probably better that most of a notebook may be restored rather than the whole thing failing when just one cell has an issue. I considered adding a similar state to the cells themselves, so they could report when their own decoding fails, but I don't know how necessary that is given the conditions above.

Also `NotebookState` -> `State`, `NotebookQuery` -> `Query` for consistency.

Anyone who has time to review please :smile: