### PR TITLE
[SD-1388] update SQL^2 constant syntax; Upgrade to Quasar 4.0.0

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>SlamData</title>
+    <meta charset="UTF-8">
     <script type="text/javascript" src="js/ace.js"></script>
     <script type="text/javascript" src="js/ace/ext-language_tools.js"></script>
     <script type="text/javascript" src="js/filesystem.js"></script>

--- a/public/notebook.html
+++ b/public/notebook.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>SlamData</title>
+    <meta charset="UTF-8">
     <script type="text/javascript" src="js/keyboard.js"></script>
     <script type="text/javascript" src="js/echarts-all.js"></script>
     <script type="text/javascript" src="js/ace.js"></script>

--- a/quasar-versions.json
+++ b/quasar-versions.json
@@ -1,7 +1,7 @@
 { "quasar":
     { "owner": "quasar-analytics"
     , "repo": "quasar"
-    , "tag": "v3.0.1-web"
+    , "tag": "v4.0.0-web"
     }
 , "quasar-advanced":
     { "owner": "slamdata"

--- a/src/Data/SQL2/Literal/Core.purs
+++ b/src/Data/SQL2/Literal/Core.purs
@@ -101,7 +101,7 @@ renderLiteralF rec d =
     Boolean b -> if b then "true" else "false"
     Integer i -> show i
     Decimal a -> show a
-    String str -> singleQuote str
+    String str -> stringLiteral str
     DateTime str -> tagged "TIMESTAMP" str
     Time str -> tagged "TIME" str
     Date str -> tagged "DATE" str
@@ -122,9 +122,7 @@ renderLiteralF rec d =
       -> String
       -> String
     tagged tag str =
-      tag
-        <> " "
-        <> singleQuote str
+      tag <> parens (stringLiteral str)
 
     squares
       :: String
@@ -149,18 +147,11 @@ renderLiteralF rec d =
           Rx.noFlags { global = true }
 
     -- | Surround text in double quotes, escaping internal double quotes.
-    doubleQuote
+    stringLiteral
       :: String
       -> String
-    doubleQuote str =
-      "\"" <> replaceAll "\"" "\"\"" str <> "\""
-
-    -- | Surround text in single quotes, escaping internal quotes.
-    singleQuote
-      :: String
-      -> String
-    singleQuote str =
-      "'" <> replaceAll "'" "''" str <> "'"
+    stringLiteral str =
+      "\"" <> replaceAll "\"" "\\\"" str <> "\""
 
     commaSep
       :: forall f
@@ -177,7 +168,7 @@ renderLiteralF rec d =
     renderMap =
       F.intercalate ", " <<<
         SM.foldMap \k v ->
-          [ doubleQuote k <> ": " <> rec v ]
+          [ stringLiteral k <> ": " <> rec v ]
 
 instance showLiteralF :: (Show a) => Show (LiteralF a) where
   show = renderLiteralF show

--- a/src/SlamData/Notebook/Cell/Query/Eval.purs
+++ b/src/SlamData/Notebook/Cell/Query/Eval.purs
@@ -97,19 +97,20 @@ querySetup { inputPort, notebookPath } =
                  then R.resourceName resource
                  else R.resourcePath resource
       editor <- (MaybeT $ query unit $ request Ace.GetEditor) >>= (MaybeT <<< pure)
-      MaybeT $ query unit
-        $ action $ Ace.SetText ("SELECT  *  FROM \"" <> path <> "\" ")
+      MaybeT $ query unit $ action $ Ace.SetText ("SELECT  *  FROM `" <> path <> "` ")
       MT.lift $ liftEff do
-        readOnly editor { startRow: 0
-                        , startColumn: 0
-                        , endRow: 0
-                        , endColumn: 7
-                        }
-        readOnly editor { startRow: 0
-                        , startColumn: 10
-                        , endRow: 0
-                        , endColumn: 19 + Str.length path
-                        }
+        readOnly editor
+          { startRow: 0
+          , startColumn: 0
+          , endRow: 0
+          , endColumn: 7
+          }
+        readOnly editor
+          { startRow: 0
+          , startColumn: 10
+          , endRow: 0
+          , endColumn: 19 + Str.length path
+          }
     _ -> pure unit
 
 addCompletions :: forall a. SM.StrMap a -> AceDSL Unit

--- a/test/src/Test/Selenium/Notebook/Markdown/Interactions.purs
+++ b/test/src/Test/Selenium/Notebook/Markdown/Interactions.purs
@@ -53,11 +53,11 @@ provideMdForFormWithAllInputTypes =
 provideMdForFormWithEvaluatedContent :: Check (Array Unit)
 provideMdForFormWithEvaluatedContent =
     T.traverse provideMd
-      [ "discipline = __ (!`SELECT discipline FROM \"/test-mount/testDb/olympics\" LIMIT 1`)"
-      , "year = __ (!`SELECT year FROM \"/test-mount/testDb/olympics\" LIMIT 1`)"
-      , "country = {!`SELECT DISTINCT country FROM \"/test-mount/testDb/olympics\"`} (!`SELECT country FROM \"/test-mount/testDb/olympics\" LIMIT 1`)"
-      , "type = (!`SELECT DISTINCT type FROM \"/test-mount/testDb/olympics\" LIMIT 1`) !`SELECT DISTINCT type FROM \"/test-mount/testDb/olympics\" OFFSET 1`"
-      , "gender = [!`SELECT gender FROM \"/test-mount/testDb/olympics\" LIMIT 1`] !`SELECT DISTINCT gender FROM \"/test-mount/testDb/olympics\"`"
+      [ "discipline = __ (!`SELECT discipline FROM `/test-mount/testDb/olympics` LIMIT 1`)"
+      , "year = __ (!`SELECT year FROM `/test-mount/testDb/olympics` LIMIT 1`)"
+      , "country = {!`SELECT DISTINCT country FROM `/test-mount/testDb/olympics``} (!`SELECT country FROM `/test-mount/testDb/olympics` LIMIT 1`)"
+      , "type = (!`SELECT DISTINCT type FROM `/test-mount/testDb/olympics` LIMIT 1`) !`SELECT DISTINCT type FROM `/test-mount/testDb/olympics` OFFSET 1`"
+      , "gender = [!`SELECT gender FROM `/test-mount/testDb/olympics` LIMIT 1`] !`SELECT DISTINCT gender FROM `/test-mount/testDb/olympics` `"
       ]
 
 createMdQueryCell :: Check Unit
@@ -71,7 +71,7 @@ provideMdQuery query = focusMdQueryField *> (sequence $ keys $ query ++ " ")
 
 provideMdQueryWhichFiltersUsingFormValues :: Check Unit
 provideMdQueryWhichFiltersUsingFormValues = F.traverse_ provideMdQuery
-  [ "SELECT * FROM \"/test-mount/testDb/olympics\""
+  [ "SELECT * FROM `/test-mount/testDb/olympics`"
   , "WHERE discipline = :discipline"
   , "AND type != :type"
   , "AND gender IN :gender"


### PR DESCRIPTION
To resolve [SD-1388](https://slamdata.atlassian.net/browse/SD-1388), work in progress

- [x] make sure that this contains all the relevant changes
   - [x] correct escaping
- [x] Get rid of https://github.com/slamdata/slamdata/blob/master/src/SlamData/Notebook/Cell/Search/Interpret.purs#L292 (I thought I'd killed all of that a month ago, but I must have missed it)!!!!!


- [x] upgrade to version of new Quasar prior to merge
- [x] ~~Resolve incompatibilities with Quasar 4.0.0~~ Tests failed once for me, but then it has succeeded three times now since, so it may just be that our tests our not valid.