### PR TITLE
drop jtable page to first if resource has been changed

### DIFF
--- a/src/SlamData/Notebook/Cell/Component.purs
+++ b/src/SlamData/Notebook/Cell/Component.purs
@@ -187,7 +187,7 @@ makeResultsCellComponent def = makeCellComponentPart def render
   nextCellButtons (Just p) = case p of
     VarMap _ ->
       [ nextCellButton (Ace SQLMode) ]
-    Resource _ ->
+    TaggedResource _ ->
       [ nextCellButton (Ace SQLMode)
       , nextCellButton Search
       , nextCellButton Viz

--- a/src/SlamData/Notebook/Cell/Explore/Component.purs
+++ b/src/SlamData/Notebook/Cell/Explore/Component.purs
@@ -78,7 +78,7 @@ eval (NC.EvalCell info k) =
       >>= \x -> unless x $ EC.throwError
                 $ "File " <> R.resourcePath resource <> " doesn't exist"
 
-    pure $ Port.Resource resource
+    pure $ Port.TaggedResource {resource, tag: Nothing}
 eval (NC.SetupCell _ next) = pure next
 eval (NC.Save k) = do
   file <- query unit (request FI.GetSelectedFile)

--- a/src/SlamData/Notebook/Cell/JTable/Component/State.purs
+++ b/src/SlamData/Notebook/Cell/JTable/Component/State.purs
@@ -91,6 +91,7 @@ _isEnteringPageSize = lens _.isEnteringPageSize (_ { isEnteringPageSize = _ })
 -- | The cell input state.
 type Input =
   { resource :: Resource
+  , tag :: Maybe String
   , size :: Int
   }
 
@@ -101,6 +102,11 @@ _resource = lens _.resource (_ { resource = _ })
 -- | The total size of the resource's result set.
 _size :: LensP Input Int
 _size = lens _.size (_ { size = _ })
+
+-- | This is used to determine if query producing temporary resource has
+-- | been changed. It holds sql query.
+_tag :: LensP Input (Maybe String)
+_tag = lens _.tag _{tag = _}
 
 -- | A record with information about the current page number, page size, and
 -- | total number of pages.
@@ -174,11 +180,6 @@ setPageSize size = _pageSize ?~ Left size
 
 toModel :: State -> Model
 toModel st = { input: Nothing, result: Nothing }
--- toModel =
---   { input: st.input
---   , page: view _These st.page
---   , pageSize: view _These st.pageSize
---   }
 
 fromModel :: Model -> State
 fromModel _ = initialState

--- a/src/SlamData/Notebook/Cell/Search/Component.purs
+++ b/src/SlamData/Notebook/Cell/Search/Component.purs
@@ -150,7 +150,7 @@ cellEval q =
           >>= \x -> when (not x)
                     $ EC.throwError "Error making search temporary resource"
 
-        pure $ Port.Resource outputResource
+        pure $ Port.TaggedResource { resource: outputResource, tag: pure sql }
 
     NC.SetupCell { inputPort } next -> do
       case preview Port._Resource inputPort of


### PR DESCRIPTION
Fixes SD-1352 

+ Added `TaggedResource` constructor to `Port` it takes `Resource` and `String` (here this string is sql producing this resource)
+ Changed type of output port in search and query cell to `TaggedResource`. 
+ Added check that resource _or_ tag have been changed in jtable eval. It drops jtable state to initial.

@jonsterling please, review