### PR TITLE
Quesion: count error

### DIFF
--- a/src/Notebook/Component.purs
+++ b/src/Notebook/Component.purs
@@ -47,7 +47,7 @@ import Data.Path.Pathy ((</>))
 import Data.Path.Pathy as Pathy
 import Data.Set as S
 import Data.String as Str
-import Data.These (These(..), theseRight)
+import Data.These (These(..))
 import Data.Time (Milliseconds(..))
 import Data.Traversable (for)
 import Data.Tuple (Tuple(..), fst, snd)
@@ -263,6 +263,7 @@ peekCell cellId q = case q of
   TrashCell _ -> do
     descendants <- gets (findDescendants cellId)
     modify $ removeCells (S.insert cellId descendants)
+    triggerSave unit
   CreateChildCell cellType _ -> do
     Tuple st newCellId <- gets $ addCell' cellType (Just cellId)
     set st

--- a/src/Notebook/Component/Query.purs
+++ b/src/Notebook/Component/Query.purs
@@ -20,7 +20,6 @@ module Notebook.Component.Query
 
 import Data.BrowserFeatures as BF
 import Data.Maybe as M
-import Data.Path.Pathy as P
 
 import Model.AccessType as AT
 import Notebook.Cell.CellId as CID


### PR DESCRIPTION
Querying non-existent collection produce sql-mount that responds `"["` to all requests. This blocks ui rendering. 
So, there are couple questions: 
+ Why do we use `retry defaultPolicy` in `getOnce`? Could we switch to `affjax`? 
+ Error produced in result cell couldn't be shown, could it? Good example of this problem is exploring non-existent files: resource is propagated to `JTable` without any check and `JTable` doesn't say anything about it. We can check if resource is correct in  explore's `cellEval`, is this ok? 
+ OTOH, maybe it would be better to show result cell errors, probably displayed on top of editor cells error panel. What do you think? 