### PR TITLE
deletion view mounts fix

### DIFF
--- a/src/SlamData/Notebook/Cell/Common/EvalQuery.purs
+++ b/src/SlamData/Notebook/Cell/Common/EvalQuery.purs
@@ -95,11 +95,13 @@ prepareCellEvalInput cachingEnabled { notebookPath, inputPort, cellId, globalVar
   }
 
 temporaryOutputResource
-  :: forall r
-   . CellEvalInputP r
+  :: CellEvalInput
   -> R.Resource
 temporaryOutputResource info =
-  R.mkFile $ E.Left $ outputDirectory </> outputFile
+  (outputDirectory </> outputFile)
+    # if M.fromMaybe false info.cachingEnabled
+      then R.File
+      else R.ViewMount
   where
     outputDirectory =
       filterMaybe (== P.rootDir) info.notebookPath #


### PR DESCRIPTION
This unfortunately doesn't fix that `net::...` error and my `[` error, but fixes deletion of view mounts. 
@jonsterling please, review. 
I think we shouldn't release this before finding what's going on with these errors. It could be somehow be connected with `slamjax` retry policies. 