### PR TITLE
Readonly

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "tests"
   ],
   "dependencies": {
-    "purescript-ace-halogen": "^0.4.0",
+    "purescript-ace-halogen": "^0.5.0",
     "purescript-affjax": "^0.10.0",
     "purescript-argonaut": "^0.12.0",
     "purescript-datetime": "^0.9.1",

--- a/less/main.less
+++ b/less/main.less
@@ -703,6 +703,12 @@ div.viz-cell-editor, div.download-cell-editor {
   color: gray;
 }
 
+.readonly-highlight {
+    background-color: blue;
+    opacity: 0.2;
+    position: absolute;
+}
+
 @import "bootstrap-overloads";
 @import "nav";
 @import "menu";

--- a/src/Model/Download.purs
+++ b/src/Model/Download.purs
@@ -1,3 +1,19 @@
+{-
+Copyright 2015 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
 module Model.Download where
 
 import Prelude
@@ -22,6 +38,14 @@ type CSVOptionsRec =
   , arrays :: ArrayMode
   }
 newtype CSVOptions = CSVOptions CSVOptionsRec
+
+instance eqCSVOptions :: Eq CSVOptions where
+  eq (CSVOptions opts) (CSVOptions opts') =
+    opts.colDelimiter == opts'.colDelimiter
+    && opts.rowDelimiter == opts'.rowDelimiter
+    && opts.quoteChar == opts'.quoteChar
+    && opts.escapeChar == opts'.escapeChar
+    && opts.arrays == opts'.arrays
 
 instance encodeJsonCSVOptions :: EncodeJson CSVOptions where
   encodeJson (CSVOptions r) =
@@ -81,6 +105,10 @@ type JSONOptionsRec =
   }
 newtype JSONOptions = JSONOptions JSONOptionsRec
 
+instance eqJsonOptions :: Eq JSONOptions where
+  eq (JSONOptions opts) (JSONOptions opts') =
+    opts.multivalues == opts'.multivalues && opts.precision == opts'.precision
+
 instance encodeJsonJSONOptions :: EncodeJson JSONOptions where
   encodeJson (JSONOptions r) =
        "multivalues" := r.multivalues
@@ -111,6 +139,11 @@ _precision :: LensP JSONOptions PrecisionMode
 _precision = _JSONOptions <<< lens _.precision (_ { precision = _ })
 
 data ArrayMode = Flatten | Separate String
+
+instance eqArrayMode :: Eq ArrayMode where
+  eq Flatten Flatten = true
+  eq (Separate s) (Separate s') = s == s'
+  eq _ _ = false
 
 instance encodeJsonArrayMode :: EncodeJson ArrayMode where
   encodeJson Flatten =

--- a/src/Notebook/Cell/Ace/Model.purs
+++ b/src/Notebook/Cell/Ace/Model.purs
@@ -1,0 +1,56 @@
+{-
+Copyright 2015 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
+module Notebook.Cell.Ace.Model
+  ( Model()
+  , emptyModel
+  , encode
+  , decode
+  ) where
+
+import Prelude
+
+import Control.Bind ((>=>))
+
+import Data.Argonaut
+  (Json(), (:=), (~>), (.?), decodeJson, encodeJson, jsonEmptyObject)
+import Data.Either (Either())
+import Data.Traversable (traverse)
+import Utils.Ace (RangeRec(), encodeRangeRec, decodeRangeRec)
+
+type Model =
+  { text :: String
+  , ranges :: Array RangeRec
+  }
+
+emptyModel :: Model
+emptyModel =
+  { text: ""
+  , ranges: []
+  }
+
+encode :: Model -> Json
+encode m
+   = ("text" := m.text)
+  ~> ("ranges" := (encodeJson $ map encodeRangeRec m.ranges))
+  ~> jsonEmptyObject
+
+
+decode :: Json -> Either String Model
+decode = decodeJson >=> \obj -> do
+  { text: _, ranges: _ }
+    <$> (obj .? "text")
+    <*> (obj .? "ranges" >>= traverse decodeRangeRec)

--- a/src/Notebook/Cell/Chart/ChartConfiguration.purs
+++ b/src/Notebook/Cell/Chart/ChartConfiguration.purs
@@ -23,7 +23,7 @@ import Control.Bind ((>=>))
 import Data.Argonaut (Json(), JCursor(), (:=), (~>), (.?), decodeJson, jsonEmptyObject)
 import Data.Array (filter)
 import Data.Foldable (any)
-import Data.Lens (LensP(), lens, (^.))
+import Data.Lens ((^.))
 import Data.Maybe (maybe)
 import Data.Either (Either())
 

--- a/src/Notebook/Cell/Download/Component.purs
+++ b/src/Notebook/Cell/Download/Component.purs
@@ -1,3 +1,19 @@
+{-
+Copyright 2015 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
 module Notebook.Cell.Download.Component where
 
 import Prelude

--- a/src/Notebook/Cell/Download/Component/Query.purs
+++ b/src/Notebook/Cell/Download/Component/Query.purs
@@ -1,3 +1,19 @@
+{-
+Copyright 2015 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
 module Notebook.Cell.Download.Component.Query where
 
 import Data.Functor.Coproduct (Coproduct())

--- a/src/Notebook/Cell/Download/Component/State.purs
+++ b/src/Notebook/Cell/Download/Component/State.purs
@@ -1,3 +1,19 @@
+{-
+Copyright 2015 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
 module Notebook.Cell.Download.Component.State where
 
 import Prelude

--- a/src/Render/Download.purs
+++ b/src/Render/Download.purs
@@ -1,3 +1,19 @@
+{-
+Copyright 2015 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
 module Render.Download where
 
 import Prelude

--- a/src/Utils/Ace.purs
+++ b/src/Utils/Ace.purs
@@ -1,0 +1,141 @@
+{-
+Copyright 2015 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
+module Utils.Ace where
+
+import Prelude
+
+import Ace.Types (Editor(), EditSession(), ACE(), Position(..), Command(..), Range())
+import Ace.Editor as Editor
+import Ace.EditSession as Session
+import Ace.Document as Document
+import Ace.Anchor as Anchor
+import Ace.Range as Range
+import Ace.KeyBinding as KeyBinding
+import Ace.Marker as Marker
+
+import Control.Bind ((>=>))
+import Control.Monad.Eff (Eff())
+import Control.Monad.Eff.Ref (newRef, writeRef, readRef, REF())
+import Data.Argonaut
+  (Json(), (:=), (~>), (.?), decodeJson, jsonEmptyObject)
+import Data.Array as Arr
+import Data.Either (Either())
+import Data.Maybe (Maybe(..))
+import Data.Traversable as T
+import Data.Tuple (Tuple(..), fst, snd)
+import DOM (DOM())
+
+type Effects e = (ace :: ACE, dom :: DOM, ref :: REF|e)
+
+readonlyClazz :: String
+readonlyClazz = "readonly-highlight"
+
+readonlyTag :: String
+readonlyTag = "readonly"
+
+addMarker :: forall e. Range -> EditSession -> Eff (Effects e) Int
+addMarker r session = Session.addMarker r readonlyClazz readonlyTag false session
+
+type RangeRec =
+  { startRow :: Int
+  , startColumn :: Int
+  , endRow :: Int
+  , endColumn :: Int
+  }
+
+eqRangeRec :: RangeRec -> RangeRec -> Boolean
+eqRangeRec r rr =
+  r.startRow == rr.startRow
+  && r.startColumn == rr.startColumn
+  && r.endRow == rr.endRow
+  && r.endColumn == rr.endColumn
+
+
+encodeRangeRec :: RangeRec -> Json
+encodeRangeRec p
+   = "startRow" := p.startRow
+  ~> "startColumn" := p.startColumn
+  ~> "endRow" := p.endRow
+  ~> "endColumn" := p.endColumn
+  ~> jsonEmptyObject
+
+decodeRangeRec :: Json -> Either String RangeRec
+decodeRangeRec = decodeJson >=> \obj ->
+  { startRow: _, startColumn: _, endRow: _, endColumn: _ }
+    <$> obj .? "startRow"
+    <*> obj .? "startColumn"
+    <*> obj .? "endRow"
+    <*> obj .? "endColumn"
+
+
+readOnly :: forall e. Editor -> RangeRec -> Eff (Effects e) Unit
+readOnly editor {startRow, startColumn, endRow, endColumn} = do
+  session <- Editor.getSession editor
+  document <- Session.getDocument session
+  startAnchor <- Document.createAnchor startRow startColumn document
+  endAnchor <- Document.createAnchor endRow endColumn document
+  Anchor.setInsertRight true endAnchor
+
+  range <- Range.create startRow startColumn endRow endColumn
+  markerRef <- addMarker range session >>= newRef
+  let rerenderMarker _ = do
+        readRef markerRef >>= flip Session.removeMarker session
+        Position {row: startRow, column: startColumn}
+          <- Anchor.getPosition startAnchor
+        Position {row: endRow, column: endColumn}
+          <- Anchor.getPosition endAnchor
+        markRange <- Range.create startRow startColumn endRow endColumn
+        newMid <- addMarker markRange session
+        writeRef markerRef newMid
+  Anchor.onChange startAnchor rerenderMarker
+  Anchor.onChange endAnchor rerenderMarker
+
+  Editor.getKeyBinding editor
+    >>= KeyBinding.addKeyboardHandler \_ hs kstring kcode _ -> do
+      if hs == -1 || (kcode <= 40 && kcode >= 37) -- arrows
+        then pure Nothing
+        else do
+        Position {row: startRow, column: startColumn}
+          <- Anchor.getPosition startAnchor
+        Position {row: endRow, column: endColumn}
+          <- Anchor.getPosition endAnchor
+        selectedRange <- Editor.getSelectionRange editor
+        newRange <-
+          if kstring == "backspace"
+          then Range.create startRow (startColumn + 1) endRow endColumn
+          else if kstring == "delete" || (kstring == "d" && hs == 1)
+               then Range.create startRow startColumn endRow (endColumn - 1)
+               else Range.create startRow (startColumn + 1) endRow (endColumn - 1)
+        intersected <- Range.intersects newRange selectedRange
+        pure if intersected
+             then Just {command: Null, passEvent: false}
+             else Nothing
+  Editor.navigateFileEnd editor
+
+
+getRangeRecs :: forall e. Editor -> Eff (Effects e) (Array RangeRec)
+getRangeRecs editor = do
+  markers <- Editor.getSession editor >>= Session.getMarkers
+  tpls <- T.traverse (\m -> Tuple m <$> Marker.getType m) markers
+  ranges <- T.for (map fst $ Arr.filter (eq "readonly" <<< snd) tpls) Marker.getRange
+  T.for (Arr.catMaybes ranges) mkRangeRec
+  where
+  mkRangeRec :: Range -> Eff (Effects e) RangeRec
+  mkRangeRec r = do
+    Position {row: startRow, column: startColumn} <- Range.getStart r
+    Position {row: endRow, column: endColumn} <- Range.getEnd r
+    pure { startRow, startColumn, endRow, endColumn }

--- a/test/src/Test/Property.purs
+++ b/test/src/Test/Property.purs
@@ -22,7 +22,6 @@ import Control.Monad.Eff.Console (log)
 
 main :: QC Unit
 main = do
-
   log "Check Data.SQL2.Literal..."
   Test.Property.SQL2.Literal.check
 
@@ -71,3 +70,11 @@ main = do
   log "Check Notebook.Model..."
   Test.Property.Notebook.Model.check
 
+  log "Check Model.Download..."
+  Test.Property.Model.Download.check
+
+  log "Check Notebook.Cell.Download.Component.State..."
+  Test.Property.Notebook.Cell.Download.Component.State.check
+
+  log "Check Notebook.Cell.Ace.Model..."
+  Test.Property.Notebook.Cell.Ace.Model.check

--- a/test/src/Test/Property/Model/Download.purs
+++ b/test/src/Test/Property/Model/Download.purs
@@ -1,0 +1,116 @@
+module Test.Property.Model.Download where
+
+import Prelude
+
+import Data.Argonaut (encodeJson, decodeJson)
+import Data.Either (Either(..))
+
+import Test.StrongCheck (QC(), Result(..), Arbitrary, arbitrary, quickCheck, (<?>))
+import Model.Download as D
+
+newtype ArbArrayMode = ArbArrayMode D.ArrayMode
+
+runArbArrayMode :: ArbArrayMode -> D.ArrayMode
+runArbArrayMode (ArbArrayMode m) = m
+
+instance arbitraryArbArrayMode :: Arbitrary ArbArrayMode where
+  arbitrary = do
+    isFlatten <- arbitrary
+    map ArbArrayMode $ if isFlatten
+                       then pure D.Flatten
+                       else map D.Separate arbitrary
+
+checkArrayMode :: QC Unit
+checkArrayMode = quickCheck $ runArbArrayMode >>> \am ->
+  case decodeJson (encodeJson am) of
+    Left err -> Failed $ "Decode failed: " <> err
+    Right am' -> am == am' <?> "Decoded array mode doesn't match ecoded array mode"
+
+
+newtype ArbMultiValueMode = ArbMultiValueMode D.MultiValueMode
+
+runArbMultiValueMode :: ArbMultiValueMode -> D.MultiValueMode
+runArbMultiValueMode (ArbMultiValueMode mm) = mm
+
+instance arbitraryArbMultiValueMode :: Arbitrary ArbMultiValueMode where
+  arbitrary = do
+    isArrayWrapped <- arbitrary
+    pure $ ArbMultiValueMode $ if isArrayWrapped
+                               then D.ArrayWrapped
+                               else D.LineDelimited
+
+checkMultiValueMode :: QC Unit
+checkMultiValueMode = quickCheck $ runArbMultiValueMode >>> \mm ->
+  case decodeJson (encodeJson mm) of
+    Left err -> Failed $ "Decode failed: " <> err
+    Right mm' -> mm == mm' <?> "Decoded multi value mode doesn't match encoded"
+
+newtype ArbPrecisionMode = ArbPrecisionMode D.PrecisionMode
+
+runArbPrecisionMode :: ArbPrecisionMode -> D.PrecisionMode
+runArbPrecisionMode (ArbPrecisionMode pm) = pm
+
+instance arbitraryArbPrecisionMode :: Arbitrary ArbPrecisionMode where
+  arbitrary = do
+    isReadable <- arbitrary
+    pure $ ArbPrecisionMode $ if isReadable
+                              then D.Readable
+                              else D.Precise
+
+checkPrecisionMode :: QC Unit
+checkPrecisionMode = quickCheck $ runArbPrecisionMode >>> \pm ->
+  case decodeJson (encodeJson pm) of
+    Left err -> Failed $ "Decode failed: " <> err
+    Right pm' -> pm == pm' <?> "Decoded precision mode doesn't match encoded"
+
+newtype ArbCSVOptions = ArbCSVOptions D.CSVOptions
+
+instance arbitraryArbCSVOptions :: Arbitrary ArbCSVOptions where
+  arbitrary = do
+    r <- { colDelimiter: _
+         , rowDelimiter: _
+         , quoteChar: _
+         , escapeChar: _
+         , arrays: _
+         }
+         <$> arbitrary
+         <*> arbitrary
+         <*> arbitrary
+         <*> arbitrary
+         <*> (map runArbArrayMode arbitrary)
+    pure $ ArbCSVOptions $ D.CSVOptions r
+
+runArbCSVOptions :: ArbCSVOptions -> D.CSVOptions
+runArbCSVOptions (ArbCSVOptions o) = o
+
+newtype ArbJSONOptions = ArbJSONOptions D.JSONOptions
+
+runArbJSONOptions :: ArbJSONOptions -> D.JSONOptions
+runArbJSONOptions (ArbJSONOptions o) = o
+
+instance arbitraryArbJSONOptions :: Arbitrary ArbJSONOptions where
+  arbitrary = do
+    r <- { multivalues: _, precision: _ }
+         <$> (map runArbMultiValueMode arbitrary)
+         <*> (map runArbPrecisionMode arbitrary)
+    pure $ ArbJSONOptions $ D.JSONOptions r
+
+checkCSVOptions :: QC Unit
+checkCSVOptions = quickCheck $ runArbCSVOptions >>> \opts ->
+  case decodeJson (encodeJson opts) of
+    Left err -> Failed $ "Decode failed: " <> err
+    Right opts' -> opts == opts' <?> "Decoded csv options doesn't match encoded"
+
+checkJSONOptions :: QC Unit
+checkJSONOptions = quickCheck $ runArbJSONOptions >>> \opts ->
+  case decodeJson (encodeJson opts) of
+    Left err -> Failed $ "Decode failed: " <> err
+    Right opts' -> opts == opts' <?> "Decoded json options doesn't match encoded"
+
+check :: QC Unit
+check = do
+  checkPrecisionMode
+  checkMultiValueMode
+  checkArrayMode
+  checkCSVOptions
+  checkJSONOptions

--- a/test/src/Test/Property/Notebook/Cell/Ace/Model.purs
+++ b/test/src/Test/Property/Notebook/Cell/Ace/Model.purs
@@ -1,0 +1,49 @@
+module Test.Property.Notebook.Cell.Ace.Model
+  ( ArbModel()
+  , runArbModel
+  , check
+  ) where
+
+import Prelude
+
+import Data.Array as A
+import Data.Either (Either(..))
+import Data.Foldable (foldl)
+import Notebook.Cell.Ace.Model as M
+import Utils.Ace (RangeRec(), eqRangeRec)
+
+import Test.StrongCheck (QC(), Result(..), Arbitrary, arbitrary, quickCheck, (<?>))
+
+newtype ArbRangeRec = ArbRangeRec RangeRec
+
+runArbRangeRec :: ArbRangeRec -> RangeRec
+runArbRangeRec (ArbRangeRec r) = r
+
+instance arbitraryArbRangeRec :: Arbitrary ArbRangeRec where
+  arbitrary = do
+    r <- { startColumn: _, startRow: _, endColumn: _, endRow: _ }
+         <$> arbitrary
+         <*> arbitrary
+         <*> arbitrary
+         <*> arbitrary
+    pure $ ArbRangeRec r
+
+newtype ArbModel = ArbModel M.Model
+
+runArbModel :: ArbModel -> M.Model
+runArbModel (ArbModel m) = m
+
+instance arbitraryArbModel :: Arbitrary ArbModel where
+  arbitrary = do
+    r <- { text: _, ranges: _ }
+         <$> arbitrary
+         <*> (map (map runArbRangeRec) arbitrary)
+    pure $ ArbModel r
+
+check :: QC Unit
+check = quickCheck $ runArbModel >>> \m ->
+  case M.decode (M.encode m) of
+    Left err -> Failed $ "Decode failed: " <> err
+    Right m' -> (   m.text == m'.text
+                 && foldl conj true (A.zipWith eqRangeRec m.ranges m'.ranges))
+                <?> "Decoded ace cell model doesn't match encoded"

--- a/test/src/Test/Property/Notebook/Cell/Download/Component/State.purs
+++ b/test/src/Test/Property/Notebook/Cell/Download/Component/State.purs
@@ -1,0 +1,37 @@
+module Test.Property.Notebook.Cell.Download.Component.State
+  ( ArbState()
+  , runArbState
+  , check
+  ) where
+
+import Prelude
+
+import Data.Bifunctor (bimap)
+import Data.Either (Either(..))
+import Notebook.Cell.Download.Component.State as M
+
+import Test.StrongCheck (QC(), Result(..), Arbitrary, arbitrary, quickCheck, (<?>))
+import Test.Property.Model.Resource (runArbResource)
+import Test.Property.Model.Download (runArbCSVOptions, runArbJSONOptions)
+
+newtype ArbState = ArbState M.State
+
+runArbState :: ArbState -> M.State
+runArbState (ArbState s) = s
+
+instance arbitraryArbState :: Arbitrary ArbState where
+  arbitrary = do
+    r <- { compress: _, options: _, source: _ }
+         <$> arbitrary
+         <*> (map (bimap runArbCSVOptions runArbJSONOptions) arbitrary)
+         <*> (map runArbResource arbitrary)
+    pure $ ArbState r
+
+check :: QC Unit
+check = quickCheck $ runArbState >>> \m ->
+  case M.decode (M.encode m) of
+    Left err -> Failed $ "Decode failed: " <> err
+    Right m' -> (   m.compress == m'.compress
+                 && m.options == m'.options
+                 && m.source == m'.source)
+                <?> "Decoded download cell model doesn't match encoded"


### PR DESCRIPTION
depends on slamdata/purescript-ace#19

+ Readonly regions are set in `SetupCell` for query-cells.
+ These regions are saved and restored during serialization. 
+ Regions aren't part of cell state, they live in `Editor`. 

@garyb please, review