### PR TITLE
Simplify default build, ignore /jars/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /coverage/
 /test/node_modules
 /test/index.js
+/jars/
 public/js/*.js
 !public/js/ace*
 !public/js/keyboard*

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -156,5 +156,5 @@ gulp.task("less", function() {
 });
 mkWatch("watch-less", "less", ["less/**/*.less"]);
 
-// gulp.task("default", ["add-headers", "trim-whitespace", "less", "bundle"]);
-gulp.task("default", ["less", "make", "property-tests", "bundle"]);
+gulp.task("full", ["add-headers", "trim-whitespace", "less", "bundle"]);
+gulp.task("default", ["less", "bundle"]);


### PR DESCRIPTION
Two little things that have been slightly irritating.

The `property-tests` task is still run as part of Travis, so even if we forget to run it locally we'll still pick up any breakages that way.