### PR TITLE
MongoDB mount dialog amends

### DIFF
--- a/less/dialog/mount.less
+++ b/less/dialog/mount.less
@@ -43,14 +43,8 @@
     }
 
     .mount-userinfo {
-        label {
-            width: 50%;
-        }
         label+label {
-            span {
-                padding-right: 10px;
-                text-align: right;
-            }
+            padding-top: 10px;
         }
     }
 

--- a/src/SlamData/FileSystem/Dialog/Mount/MongoDB/Component.purs
+++ b/src/SlamData/FileSystem/Dialog/Mount/MongoDB/Component.purs
@@ -124,7 +124,7 @@ fldPath :: State -> ComponentHTML Query
 fldPath state =
   H.div
     [ P.class_ Rc.mountPath ]
-    [ label "Path" [ input state _path [] ] ]
+    [ label "Database" [ input state _path [] ] ]
 
 -- | A labelled section within the form.
 label :: forall i p. String -> Array (HTML p i) -> HTML p i

--- a/src/SlamData/FileSystem/Dialog/Mount/MongoDB/Component/State.purs
+++ b/src/SlamData/FileSystem/Dialog/Mount/MongoDB/Component/State.purs
@@ -124,7 +124,8 @@ hostsFromURI _ = []
 
 pathFromURI :: Uri.AbsoluteURI -> String
 pathFromURI (Uri.AbsoluteURI _ (Uri.HierarchicalPart _ (Just p)) _) =
-  either printPath printPath p
+  let s = either printPath printPath p
+  in if S.take 1 s == "/" then S.drop 1 s else s
 pathFromURI _ = ""
 
 userFromURI :: Uri.AbsoluteURI -> String


### PR DESCRIPTION
In response to comments from @jdegoes in Slack.

1. The "Path" field under authentication is now "Database".
2. When printing the path/database field the initial `/` prefix is now omitted.

Re: 1, I used "Authentication database" at first, but it's difficult to arrange the form in a natural way with a label that long, and it's also in a section called "Authentication" so seemed a little redundant, but if you think using the exact term is important I can probably restyle the form a bit to make it work?