### PR TITLE
clean view mount children before move/delete

### DIFF
--- a/src/Model/Resource.purs
+++ b/src/Model/Resource.purs
@@ -136,7 +136,7 @@ newDatabase :: Resource
 newDatabase = Database $ P.rootDir </> P.dir Config.newDatabaseName
 
 newViewMount :: Resource
-newViewMount = Database $ P.rootDir </> P.dir Config.newViewMountName
+newViewMount = ViewMount $ P.rootDir </> P.file Config.newViewMountName
 
 -- CONSTRUCTORS
 root :: Resource


### PR DESCRIPTION
@jonsterling review, please

Fixes SD-1290
+ Fixed `Model.Resource.newViewMount` 
+ Check if resource has view mount children and remove them before move/delete