### PR TITLE
Sd 1346

### DIFF
--- a/src/SlamData/Notebook/Cell/API/Component.purs
+++ b/src/SlamData/Notebook/Cell/API/Component.purs
@@ -106,6 +106,7 @@ eval q =
       F.for_ (Model.decode json) \{items} ->
         query unit $ action (FB.SetItems (L.toList items) >>> left)
       pure next
+    NC.SetCanceler _ next -> pure next
 
 getChildF :: forall i f. Natural (ChildF i f) f
 getChildF (ChildF _ q) =

--- a/src/SlamData/Notebook/Cell/APIResults/Component.purs
+++ b/src/SlamData/Notebook/Cell/APIResults/Component.purs
@@ -98,3 +98,4 @@ evalCell q =
       pure $ k J.jsonEmptyObject
     NC.Load json next ->
       pure next
+    NC.SetCanceler _ next -> pure next

--- a/src/SlamData/Notebook/Cell/Ace/Component.purs
+++ b/src/SlamData/Notebook/Cell/Ace/Component.purs
@@ -119,3 +119,4 @@ aceComponent {mode, evaluator, setup} = makeEditorCellComponent
       F.traverse_ (readOnly editor) ranges
       Editor.navigateFileEnd editor
     pure next
+  eval (SetCanceler _ next) = pure next

--- a/src/SlamData/Notebook/Cell/Chart/Component.purs
+++ b/src/SlamData/Notebook/Cell/Chart/Component.purs
@@ -94,3 +94,4 @@ eval (Ec.SetupCell _ next) = pure next
 -- the notebook is restored
 eval (Ec.Save k) = pure (k jsonEmptyObject)
 eval (Ec.Load _ next) = pure next
+eval (Ec.SetCanceler _ next) = pure next

--- a/src/SlamData/Notebook/Cell/Common/EvalQuery.purs
+++ b/src/SlamData/Notebook/Cell/Common/EvalQuery.purs
@@ -26,10 +26,17 @@ module SlamData.Notebook.Cell.Common.EvalQuery
   , runCellEvalT
   , temporaryOutputResource
   , prepareCellEvalInput
+  , liftWithCanceler
+  , liftWithCanceler'
   ) where
 
 import Prelude
 
+import Control.Coroutine.Aff (produce)
+import Control.Coroutine.Stalling as SCR
+
+import Control.Monad.Aff (Canceler(), forkAff)
+import Control.Monad.Aff.AVar (makeVar, putVar, takeVar)
 import Control.Monad.Error.Class as EC
 import Control.Monad.Except.Trans as ET
 import Control.Monad.Trans as MT
@@ -38,17 +45,23 @@ import Control.Monad.Writer.Trans as WT
 
 import Data.Argonaut.Core (Json())
 import Data.Either as E
+import Data.Functor.Coproduct (Coproduct(), left)
 import Data.Maybe as M
 import Data.Path.Pathy ((</>))
 import Data.Path.Pathy as P
+import Data.Functor.Aff (liftAff)
 import Data.Tuple as TPL
 
 import SlamData.FileSystem.Resource as R
 import SlamData.Notebook.Cell.CellId as CID
 import SlamData.Notebook.Cell.Port (Port())
 import SlamData.Notebook.Cell.Port.VarMap as Port
+import SlamData.Notebook.Effects (Slam(), NotebookEffects())
 
 import Utils.Path (DirPath())
+
+import Halogen (ParentDSL(), subscribe')
+import Halogen.Query.EventSource (EventSource(..))
 
 type CellEvalInputP r =
   { notebookPath :: M.Maybe DirPath
@@ -116,6 +129,7 @@ data CellEvalQuery a
   = EvalCell CellEvalInput (CellEvalResult -> a)
   | SetupCell CellSetupInfo a
   | NotifyRunCell a
+  | SetCanceler (Canceler NotebookEffects) a
   | Save (Json -> a)
   | Load Json a
 
@@ -175,3 +189,42 @@ runCellEvalT (CellEvalT m) =
     { output: E.either (const M.Nothing) M.Just r
     , messages: E.either (E.Left >>> pure) (const []) r <> map E.Right ms
     }
+
+
+liftWithCanceler
+  :: forall a state slot innerQuery innerState
+   . Slam a
+  -> ParentDSL state innerState CellEvalQuery innerQuery Slam slot a
+liftWithCanceler aff = do
+  v <- liftAff makeVar
+  canceler <- liftAff $ forkAff do
+    res <- aff
+    putVar v res
+  subscribe'
+    $ EventSource
+    $ SCR.producerToStallingProducer
+    $ produce \emit -> do
+      emit $ E.Left $ SetCanceler canceler unit
+      emit $ E.Right unit
+  liftAff $ takeVar v
+
+
+liftWithCanceler'
+  :: forall a state innerState innerQuery query slot
+   . Slam a
+  -> ParentDSL
+       state innerState
+       (Coproduct CellEvalQuery query) innerQuery
+       Slam slot a
+liftWithCanceler' aff = do
+  v <- liftAff makeVar
+  canceler <- liftAff $ forkAff do
+    res <- aff
+    putVar v res
+  subscribe'
+    $ EventSource
+    $ SCR.producerToStallingProducer
+    $ produce \emit -> do
+      emit $ E.Left $ left $ SetCanceler canceler unit
+      emit $ E.Right unit
+  liftAff $ takeVar v

--- a/src/SlamData/Notebook/Cell/Component/Query.purs
+++ b/src/SlamData/Notebook/Cell/Component/Query.purs
@@ -82,6 +82,7 @@ import SlamData.Notebook.Cell.Viz.Component.Query as Viz
 -- |   share/embed message appropriate for the cell.
 data CellQuery a
   = RunCell a
+  | StopCell a
   | UpdateCell CellEvalInputPre (Maybe Port -> a)
   | RefreshCell a
   | TrashCell a

--- a/src/SlamData/Notebook/Cell/Component/Render.purs
+++ b/src/SlamData/Notebook/Cell/Component/Render.purs
@@ -86,7 +86,9 @@ statusBar hasResults cs =
     [ P.classes [CSS.cellEvalLine, B.clearfix, B.row] ]
     $ [ H.button
           [ P.classes [B.btn, B.btnPrimary, button.className]
-          , E.onClick (E.input_ RunCell)
+          , E.onClick (E.input_ $ if isRunning cs.runState
+                                  then StopCell
+                                  else RunCell)
           , P.title button.label
           , ARIA.label button.label
           ]

--- a/src/SlamData/Notebook/Cell/Component/State.purs
+++ b/src/SlamData/Notebook/Cell/Component/State.purs
@@ -30,6 +30,7 @@ module SlamData.Notebook.Cell.Component.State
   , _cachingEnabled
   , _input
   , _output
+  , _canceler
   , AnyCellState()
   , _AceState
   , _ExploreState
@@ -45,8 +46,11 @@ module SlamData.Notebook.Cell.Component.State
 
 import Prelude
 
+import Control.Monad.Aff (Canceler())
+
 import Data.Either (Either())
 import Data.Lens (LensP(), lens, PrismP(), TraversalP(), prism', wander)
+import Data.Monoid (mempty)
 import Data.Maybe (Maybe(..))
 import Data.Visibility (Visibility(..))
 
@@ -66,7 +70,7 @@ import SlamData.Notebook.Cell.Port (Port())
 import SlamData.Notebook.Cell.RunState (RunState(..))
 import SlamData.Notebook.Cell.Search.Component.State as Search
 import SlamData.Notebook.Cell.Viz.Component.State as Viz
-import SlamData.Notebook.Effects (Slam())
+import SlamData.Notebook.Effects (Slam(), NotebookEffects())
 
 -- | The common state value for notebook cells.
 -- |
@@ -98,6 +102,7 @@ type CellState =
   , cachingEnabled :: Maybe Boolean -- Nothing if the option isn't available
   , input :: Maybe Port
   , output :: Maybe Port
+  , canceler :: Canceler NotebookEffects
   }
 
 type CellStateP = InstalledState CellState AnyCellState CellQuery InnerCellQuery Slam Unit
@@ -116,6 +121,7 @@ initEditorCellState =
   , cachingEnabled: Nothing
   , input: Nothing
   , output: Nothing
+  , canceler: mempty
   }
 
 -- | Creates an initial `CellState` value for a results cell.
@@ -132,6 +138,7 @@ initResultsCellState =
   , cachingEnabled: Nothing
   , input: Nothing
   , output: Nothing
+  , canceler: mempty
   }
 
 _accessType :: LensP CellState AccessType
@@ -174,6 +181,9 @@ _input = lens _.input (_ { input = _ })
 -- | the cell was evaluated.
 _output :: LensP CellState (Maybe Port)
 _output = lens _.output (_ { output = _ })
+
+_canceler :: LensP CellState (Canceler NotebookEffects)
+_canceler = lens _.canceler _{canceler = _}
 
 data AnyCellState
   = AceState Ace.StateP

--- a/src/SlamData/Notebook/Cell/Download/Component.purs
+++ b/src/SlamData/Notebook/Cell/Download/Component.purs
@@ -157,6 +157,7 @@ cellEval (Ec.SetupCell { inputPort } next) = do
   for_ (preview P._Resource inputPort) \res ->
     modify $ _source .~ res
   pure next
+cellEval (Ec.SetCanceler _ next) = pure next
 
 downloadEval :: Natural Query DownloadDSL
 downloadEval (SetOutput ty next) = do

--- a/src/SlamData/Notebook/Cell/Explore/Component.purs
+++ b/src/SlamData/Notebook/Cell/Explore/Component.purs
@@ -29,7 +29,6 @@ import Control.Monad.Trans as MT
 
 import Data.Argonaut (encodeJson, decodeJson)
 import Data.Either (Either(..), either)
-import Data.Functor.Aff (liftAff)
 import Data.Maybe (Maybe(..), maybe)
 
 import Halogen
@@ -75,7 +74,7 @@ eval (NC.EvalCell info k) =
         <#> (join <<< maybe (Left "There is no file input subcomponent") Right)
         # MT.lift
         >>= either EC.throwError pure
-    (MT.lift $ liftAff $ Quasar.resourceExists resource)
+    (MT.lift $ NC.liftWithCanceler $ Quasar.resourceExists resource)
       >>= \x -> unless x $ EC.throwError
                 $ "File " <> R.resourcePath resource <> " doesn't exist"
 
@@ -90,3 +89,4 @@ eval (NC.Load json next) = do
   let file = either (const Nothing) id $ decodeJson json
   maybe (pure unit) (\file' -> void $ query unit $ action (FI.SelectFile file')) file
   pure next
+eval (NC.SetCanceler _ next) = pure next

--- a/src/SlamData/Notebook/Cell/JTable/Component.purs
+++ b/src/SlamData/Notebook/Cell/JTable/Component.purs
@@ -93,6 +93,7 @@ evalCell (Save k) =
 evalCell (Load json next) = do
   either (const (pure unit)) set $ fromModel <$> Model.decode json
   pure next
+evalCell (SetCanceler _ next) = pure next
 
 -- | Evaluates jtable-specific cell queries.
 evalJTable :: Natural Query (ComponentDSL State QueryP Slam)

--- a/src/SlamData/Notebook/Cell/Markdown/Component.purs
+++ b/src/SlamData/Notebook/Cell/Markdown/Component.purs
@@ -123,6 +123,7 @@ eval (Load json next) = do
         query unit $ action (MD.PopulateForm state)
     _ -> pure unit
   pure next
+eval (SetCanceler _ next) = pure next
 
 error :: String -> CellEvalResult
 error msg =

--- a/src/SlamData/Notebook/Editor/Component.purs
+++ b/src/SlamData/Notebook/Editor/Component.purs
@@ -286,6 +286,10 @@ peekCell cellId q = case q of
     when (autorun cellType) $ runCell newCellId
     triggerSave unit
   ShareCell _ -> pure unit
+  StopCell _ -> do
+    modify $ _runTrigger .~ Nothing
+    modify $ _pendingCells %~ S.delete cellId
+    runPendingCells unit
   _ -> pure unit
 
 -- | Peek on the inner cell components to observe `NotifyRunCell`, which is
@@ -331,7 +335,6 @@ aceQueryShouldSave (ChildF _ q) =
 runPendingCells :: Unit -> NotebookDSL Unit
 runPendingCells _ = do
   cells <- gets _.pendingCells
-  modify (_pendingCells .~ S.empty)
   traverse_ runCell' cells
   where
   runCell' :: CellId -> NotebookDSL Unit
@@ -348,6 +351,7 @@ runPendingCells _ = do
           Nothing -> pure unit
           -- if there's a parent and an output, pass it on as this cell's input
           Just p -> updateCell (Just p) cellId
+    modify $ _pendingCells %~ S.delete cellId
     triggerSave unit
 
 -- | Enqueues the cell with the specified ID in the set of cells that are


### PR DESCRIPTION
Fixes SD-1346 

+ Added `AddCanceler` and `Cancel` to `CellEvalQuery`. First is for canceling computation from inner cell, second for adding canceler to cell state.
+ Added helper function that lifts `Aff` and emits `AddCanceler`. 
+ Machinery for stopping cells in `Notebook.Component`. 

@garyb please, review. Should I rebase this to #634? 