### PR TITLE
[SD-1351] Clear results when running a cell errors

### DIFF
--- a/src/SlamData/Notebook/Cell/Download/Component/State.purs
+++ b/src/SlamData/Notebook/Cell/Download/Component/State.purs
@@ -19,25 +19,27 @@ module SlamData.Notebook.Cell.Download.Component.State where
 import Prelude
 
 import Control.Bind ((>=>))
+
 import Data.Argonaut (Json(), (:=), (~>), (.?), decodeJson, jsonEmptyObject)
-import Data.Either
+import Data.Either (Either(..))
 import Data.Lens (LensP(), lens)
-import SlamData.FileSystem.Resource (Resource(), root)
+import Data.Maybe (Maybe(..))
+
 import SlamData.Download.Model as D
+import SlamData.FileSystem.Resource (Resource())
 
 type State =
   { compress :: Boolean
   , options :: Either D.CSVOptions D.JSONOptions
-  , source :: Resource
+  , source :: Maybe Resource
   }
 
 initialState :: State
 initialState =
   { compress: false
   , options: Left D.initialCSVOptions
-  , source: root
+  , source: Nothing
   }
-
 
 _compress :: forall a r. LensP {compress :: a|r} a
 _compress = lens _.compress _{compress = _}

--- a/src/SlamData/Notebook/Cell/Port.purs
+++ b/src/SlamData/Notebook/Cell/Port.purs
@@ -45,6 +45,7 @@ data Port
   | VarMap VarMap
   | ChartOptions ChartPort
   | TaggedResource {tag :: Maybe String, resource :: R.Resource }
+  | Blocked
 
 _SlamDown :: PrismP Port SlamDown
 _SlamDown = prism' SlamDown \p -> case p of
@@ -71,3 +72,8 @@ _Resource :: TraversalP Port R.Resource
 _Resource = wander \f s -> case s of
   TaggedResource o -> (TaggedResource <<< o{resource = _}) <$> f o.resource
   _ -> pure s
+
+_Blocked :: PrismP Port Unit
+_Blocked = prism' (const Blocked) \p -> case p of
+  Blocked -> Just unit
+  _ -> Nothing

--- a/src/SlamData/Notebook/Cell/Search/Component.purs
+++ b/src/SlamData/Notebook/Cell/Search/Component.purs
@@ -114,6 +114,8 @@ eval = coproduct cellEval searchEval
 cellEval :: Natural NC.CellEvalQuery (ParentDSL State FI.State Query FI.Query Slam Unit)
 cellEval q =
   case q of
+    NC.EvalCell { inputPort: M.Just Port.Blocked } k -> do
+      pure $ k { output: M.Nothing, messages: [] }
     NC.EvalCell info k -> runWith do
       k <$> NC.runCellEvalT do
         inputResource <-

--- a/src/SlamData/Notebook/Editor/Component.purs
+++ b/src/SlamData/Notebook/Editor/Component.purs
@@ -39,7 +39,7 @@ import Data.Functor.Coproduct (coproduct, left, right)
 import Data.Functor.Eff (liftEff)
 import Data.Lens (LensP(), view, (.~), (%~), (?~))
 import Data.List as List
-import Data.Maybe (Maybe(..), maybe, isNothing)
+import Data.Maybe (Maybe(..), maybe, fromMaybe, isNothing)
 import Data.Path.Pathy ((</>))
 import Data.Path.Pathy as Pathy
 import Data.Set as S
@@ -75,7 +75,7 @@ import SlamData.Notebook.Cell.Common.EvalQuery (CellEvalQuery(..))
 import SlamData.Notebook.Cell.Component (CellQueryP(), CellQuery(..), InnerCellQuery(), CellStateP(), AnyCellQuery(..))
 import SlamData.Notebook.Cell.JTable.Component as JTC
 import SlamData.Notebook.Cell.Markdown.Component as MDC
-import SlamData.Notebook.Cell.Port (Port())
+import SlamData.Notebook.Cell.Port (Port(..))
 import SlamData.Notebook.Editor.Component.CellSlot (CellSlot(..))
 import SlamData.Notebook.Editor.Component.Query
 import SlamData.Notebook.Editor.Component.State
@@ -372,7 +372,7 @@ updateCell inputPort cellId = do
   globalVarMap <- gets _.globalVarMap
   let input = { notebookPath: path, inputPort, cellId, globalVarMap }
   result <- join <$> (query (CellSlot cellId) $ left $ request (UpdateCell input))
-  maybe (pure unit) (runCellDescendants cellId) result
+  runCellDescendants cellId (fromMaybe Blocked result)
   where
   runCellDescendants :: CellId -> Port -> NotebookDSL Unit
   runCellDescendants parentId value = do

--- a/test/src/Test/Property/SlamData/Notebook/Cell/Download/Component/State.purs
+++ b/test/src/Test/Property/SlamData/Notebook/Cell/Download/Component/State.purs
@@ -24,7 +24,7 @@ instance arbitraryArbState :: Arbitrary ArbState where
     r <- { compress: _, options: _, source: _ }
          <$> arbitrary
          <*> (map (bimap runArbCSVOptions runArbJSONOptions) arbitrary)
-         <*> (map runArbResource arbitrary)
+         <*> (map (map runArbResource) arbitrary)
     pure $ ArbState r
 
 check :: QC Unit


### PR DESCRIPTION
The fix I've put in here definitely does what the title here says, but I'm not sure if this is entirely the best way to handle it.

The two concerns I have: 

1. We possibly need to put a fallback case in each result cell eval to reset the state when a `Nothing` input port is provided.
2. The cell error will propagate into any descendant cells also, possibly causing other issues.

I think 1 is maybe okay as it is, as I'm pretty sure only cells that feed into JTable can fail in the way we're talking about here, so the other results cells don't need to do anything in particular.

2 is more of a worry, as it's difficult to not propagate this to descendants due to the structure of notebooks now.

Any thoughts @cryogenian, @jonsterling?