### PR TITLE
Explore fixes

### DIFF
--- a/src/Dashboard/Component.purs
+++ b/src/Dashboard/Component.purs
@@ -407,7 +407,8 @@ cellPeek cid q =
         _ ->
           pure SM.empty
 
-    liftFormBuilderQuery :: CID.CellId -> Natural FB.Query (ET.ExceptT String DashboardDSL)
+    liftFormBuilderQuery
+      :: CID.CellId -> Natural FB.Query (ET.ExceptT String DashboardDSL)
     liftFormBuilderQuery cid =
       liftCellQuery cid
         <<< CQ.APIQuery
@@ -415,7 +416,8 @@ cellPeek cid q =
         <<< ChildF unit
         <<< left
 
-    liftCellQuery :: CID.CellId -> Natural CQ.AnyCellQuery (ET.ExceptT String DashboardDSL)
+    liftCellQuery
+      :: CID.CellId -> Natural CQ.AnyCellQuery (ET.ExceptT String DashboardDSL)
     liftCellQuery cid =
       queryCell cid >>> MT.lift
         >=> maybe (EC.throwError "Error querying cell") pure

--- a/src/FileSystem/Item.purs
+++ b/src/FileSystem/Item.purs
@@ -38,6 +38,7 @@ import Halogen.HTML.Properties as P
 import Halogen.HTML.Properties.ARIA as ARIA
 import Halogen.Query (action, modify, gets)
 import Halogen.Themes.Bootstrap3 as B
+import Halogen.CustomProps as Cp
 
 import CSS.Geometry (marginBottom)
 import CSS.Size (px)
@@ -230,6 +231,7 @@ showToolbar it =
 
   toolItem func label cls =
     H.li_ [ H.button [ E.onClick (\_ -> pure $ action func)
+                     , Cp.mbDoubleClick (\_ -> E.stopPropagation $> Nothing)
                      , ARIA.label label
                      , P.title label
                      ]

--- a/src/Halogen/CustomProps.purs
+++ b/src/Halogen/CustomProps.purs
@@ -56,6 +56,9 @@ mbKeyDown = mbHandler (eventName "keydown")
 mbClick :: forall i. MbEventProp MouseEvent i
 mbClick = mbHandler (eventName "click")
 
+mbDoubleClick :: forall i. MbEventProp MouseEvent i
+mbDoubleClick = mbHandler (eventName "dblclick")
+
 mbInput :: forall i. MbEventProp () i
 mbInput = mbHandler (eventName "input")
 

--- a/src/Halogen/CustomProps/Indexed.purs
+++ b/src/Halogen/CustomProps/Indexed.purs
@@ -22,7 +22,7 @@ import Unsafe.Coerce (unsafeCoerce)
 
 import Data.Maybe (Maybe())
 import Halogen.HTML.Events.Handler (EventHandler())
-import Halogen.HTML.Events.Types (Event())
+import Halogen.HTML.Events.Types (Event(), MouseEvent())
 import Halogen.HTML.Properties.Indexed (IProp(), I())
 import Halogen.CustomProps as Cp
 
@@ -39,3 +39,5 @@ mbValueInput = unsafeCoerce Cp.mbValueInput
 nonSubmit :: forall i r . IProp (onSubmit :: I | r) i
 nonSubmit = unsafeCoerce Cp.nonSubmit
 
+mbDoubleClick :: forall r i. MbIEventProp (onDoubleClick :: I|r) MouseEvent i
+mbDoubleClick = unsafeCoerce Cp.mbDoubleClick

--- a/src/Model/Common.purs
+++ b/src/Model/Common.purs
@@ -31,22 +31,19 @@ import Data.Foldable as F
 import Data.Maybe as M
 import Data.Path.Pathy as P
 import Data.StrMap as SM
-import Data.Either as E
 
 import Model.AccessType as AT
 import Model.Notebook.Action as NA
 import Notebook.Cell.Port.VarMap as Port
 import Notebook.Cell.CellId as CID
-import Model.Resource as Resource
 import Model.Salt as Salt
 import Model.Sort as Sort
 
-
 import Utils.Path as UP
 
-parentURL :: UP.DirPath -> String
+parentURL :: UP.AnyPath -> String
 parentURL childPath =
-  browseURL M.Nothing Sort.Asc (Salt.Salt "") $ UP.getDir $ E.Right childPath
+  browseURL M.Nothing Sort.Asc (Salt.Salt "") $ UP.getDir childPath
 
 browseURL :: M.Maybe String -> Sort.Sort -> Salt.Salt -> UP.DirPath -> String
 browseURL search sort salt path =


### PR DESCRIPTION
+ Added `mbDoubleClickHandler` to stop double click propagation from toolbar buttons. It's impossible to accidentally open notebook during deleting/moving. 
+ Back button fix in explore mode
+ Drop state in `ExploreFile` 
+ Altered behavior of `SetName` in notebook. (Actually I think it's just backport of current _master_) 

@garyb please, review