### PR TITLE
"Fix" SD-1326

### DIFF
--- a/src/Notebook/Component.purs
+++ b/src/Notebook/Component.purs
@@ -116,7 +116,11 @@ render state =
           -- otherwise the various nested components won't initialise correctly
         , renderCells false
         ]
-    Ready -> renderCells true
+    Ready ->
+      -- WARNING: Very strange things happen when this is not in a div; see SD-1326.
+      H.div_
+        [ renderCells true
+        ]
     Error err ->
       H.div
         [ P.classes [ B.alert, B.alertDanger ] ]


### PR DESCRIPTION
I have no idea at all why this fixes [SD-1326](https://slamdata.atlassian.net/browse/SD-1326), but perhaps it has something to do with some weird DOM thing that I don't understand. :fearful: 

`git bisect` led me to cbfab9a69aa6ed83bf2fbd49e076e95e52029088; then, I found the "fix" by trying pretty much every subset of the changes in that commit.

Does anyone have any insight on why this would happen in the first place, and why this change helped?