### PR TITLE
; -> , in permissions

### DIFF
--- a/src/Quasar/Auth/Permission.purs
+++ b/src/Quasar/Auth/Permission.purs
@@ -30,7 +30,7 @@ permissionsHeader ps = do
   guard (not $ Arr.null ps)
   pure
     $ RequestHeader "X-Extra-Permissions"
-    $ Str.joinWith ";"
+    $ Str.joinWith ","
     $ map runPermission ps
 
 retrievePermissions
@@ -56,5 +56,5 @@ retrievePermissions =
   permissionTokens :: String -> Array String
   permissionTokens s =
     M.fromMaybe []
-      $ Str.split ";"
+      $ Str.split ","
       <$> extractPermissionsString s


### PR DESCRIPTION
Missed @drostron comment. `X-Extra-Permissions` should use `,` not `;`. 

@jonsterling review, please