### PR TITLE
[gitignore] Unignore echarts-all.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 public/js/*.js
 !public/js/ace*
 !public/js/keyboard*
+!public/js/echarts*
 public/css/*.css
 !public/css/bootstrap*.css
 .psci_modules


### PR DESCRIPTION
This was causing `echarts` to not be bundled with SlamData Advanced. What happens is that npm actually uses the `.gitignore` to filter out files from a release (which is beyond dumb in my opinion, but I assume others may disagree for good reasons).