### PR TITLE
SD-1373 (auth)

### DIFF
--- a/src/Quasar/Auth.purs
+++ b/src/Quasar/Auth.purs
@@ -1,0 +1,38 @@
+module Quasar.Auth
+  ( IdToken()
+  , authHeader
+  , authed
+  , retrieveIdToken
+  ) where
+
+import Prelude
+import Control.Monad.Eff (Eff())
+import Control.Monad.Eff.Class (liftEff)
+import Control.Monad.Aff (Aff())
+import Data.Maybe as M
+import DOM (DOM())
+import Network.HTTP.RequestHeader
+
+newtype IdToken = IdToken String
+
+authHeader
+  :: IdToken
+  -> RequestHeader
+authHeader (IdToken tok) =
+  RequestHeader
+    "Authorization"
+    ("Bearer " <> tok)
+
+
+-- | TODO!!
+retrieveIdToken :: forall e. Eff (dom :: DOM | e) (M.Maybe IdToken)
+retrieveIdToken =
+  pure M.Nothing
+
+authed
+  :: forall a e
+   . (M.Maybe IdToken -> Aff (dom :: DOM | e) a)
+  -> Aff (dom :: DOM | e) a
+authed f =
+  liftEff retrieveIdToken
+    >>= f

--- a/src/SlamData/FileSystem/Dialog/Mount/Component.purs
+++ b/src/SlamData/FileSystem/Dialog/Mount/Component.purs
@@ -46,6 +46,7 @@ import Halogen
 import Network.HTTP.Affjax (AJAX())
 
 import Quasar.Aff as API
+import Quasar.Auth as Auth
 
 import SlamData.FileSystem.Dialog.Mount.Component.Query
 import SlamData.FileSystem.Dialog.Mount.Component.Render
@@ -103,7 +104,7 @@ eval (Save next) = do
   let resource = R.Database $ state.parent </> dir state.name
   modify (_inProgress .~ true)
   modify (_externalValidationError .~ Nothing)
-  result <- liftAff $ attempt $ API.saveMount resource state.connectionURI
+  result <- liftAff $ attempt $ Auth.authed $ API.saveMount resource state.connectionURI
   case result of
     Left err -> do
       modify (_externalValidationError ?~ msg err)

--- a/src/SlamData/FileSystem/Dialog/SQLMount/Component.purs
+++ b/src/SlamData/FileSystem/Dialog/SQLMount/Component.purs
@@ -31,6 +31,7 @@ import Halogen.HTML.Properties.Indexed as P
 import Halogen.Query.EventSource (EventSource(..))
 import Halogen.Themes.Bootstrap3 as B
 import Quasar.Aff as Api
+import Quasar.Auth as Auth
 import SlamData.Dialog.Render (modalDialog, modalHeader, modalBody, modalFooter)
 import SlamData.FileSystem.Effects (Slam())
 import SlamData.FileSystem.Resource as R
@@ -120,16 +121,11 @@ eval (Submit next) = do
   name <-
     if state.nameFreezed
     then pure state.name
-    else liftAff $ Api.getNewName state.path state.name
+    else liftAff $ Auth.authed $ Api.getNewName state.path state.name
   let
     src = R.Directory state.path
     tgt = R.ViewMount $ state.path Pt.</> Pt.file name
-  eiResult <- liftAff $ attempt
-    $ Api.portView
-       src
-       tgt
-       content
-       (Sm.fromFoldable state.vars)
+  eiResult <- liftAff $ attempt $ Auth.authed $ Api.portView src tgt content (Sm.fromFoldable state.vars)
   modify $ _inProgress .~ false
   modify $ _name .~ name
   case eiResult of

--- a/src/SlamData/FileSystem/Listing/Item/Component.purs
+++ b/src/SlamData/FileSystem/Listing/Item/Component.purs
@@ -40,6 +40,7 @@ import CSS.Geometry (marginBottom)
 import CSS.Size (px)
 
 import Quasar.Aff as API
+import Quasar.Auth as Auth
 
 import SlamData.FileSystem.Effects (Slam())
 import SlamData.FileSystem.Listing.Item (Item(..), itemResource)
@@ -134,7 +135,7 @@ eval (HideActions next) = modify (_item %~ hideActions) $> next
 eval (Open next) = pure next
 eval (Configure next) = do
   res <- gets (_.item >>> itemResource)
-  uri <- liftAff $ attempt $ API.mountInfo res
+  uri <- liftAff $ attempt $ Auth.authed $ API.mountInfo res
   modify (_mbURI .~ either (const Nothing) Just uri) $> next
 eval (Move next) = pure next
 eval (Download next) = pure next

--- a/src/SlamData/Notebook/Cell/Explore/Component.purs
+++ b/src/SlamData/Notebook/Cell/Explore/Component.purs
@@ -36,6 +36,7 @@ import Halogen.HTML.Indexed as H
 import Halogen.HTML.Properties.Indexed as P
 
 import Quasar.Aff as Quasar
+import Quasar.Auth as Auth
 
 import SlamData.FileSystem.Resource as R
 import SlamData.Notebook.Cell.CellType as CT
@@ -74,7 +75,7 @@ eval (NC.EvalCell info k) =
         <#> (join <<< maybe (Left "There is no file input subcomponent") Right)
         # MT.lift
         >>= either EC.throwError pure
-    (MT.lift $ NC.liftWithCanceler $ Quasar.resourceExists resource)
+    (MT.lift $ NC.liftWithCanceler $ Auth.authed $ Quasar.resourceExists resource)
       >>= \x -> unless x $ EC.throwError
                 $ "File " <> R.resourcePath resource <> " doesn't exist"
 

--- a/src/SlamData/Notebook/Cell/Markdown/Eval.purs
+++ b/src/SlamData/Notebook/Cell/Markdown/Eval.purs
@@ -37,6 +37,7 @@ import Data.String as Str
 import Data.StrMap as SM
 
 import Quasar.Aff as Quasar
+import Quasar.Auth as Auth
 
 import SlamData.FileSystem.Resource (Resource(..))
 import SlamData.Notebook.Cell.Ace.Component (AceDSL())
@@ -127,5 +128,5 @@ evalEmbeddedQueries dir cellId =
       n <- get :: EvalM Int
       modify (+ 1)
       let tempFile = File $ dir' </> file ("tmp" <> cellIdToString cellId <> "-" <> show n)
-      result <- liftAff $ Quasar.query' tempFile code
+      result <- liftAff $ Auth.authed $ Quasar.query' tempFile code
       either (throwError <<< error) pure result

--- a/src/SlamData/Notebook/Cell/Viz/Component.purs
+++ b/src/SlamData/Notebook/Cell/Viz/Component.purs
@@ -51,6 +51,7 @@ import Halogen.HTML.Properties.Indexed.ARIA as ARIA
 import Halogen.Themes.Bootstrap3 as B
 
 import Quasar.Aff as Api
+import Quasar.Auth as Auth
 
 import SlamData.FileSystem.Resource as R
 import SlamData.Form.Select (Select(), autoSelect, newSelect, (<->), ifSelected, trySelect', _value)
@@ -251,7 +252,7 @@ cellEval (EvalCell info continue) = do
       r <- maybe (throwError "Incorrect port in visual builder cell") pure
            $ info.inputPort >>= preview P._Resource
       lift $ updateForms r
-      records <- lift $ liftWithCanceler' $ Api.all r
+      records <- lift $ liftWithCanceler' $ Auth.authed $ Api.all r
       when (length records > 10000)
         $ throwError
         $  "Maximum record count available for visualization -- 10000, "
@@ -303,7 +304,7 @@ responsePort = do
 
 updateForms :: R.Resource -> VizDSL Unit
 updateForms file = do
-  jarr <- liftWithCanceler' $ Api.sample file 0 20
+  jarr <- liftWithCanceler' $ Auth.authed $ Api.sample file 0 20
   if null jarr
     then
     modify $ _availableChartTypes .~ Set.empty

--- a/src/SlamData/Notebook/FileInput/Component.purs
+++ b/src/SlamData/Notebook/FileInput/Component.purs
@@ -49,6 +49,7 @@ import Halogen.Themes.Bootstrap3 as B
 import Network.HTTP.Affjax (AJAX())
 
 import Quasar.Aff as API
+import Quasar.Auth as Auth
 
 import SlamData.FileSystem.Resource as R
 import SlamData.Render.CSS as CSS
@@ -98,10 +99,11 @@ eval q =
       shouldShowFiles <- get <#> _.showFiles >>> not
       modify (_ { showFiles = shouldShowFiles })
       when shouldShowFiles $ do
+        idToken <- liftEff' Auth.retrieveIdToken
         let
           fileProducer =
             FT.hoistFreeT liftH $
-              API.transitiveChildrenProducer P.rootDir
+              API.transitiveChildrenProducer P.rootDir idToken
           fileConsumer =
             CR.consumer \fs -> do
               modify $ appendFiles fs


### PR DESCRIPTION
Per our discussion in Slack, we decided to do this in the "dead simple" way for now to avoid introducing unnecessary friction and changes prior to the release of SlamData 2.5; when we begin refactoring the Quasar client, we will also refactor this to be nicer. 

This PR adds auth tokens to `Quasar.Aff` where applicable, and adjusts the rest of SlamData accordingly. Currently, the `authed` combinator just instantiates the auth token as `Nothing`.