### PR TITLE
Sd 1402

### DIFF
--- a/less/main.less
+++ b/less/main.less
@@ -754,3 +754,4 @@ div.viz-cell-editor, div.download-cell-editor {
 @import "dialog/embed";
 @import "dialog/download";
 @import "form-builder";
+@import "share-permissions";

--- a/less/share-permissions.less
+++ b/less/share-permissions.less
@@ -1,0 +1,29 @@
+.token-generator-form {
+    width: 400px;
+    button {
+        width: 100px;
+    }
+    img.cancel-input-run-icon {
+        width: 16px;
+        height: 16px;
+        position: absolute;
+        right: 110px;
+        top: 10px;
+        z-index: 100;
+        opacity: 0.8;
+        cursor: pointer;
+        text-decoration: none;
+        &:hover {
+            text-decoration: none;
+            opacity: 1.0;
+        }
+    }
+}
+
+.user-share-form {
+    width: 400px;
+    top: 10px;
+    left: 50%;
+    position: relative;
+    margin-left: -200px;
+}

--- a/src/OIDC/Aff.purs
+++ b/src/OIDC/Aff.purs
@@ -1,3 +1,19 @@
+{-
+Copyright 2016 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
 module OIDC.Aff where
 
 import Prelude

--- a/src/Quasar/Aff.purs
+++ b/src/Quasar/Aff.purs
@@ -137,7 +137,7 @@ instance listingRespondable :: AX.Respondable Listing where
 insertAuthHeaders
   :: forall a
    . M.Maybe Auth.IdToken
-  -> Array Perm.Permission
+  -> Array Perm.PermissionToken
   -> AX.AffjaxRequest a
   -> AX.AffjaxRequest a
 insertAuthHeaders mbToken perms r =
@@ -152,7 +152,7 @@ children
   :: forall e
    . PU.DirPath
   -> M.Maybe Auth.IdToken
-  -> Array Perm.Permission
+  -> Array Perm.PermissionToken
   -> Aff (RetryEffects (ajax :: AX.AJAX, dom :: DOM | e)) (Array R.Resource)
 children dir idToken perms = do
   cs <- children' dir idToken perms
@@ -164,7 +164,7 @@ children'
   :: forall e
    . PU.DirPath
   -> M.Maybe Auth.IdToken
-  -> Array Perm.Permission
+  -> Array Perm.PermissionToken
   -> Aff (RetryEffects (ajax :: AX.AJAX | e)) (Array R.Resource)
 children' dir idToken perms =
   listing dir idToken perms
@@ -177,7 +177,7 @@ listing
   :: forall e
    . PU.DirPath
   -> M.Maybe Auth.IdToken
-  -> Array Perm.Permission
+  -> Array Perm.PermissionToken
   -> AX.Affjax (RetryEffects e) Listing
 listing p idToken perms =
   case P.relativeTo p P.rootDir of
@@ -195,7 +195,7 @@ makeFile
   -> MimeType
   -> String
   -> M.Maybe Auth.IdToken
-  -> Array Perm.Permission
+  -> Array Perm.PermissionToken
   -> Aff (RetryEffects (ajax :: AX.AJAX | e)) Unit
 makeFile path mime content idToken perms =
   getResponse "error while creating file"
@@ -241,7 +241,7 @@ retryGet
   => P.Path P.Abs fd P.Sandboxed
   -> MimeType
   -> M.Maybe Auth.IdToken
-  -> Array Perm.Permission
+  -> Array Perm.PermissionToken
   -> AX.Affjax (RetryEffects e) a
 retryGet =
   getWithPolicy $ AX.defaultRetryPolicy { delayCurve = const 1000 }
@@ -251,7 +251,7 @@ mkRequest
    . P.Path P.Abs fd P.Sandboxed
   -> MimeType
   -> M.Maybe Auth.IdToken
-  -> Array Perm.Permission
+  -> Array Perm.PermissionToken
   -> Aff (RetryEffects e) (AX.AffjaxRequest Unit)
 mkRequest u mime idToken perms = do
   nocache <- liftEff $ Date.nowEpochMilliseconds
@@ -273,7 +273,7 @@ getOnce
   => P.Path P.Abs fd P.Sandboxed
   -> MimeType
   -> M.Maybe Auth.IdToken
-  -> Array Perm.Permission
+  -> Array Perm.PermissionToken
   -> AX.Affjax (RetryEffects e) a
 getOnce u mime idToken perms =
   mkRequest u mime idToken perms
@@ -286,7 +286,7 @@ getWithPolicy
   -> P.Path P.Abs fd P.Sandboxed
   -> MimeType
   -> M.Maybe Auth.IdToken
-  -> Array Perm.Permission
+  -> Array Perm.PermissionToken
   -> AX.Affjax (RetryEffects e) a
 getWithPolicy policy u mime idToken perms =
   mkRequest u mime idToken perms
@@ -297,7 +297,7 @@ retryDelete
    . (AX.Respondable a)
   => P.Path P.Abs fd P.Sandboxed
   -> M.Maybe Auth.IdToken
-  -> Array Perm.Permission
+  -> Array Perm.PermissionToken
   -> AX.Affjax (RetryEffects e) a
 retryDelete u idToken perms = do
   slamjax
@@ -313,7 +313,7 @@ retryPost
   => P.Path P.Abs fd P.Sandboxed
   -> a
   -> M.Maybe Auth.IdToken
-  -> Array Perm.Permission
+  -> Array Perm.PermissionToken
   -> AX.Affjax (RetryEffects e) b
 retryPost u c idToken perms =
   slamjax
@@ -331,7 +331,7 @@ retryPut
   -> a
   -> MimeType
   -> M.Maybe Auth.IdToken
-  -> Array Perm.Permission
+  -> Array Perm.PermissionToken
   -> AX.Affjax (RetryEffects e) b
 retryPut u c mime idToken perms =
   slamjax
@@ -365,7 +365,7 @@ mountInfo
   :: forall e
    . PU.DirPath
   -> M.Maybe Auth.IdToken
-  -> Array Perm.Permission
+  -> Array Perm.PermissionToken
   -> Aff (RetryEffects (ajax :: AX.AJAX | e)) String
 mountInfo res idToken perms = do
   result <- getOnce mountPath applicationJSON idToken perms
@@ -386,7 +386,7 @@ viewInfo
   :: forall e
    . PU.FilePath
   -> M.Maybe Auth.IdToken
-  -> Array Perm.Permission
+  -> Array Perm.PermissionToken
   -> Aff (RetryEffects (ajax :: AX.AJAX|e)) { query :: String, vars :: SM.StrMap String }
 viewInfo mountPath idToken perms = do
   result <-
@@ -438,7 +438,7 @@ getNewName
    . PU.DirPath
   -> String
   -> M.Maybe Auth.IdToken
-  -> Array Perm.Permission
+  -> Array Perm.PermissionToken
   -> Aff (RetryEffects (ajax :: AX.AJAX |e)) String
 getNewName parent name idToken perms = do
   items <- Aff.attempt (children' parent idToken perms) <#> E.either (const []) id
@@ -464,7 +464,7 @@ move
    . R.Resource
   -> PU.AnyPath
   -> M.Maybe Auth.IdToken
-  -> Array Perm.Permission
+  -> Array Perm.PermissionToken
   -> Aff (RetryEffects (ajax :: AX.AJAX, dom :: DOM |e)) (M.Maybe PU.AnyPath)
 move src tgt idToken perms = do
   let url = if R.isMount src
@@ -495,7 +495,7 @@ saveMount
    . PU.DirPath
   -> String
   -> M.Maybe Auth.IdToken
-  -> Array Perm.Permission
+  -> Array Perm.PermissionToken
   -> Aff (RetryEffects (ajax :: AX.AJAX |e)) Unit
 saveMount path uri idToken perms = do
   result <-
@@ -517,7 +517,7 @@ delete
   :: forall e
    . R.Resource
   -> M.Maybe Auth.IdToken
-  -> Array Perm.Permission
+  -> Array Perm.PermissionToken
   -> Aff (RetryEffects (ajax :: AX.AJAX, dom :: DOM |e)) (M.Maybe R.Resource)
 delete resource idToken perms =
   if not (R.isMount resource || alreadyInTrash resource)
@@ -565,7 +565,7 @@ forceDelete
   :: forall e
    . R.Resource
   -> M.Maybe Auth.IdToken
-  -> Array Perm.Permission
+  -> Array Perm.PermissionToken
   -> Aff (RetryEffects (ajax :: AX.AJAX, dom :: DOM |e)) Unit
 forceDelete res idToken perms = do
   cleanViewMounts res idToken perms
@@ -592,7 +592,7 @@ cleanViewMounts
   :: forall e
    . R.Resource
   -> M.Maybe Auth.IdToken
-  -> Array Perm.Permission
+  -> Array Perm.PermissionToken
   -> Aff (RetryEffects (ajax :: AX.AJAX, dom :: DOM|e)) Unit
 cleanViewMounts res idToken perms =
   F.for_ (R.getPath res) \dirPath ->
@@ -603,7 +603,7 @@ cleanViewMounts res idToken perms =
 getVersion
   :: forall e
    . M.Maybe Auth.IdToken
-  -> Array Perm.Permission
+  -> Array Perm.PermissionToken
   -> Aff (RetryEffects (ajax :: AX.AJAX |e)) (M.Maybe String)
 getVersion idToken perms = do
   serverInfo <- retryGet Paths.serverInfoUrl applicationJSON idToken perms
@@ -618,7 +618,7 @@ transitiveChildrenProducer
   :: forall e
    . PU.DirPath
   -> M.Maybe Auth.IdToken
-  -> Array Perm.Permission
+  -> Array Perm.PermissionToken
   -> CR.Producer
       (Array R.Resource)
       (Aff (RetryEffects (ajax :: AX.AJAX, err :: Exn.EXCEPTION, dom :: DOM | e)))
@@ -651,7 +651,7 @@ query
    . R.Resource
   -> SQL
   -> M.Maybe Auth.IdToken
-  -> Array Perm.Permission
+  -> Array Perm.PermissionToken
   -> Aff (RetryEffects (ajax :: AX.AJAX | e)) JS.JArray
 query res sql idToken perms =
   if not $ R.isFile res
@@ -667,7 +667,7 @@ query'
    . PU.FilePath
   -> SQL
   -> M.Maybe Auth.IdToken
-  -> Array Perm.Permission
+  -> Array Perm.PermissionToken
   -> Aff (RetryEffects (ajax :: AX.AJAX | e)) (E.Either String JS.JArray)
 query' path sql idToken perms = do
   let res = R.File path
@@ -685,7 +685,7 @@ count
   :: forall e
    . R.Resource
   -> M.Maybe Auth.IdToken
-  -> Array Perm.Permission
+  -> Array Perm.PermissionToken
   -> Aff (RetryEffects (ajax :: AX.AJAX | e)) Int
 count res idToken perms =
   query res sql idToken perms
@@ -711,7 +711,7 @@ resourceExists
   :: forall e
    . R.Resource
   -> M.Maybe Auth.IdToken
-  -> Array Perm.Permission
+  -> Array Perm.PermissionToken
   -> Aff (RetryEffects (ajax :: AX.AJAX|e)) Boolean
 resourceExists res idToken perms = do
   result <- existsReq
@@ -742,7 +742,7 @@ portView
   -> SQL
   -> SM.StrMap String
   -> M.Maybe Auth.IdToken
-  -> Array Perm.Permission
+  -> Array Perm.PermissionToken
   -> Aff (RetryEffects (ajax :: AX.AJAX | e)) Unit
 portView res dest sql varMap idToken perms = do
   guard $ R.isViewMount dest
@@ -775,7 +775,7 @@ portQuery
   -> SQL
   -> SM.StrMap String
   -> M.Maybe Auth.IdToken
-  -> Array Perm.Permission
+  -> Array Perm.PermissionToken
   -> Aff (RetryEffects (ajax :: AX.AJAX | e)) JS.JObject
 portQuery res dest sql vars idToken perms = do
   guard $ R.isFile dest
@@ -828,7 +828,7 @@ sample'
   -> M.Maybe Int
   -> M.Maybe Int
   -> M.Maybe Auth.IdToken
-  -> Array Perm.Permission
+  -> Array Perm.PermissionToken
   -> Aff (RetryEffects (ajax :: AX.AJAX | e)) JS.JArray
 sample' res mbOffset mbLimit idToken perms =
   if not $ R.isFile res
@@ -851,7 +851,7 @@ sample
   -> Int
   -> Int
   -> M.Maybe Auth.IdToken
-  -> Array Perm.Permission
+  -> Array Perm.PermissionToken
   -> Aff (RetryEffects (ajax :: AX.AJAX | e)) JS.JArray
 sample res offset limit =
   sample' res (M.Just offset) (M.Just limit)
@@ -860,7 +860,7 @@ all
   :: forall e
    . R.Resource
   -> M.Maybe Auth.IdToken
-  -> Array Perm.Permission
+  -> Array Perm.PermissionToken
   -> Aff (RetryEffects (ajax :: AX.AJAX | e)) JS.JArray
 all res =
   sample' res M.Nothing M.Nothing
@@ -869,7 +869,7 @@ fields
   :: forall e
    . R.Resource
   -> M.Maybe Auth.IdToken
-  -> Array Perm.Permission
+  -> Array Perm.PermissionToken
   -> Aff (RetryEffects (ajax :: AX.AJAX | e)) (Array String)
 fields res idToken perms = do
   jarr <- sample res 0 100 idToken perms
@@ -935,7 +935,7 @@ executeQuery
   -> R.Resource
   -> R.Resource
   -> M.Maybe Auth.IdToken
-  -> Array Perm.Permission
+  -> Array Perm.PermissionToken
   -> Aff (RetryEffects (ajax :: AX.AJAX, dom :: DOM | e))
       (E.Either String { outputResource :: R.Resource, plan :: M.Maybe String })
 executeQuery sql cachingEnabled varMap inputResource outputResource idToken perms = do
@@ -989,7 +989,7 @@ save
    . PU.FilePath
   -> JS.Json
   -> M.Maybe Auth.IdToken
-  -> Array Perm.Permission
+  -> Array Perm.PermissionToken
   -> Aff (RetryEffects (ajax :: AX.AJAX | e)) Unit
 save path json idToken perms =
   let apiPath = Paths.dataUrl </> PU.rootifyFile path
@@ -1004,7 +1004,7 @@ load
   :: forall e
    . PU.FilePath
   -> M.Maybe Auth.IdToken
-  -> Array Perm.Permission
+  -> Array Perm.PermissionToken
   -> Aff (RetryEffects (ajax :: AX.AJAX | e)) (E.Either String JS.Json)
 load path idToken perms =
   let apiPath = Paths.dataUrl </> PU.rootifyFile path

--- a/src/Quasar/Auth.purs
+++ b/src/Quasar/Auth.purs
@@ -1,3 +1,19 @@
+{-
+Copyright 2016 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
 module Quasar.Auth
   ( authHeader
   , authed
@@ -96,9 +112,9 @@ clearIdToken =
 
 authed
   :: forall a e
-   . (M.Maybe IdToken -> Array P.Permission -> Aff (dom :: DOM | e) a)
+   . (M.Maybe IdToken -> Array P.PermissionToken -> Aff (dom :: DOM | e) a)
   -> Aff (dom :: DOM | e) a
 authed f = do
   idToken <- liftEff retrieveIdToken
-  perms <- liftEff P.retrievePermissions
+  perms <- liftEff P.retrievePermissionTokens
   f idToken perms

--- a/src/Quasar/Auth/OpenIDConfiguration.purs
+++ b/src/Quasar/Auth/OpenIDConfiguration.purs
@@ -1,3 +1,19 @@
+{-
+Copyright 2016 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
 module Quasar.Auth.OpenIDConfiguration
   ( OpenIDConfiguration(..)
   , OpenIDConfigurationR()

--- a/src/Quasar/Auth/Permission.purs
+++ b/src/Quasar/Auth/Permission.purs
@@ -1,15 +1,36 @@
+{-
+Copyright 2016 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
 module Quasar.Auth.Permission where
 
 import Prelude
 
+import Control.Monad.Aff (later')
 import Control.Monad.Eff (Eff())
+import Control.Monad.Eff.Random (random)
 import Control.MonadPlus (guard)
 import Control.UI.Browser (decodeURIComponent)
 
+import Data.Functor.Eff (liftEff)
 import Data.String as Str
 import Data.String.Regex as Rgx
 import Data.Maybe as M
 import Data.Array as Arr
+import Data.NonEmpty as Ne
+import Data.Either as E
 
 import DOM (DOM())
 import DOM.HTML (window)
@@ -18,36 +39,82 @@ import DOM.HTML.Window as Window
 
 import Network.HTTP.RequestHeader (RequestHeader(..))
 
+import SlamData.Effects (Slam())
+import SlamData.FileSystem.Resource as R
 
-newtype Permission = Permission String
-runPermission :: Permission -> String
-runPermission (Permission s) = s
+import Utils.Path (FilePath())
+
+newtype PermissionToken = PermissionToken String
+runPermissionToken :: PermissionToken -> String
+runPermissionToken (PermissionToken s) = s
+
+type Permissions =
+  {
+    add :: Boolean
+  , read :: Boolean
+  , modify :: Boolean
+  , delete :: Boolean
+  }
+
+isPermissionsEmpty
+  :: Permissions
+  -> Boolean
+isPermissionsEmpty {add, read, modify, delete} =
+  not (add || read || modify || delete)
+
+
+newtype Group = Group FilePath
+runGroup :: Group -> FilePath
+runGroup (Group fp) = fp
+
+newtype User = User String
+runUser :: User -> String
+runUser (User s) = s
+
+type PermissionShareRequest =
+  {
+    resource :: R.Resource
+  , targets :: E.Either (Ne.NonEmpty Array Group) (Ne.NonEmpty Array User)
+  , permissions :: Permissions
+  }
+
+requestForGroups
+  :: PermissionShareRequest
+  -> Boolean
+requestForGroups {targets} =
+  E.isLeft targets
+
+requestForUsers
+  :: PermissionShareRequest
+  -> Boolean
+requestForUsers {targets} =
+  E.isRight targets
 
 permissionsHeader
-  :: Array Permission
+  :: Array PermissionToken
   -> M.Maybe RequestHeader
 permissionsHeader ps = do
   guard (not $ Arr.null ps)
   pure
-    $ RequestHeader "X-Extra-Permissions"
+    $ RequestHeader "X-Extra-PermissionTokens"
     $ Str.joinWith ","
-    $ map runPermission ps
+    $ map runPermissionToken ps
 
-retrievePermissions
+retrievePermissionTokens
   :: forall e
-   . Eff (dom :: DOM|e) (Array Permission)
-retrievePermissions =
+   . Eff (dom :: DOM|e) (Array PermissionToken)
+retrievePermissionTokens =
   window
     >>= Window.location
     >>= Location.search
     <#> permissionTokens
-    <#> map Permission
+    <#> map PermissionToken
   where
   permissionRegex :: Rgx.Regex
   permissionRegex = Rgx.regex "permissionsToken=([^&]+)" Rgx.noFlags
 
-  extractPermissionsString :: String -> M.Maybe String
-  extractPermissionsString str =
+  extractPermissionTokensString :: String -> M.Maybe String
+  extractPermissionTokensString str =
     Rgx.match permissionRegex str
       >>= flip Arr.index 1
       >>= id
@@ -57,4 +124,16 @@ retrievePermissions =
   permissionTokens s =
     M.fromMaybe []
       $ Str.split ","
-      <$> extractPermissionsString s
+      <$> extractPermissionTokensString s
+
+-- A mock for generating new tokens
+genToken :: Slam PermissionToken
+genToken =
+  later' 1000 $ liftEff $ PermissionToken <$> show <$> random
+
+-- One more mock
+makePermissionShareRequest
+  :: PermissionShareRequest
+  -> Slam Unit
+makePermissionShareRequest _ =
+  later' 1000 $ pure unit

--- a/src/Quasar/Auth/Provider.purs
+++ b/src/Quasar/Auth/Provider.purs
@@ -1,3 +1,19 @@
+{-
+Copyright 2016 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
 module Quasar.Auth.Provider
   ( Provider(..)
   , ProviderR()

--- a/src/SlamData/AuthRedirect.purs
+++ b/src/SlamData/AuthRedirect.purs
@@ -1,3 +1,19 @@
+{-
+Copyright 2016 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
 module SlamData.AuthRedirect
   ( main
   ) where

--- a/src/SlamData/AuthRedirect/RedirectHashPayload.purs
+++ b/src/SlamData/AuthRedirect/RedirectHashPayload.purs
@@ -1,3 +1,19 @@
+{-
+Copyright 2016 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
 module SlamData.AuthRedirect.RedirectHashPayload
   ( RedirectHashPayload()
   , uriHashParser

--- a/src/SlamData/Dialog/Share/Code/Component.purs
+++ b/src/SlamData/Dialog/Share/Code/Component.purs
@@ -1,0 +1,141 @@
+{-
+Copyright 2016 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
+module SlamData.Dialog.Share.Code.Component where
+
+import Prelude
+
+import Control.Monad (when)
+import Control.Monad.Aff (Canceler(), cancel)
+import Control.Monad.Eff.Exception (error)
+import Control.UI.Browser as Br
+
+import Data.Functor (($>))
+import Data.Functor.Eff (liftEff)
+import Data.Functor.Aff (liftAff)
+import Data.Lens (LensP(), lens, (?~), (.~))
+import Data.Maybe as M
+import Data.Foldable as F
+
+import DOM.HTML.Types (HTMLElement())
+
+import Halogen
+import Halogen.HTML.Indexed as H
+import Halogen.HTML.Events.Indexed as E
+import Halogen.HTML.Properties.Indexed as P
+import Halogen.HTML.Properties.Indexed.ARIA as ARIA
+import Halogen.Themes.Bootstrap3 as B
+import Halogen.CustomProps as Cp
+import Halogen.Component.Utils as Hu
+
+import Quasar.Auth.Permission as Api
+
+import SlamData.Effects (Slam(), SlamDataEffects())
+import SlamData.Render.CSS as Rc
+
+type State =
+  {
+    permissionToken :: M.Maybe Api.PermissionToken
+  , inputEl :: M.Maybe HTMLElement
+  , canceler :: M.Maybe (Canceler SlamDataEffects)
+  }
+
+_permissionToken :: forall a r. LensP {permissionToken :: a|r} a
+_permissionToken = lens _.permissionToken _{permissionToken = _}
+
+_inputEl :: forall a r. LensP {inputEl :: a|r} a
+_inputEl = lens _.inputEl _{inputEl = _}
+
+_canceler :: forall a r. LensP {canceler :: a|r} a
+_canceler = lens _.canceler _{canceler = _}
+
+initialState :: State
+initialState =
+  {
+    permissionToken: M.Nothing
+  , inputEl: M.Nothing
+  , canceler: M.Nothing
+  }
+
+data Query a
+  = Generate a
+  | Init HTMLElement a
+  | GetPermissionToken (M.Maybe Api.PermissionToken -> a)
+  | SetCanceler (Canceler SlamDataEffects) a
+  | Clear a
+
+type ShareByCodeDSL = ComponentDSL State Query Slam
+
+comp :: Component State Query Slam
+comp = component render eval
+
+render :: State -> ComponentHTML Query
+render state =
+  H.form
+    [ Cp.nonSubmit
+    , P.classes [ Rc.tokenGeneratorForm ]
+    ]
+    [ H.div [ P.classes [ B.inputGroup ] ]
+      [
+        H.input [ P.classes [ B.formControl ]
+                , P.value $ M.maybe "" Api.runPermissionToken state.permissionToken
+                , P.readonly true
+                , P.placeholder "Generated token will appear here"
+                , P.initializer (\el -> action $ Init el)
+                , ARIA.label "Permission token"
+                ]
+      , H.img [ P.classes [ Rc.cancelInputRunIcon ]
+              , P.src cancelIcon
+              , E.onClick (E.input_ Clear)
+              ]
+      , H.span [ P.classes [ B.inputGroupBtn ] ]
+        [ H.button
+          [ P.classes [ B.btn, B.btnPrimary ]
+          , E.onClick (E.input_ Generate)
+          , P.disabled (M.isJust state.canceler)
+          , ARIA.label "Generate token"
+          ]
+          [ H.text "Generate" ]
+        ]
+      ]
+    ]
+  where
+  cancelIcon =
+    if M.isJust state.canceler
+      then "img/spin.gif"
+      else "img/remove.svg"
+
+eval :: Natural Query ShareByCodeDSL
+eval (Generate next) = do
+  gets _.canceler >>= \c -> when (M.isNothing c) do
+    perm <- Hu.liftWithCanceler SetCanceler Api.genToken
+    modify $ _permissionToken ?~ perm
+    modify $ _canceler .~ M.Nothing
+    gets _.inputEl >>= F.traverse_ (liftEff <<< Br.select)
+  pure next
+eval (Init htmlEl next) = (modify $ _inputEl ?~ htmlEl) $> next
+eval (GetPermissionToken continue) =
+  map continue $ gets _.permissionToken
+eval (Clear next) = do
+  gets _.canceler >>= F.traverse_ \c -> do
+    liftAff $ cancel c $ error "Getting token has been canceled"
+    modify $ _canceler .~ M.Nothing
+  modify $ _permissionToken .~ M.Nothing
+  pure next
+eval (SetCanceler c next) = do
+  gets _.canceler >>= F.traverse_ \c ->
+    liftAff $ cancel c $ error "New token has been requested"
+  modify (_canceler ?~ c) $> next

--- a/src/SlamData/Dialog/Share/Confirm/Component.purs
+++ b/src/SlamData/Dialog/Share/Confirm/Component.purs
@@ -1,0 +1,99 @@
+{-
+Copyright 2016 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
+module SlamData.Dialog.Share.Confirm.Component where
+
+import Prelude
+
+import Control.MonadPlus (guard)
+
+import Data.Array as Arr
+import Data.Either as E
+import Data.Functor (($>))
+import Data.Path.Pathy as Pt
+import Data.NonEmpty as Ne
+import Data.Foldable as F
+
+import Halogen
+import Halogen.HTML.Indexed as H
+
+import Quasar.Auth.Permission as P
+
+import SlamData.Effects (Slam())
+import SlamData.FileSystem.Resource as R
+
+data Query a
+  = Set P.PermissionShareRequest a
+
+type PermissionShareConfirmDSL
+  = ComponentDSL P.PermissionShareRequest Query Slam
+
+
+comp :: Component P.PermissionShareRequest Query Slam
+comp = component render eval
+
+render :: P.PermissionShareRequest -> ComponentHTML Query
+render state =
+  if P.isPermissionsEmpty state.permissions
+  then
+    H.div_ [ H.p_ [ H.text "There is no set permissions to share" ] ]
+  else
+    H.div_
+      [
+        H.p_ [ H.text "You are going to provide permissions to:" ]
+      , H.ul_ $ renderPermissions state.permissions
+      , H.p_ $ [ H.text "for: " ] <> renderResource state.resource
+      , H.p_ [ H.text
+                 $ "to following "
+                 <> (if P.requestForUsers state
+                     then "users"
+                     else "groups")
+                 <> ":"
+             ]
+      , H.ul_ $ renderTargets state.targets
+      ]
+  where
+  renderPermissions :: P.Permissions -> Array (ComponentHTML Query)
+  renderPermissions p =
+    map (H.li_ <<< pure <<< H.text)
+    $ Arr.concat
+      [
+        (guard p.add) $> "ADD"
+      , (guard p.read) $> "READ"
+      , (guard p.modify) $> "MODIFY"
+      , (guard p.delete) $> "DELETE"
+      ]
+  renderResource :: R.Resource -> Array (ComponentHTML Query)
+  renderResource r =
+    let
+      resourceType (R.File _) = "File"
+      resourceType (R.Notebook _) = "Notebook"
+      resourceType (R.Directory _) = "Directory"
+      resourceType (R.Mount (R.View _)) = "View mount"
+      resourceType (R.Mount (R.Database _)) = "Database"
+      msg = (resourceType r) <> ": " <> (R.resourcePath r)
+    in
+      [ H.strong_ [ H.text msg ] ]
+
+  renderTargets
+    :: E.Either (Ne.NonEmpty Array P.Group) (Ne.NonEmpty Array P.User)
+    -> Array (ComponentHTML Query)
+  renderTargets targets =
+    F.foldMap (pure <<< H.li_ <<< pure <<< H.text)
+    $ E.either (map (P.runGroup >>> Pt.printPath)) (map P.runUser) targets
+
+eval :: Natural Query PermissionShareConfirmDSL
+eval (Set p next) = set p $> next

--- a/src/SlamData/Dialog/Share/Permissions/Component.purs
+++ b/src/SlamData/Dialog/Share/Permissions/Component.purs
@@ -1,0 +1,135 @@
+{-
+Copyright 2016 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
+module SlamData.Dialog.Share.Permissions.Component where
+
+import Prelude
+
+import Data.Functor (($>))
+import Data.Lens (LensP(), lens, (%~), (.~))
+
+import Halogen
+import Halogen.HTML.Indexed as H
+import Halogen.HTML.Events.Indexed as E
+import Halogen.HTML.Properties.Indexed as P
+import Halogen.Themes.Bootstrap3 as B
+
+import Quasar.Auth.Permission (Permissions())
+
+import SlamData.Effects (Slam())
+
+notAllowed :: Permissions
+notAllowed =
+  {
+    add: false
+  , read: false
+  , modify: false
+  , delete: false
+  }
+
+type State =
+  {
+    current :: Permissions
+  , max :: Permissions
+  }
+
+initialState :: State
+initialState =
+  {
+    current: notAllowed
+  , max: notAllowed
+  }
+
+_current :: forall a r. LensP {current :: a|r} a
+_current = lens _.current _{current = _}
+
+_max :: forall a r. LensP {max :: a|r} a
+_max = lens _.max _{max = _}
+
+_add :: forall a r. LensP {add :: a|r} a
+_add = lens _.add _{add = _}
+
+_read :: forall a r. LensP {read :: a|r} a
+_read = lens _.read _{read = _}
+
+_modify :: forall a r. LensP {modify :: a|r} a
+_modify = lens _.modify _{modify = _}
+
+_delete :: forall a r. LensP {delete :: a|r} a
+_delete = lens _.delete _{delete = _}
+
+data Query a
+  = ToggleAdd a
+  | ToggleRead a
+  | ToggleModify a
+  | ToggleDelete a
+  | SetMaximum Permissions a
+  | GetSelected (Permissions -> a)
+
+type PermissionsDSL = ComponentDSL State Query Slam
+
+comp :: Component State Query Slam
+comp = component render eval
+
+render :: State -> ComponentHTML Query
+render {current, max} =
+  H.form_
+    [
+      H.label [ P.classes [ B.checkboxInline ] ]
+        [
+          H.input [ P.inputType P.InputCheckbox
+                  , P.checked (max.add && current.add)
+                  , P.disabled $ not max.add
+                  , E.onChecked (E.input_ ToggleAdd)
+                  ]
+        , H.text  "Add"
+        ]
+    , H.label [ P.classes [ B.checkboxInline ] ]
+        [
+          H.input [ P.inputType P.InputCheckbox
+                  , P.checked (max.read && current.read)
+                  , P.disabled $ not max.read
+                  , E.onChecked (E.input_ ToggleRead)
+                  ]
+        , H.text "Read"
+        ]
+    , H.label [ P.classes [ B.checkboxInline ] ]
+        [
+          H.input [ P.inputType P.InputCheckbox
+                  , P.checked (max.modify && current.modify)
+                  , P.disabled $ not max.modify
+                  , E.onChecked (E.input_ ToggleModify)
+                  ]
+        , H.text "Modify"
+        ]
+    , H.label [ P.classes [ B.checkboxInline ] ]
+        [
+          H.input [ P.inputType P.InputCheckbox
+                  , P.checked (max.delete && current.delete)
+                  , P.disabled $ not max.delete
+                  , E.onChecked (E.input_ ToggleDelete)
+                  ]
+        , H.text "Delete"
+        ]
+    ]
+
+eval :: Natural Query PermissionsDSL
+eval (ToggleAdd next) = modify (_current <<< _add %~ not) $> next
+eval (ToggleRead next) = modify (_current <<< _read %~ not) $> next
+eval (ToggleModify next) = modify (_current <<< _modify %~ not) $> next
+eval (ToggleDelete next) = modify (_current <<< _delete %~ not) $> next
+eval (SetMaximum m next) = modify (_max .~ m) $> next
+eval (GetSelected continue) = map continue $ gets _.current

--- a/src/SlamData/Dialog/Share/User/Component.purs
+++ b/src/SlamData/Dialog/Share/User/Component.purs
@@ -1,0 +1,211 @@
+{-
+Copyright 2016 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
+module SlamData.Dialog.Share.User.Component where
+
+import Prelude
+
+import Control.Monad (when)
+import Control.MonadPlus (guard)
+
+import Data.Foldable as F
+import Data.Functor (($>))
+import Data.Functor.Eff (liftEff)
+import Data.Lens (LensP(), lens, (.~), (%~), (?~))
+import Data.Lens.Index (ix)
+import Data.Map as Map
+import Data.Maybe as M
+import Data.Time (Milliseconds(..))
+import Data.Tuple as Tpl
+
+import DOM.HTML.Types (HTMLElement())
+
+import Halogen
+import Halogen.HTML.Indexed as H
+import Halogen.HTML.Events.Indexed as E
+import Halogen.HTML.Properties.Indexed as P
+import Halogen.HTML.Properties.Indexed.ARIA as ARIA
+import Halogen.Themes.Bootstrap3 as B
+import Halogen.CustomProps as Cp
+import Halogen.Component.Utils (forceRerender, sendAfter)
+
+import SlamData.Effects (Slam())
+import SlamData.Render.CSS as Rc
+import SlamData.Render.Common (glyph, fadeWhen)
+
+import Utils.DOM (focus)
+
+type State =
+  {
+    inputs :: Map.Map Int String
+  , elements :: Map.Map Int HTMLElement
+  , blurred :: M.Maybe Int
+  }
+
+_inputs :: forall a r. LensP {inputs :: a|r} a
+_inputs = lens _.inputs _{inputs = _}
+
+_elements :: forall a r. LensP {elements :: a|r} a
+_elements = lens _.elements _{elements = _}
+
+_blurred :: forall a r. LensP {blurred :: a|r} a
+_blurred = lens _.blurred _{blurred = _}
+
+initialState :: State
+initialState =
+  {
+    inputs: Map.empty
+  , elements: Map.empty
+  , blurred: M.Nothing
+  }
+
+data Query a
+  = InputChanged Int String a
+  | Remove Int a
+  | Blurred Int a
+  | Create Int a
+  | Focused (M.Maybe Int) a
+  | RememberEl Int HTMLElement a
+  | GetValues (Array String -> a)
+
+type UserShareDSL = ComponentDSL State Query Slam
+
+comp :: Component State Query Slam
+comp = component render eval
+
+render :: State -> ComponentHTML Query
+render state =
+  H.form
+    [ Cp.nonSubmit
+    , P.classes [ Rc.userShareForm ]
+    ]
+    ((F.foldMap (Tpl.uncurry showInput) $ Map.toList state.inputs)
+     <> [ newInput newKey ]
+    )
+  where
+  mbMaxKey :: M.Maybe Int
+  mbMaxKey = F.maximum $ Map.keys state.inputs
+
+  newKey :: Int
+  newKey =
+    M.fromMaybe zero $ add one mbMaxKey
+
+  shouldFade :: Boolean
+  shouldFade =
+    mbMaxKey
+      >>= flip Map.lookup state.inputs
+      <#> eq ""
+      # M.fromMaybe false
+
+  showInput :: Int -> String -> Array (ComponentHTML Query)
+  showInput inx val =
+    [ H.div [ P.classes [ B.inputGroup ] ]
+      [
+        H.input [ P.classes [ B.formControl ]
+                , P.value val
+                , ARIA.label "User email or name"
+                , E.onValueInput (E.input (InputChanged inx))
+                , E.onBlur (E.input_ (Blurred inx))
+                , E.onFocus (E.input_ (Focused $ M.Just inx))
+                , P.key $ show inx
+                , P.initializer (\el -> action $ RememberEl inx el)
+                ]
+      , H.span [ P.classes [ B.inputGroupBtn ] ]
+        [ H.button
+          [ P.classes ([ B.btn ] <> (guard (val /= "") $> B.btnDefault))
+          , E.onClick (E.input_ (Remove inx))
+          , P.buttonType P.ButtonButton
+          , P.disabled (val == "")
+          , ARIA.label "Clear user email or name"
+          ]
+          [ glyph B.glyphiconRemove ]
+        ]
+      ]
+     ]
+
+  newInput :: Int -> ComponentHTML Query
+  newInput inx =
+    H.div [ P.classes ([ B.inputGroup ] <> fadeWhen shouldFade) ]
+      [
+        H.input [ P.classes [ B.formControl ]
+                , ARIA.label "User email or name"
+                , E.onFocus (E.input_ (Create inx))
+                , P.value ""
+                , P.key $ show inx
+                , P.initializer (\el -> action $ RememberEl inx el)
+                ]
+      , H.span [ P.classes [ B.inputGroupBtn ] ]
+        [ H.button
+          [ P.classes [ B.btn ]
+          , P.disabled true
+          , P.buttonType P.ButtonButton
+          , ARIA.label "Clear user email or name"
+          ]
+          [ glyph B.glyphiconRemove ]
+        ]
+      ]
+
+
+eval :: Natural Query UserShareDSL
+eval (Create inx next) = do
+  clearBlurred $ pure unit
+  modify $ _inputs %~ Map.insert inx ""
+  forceRerender
+  focusInx inx
+  pure next
+eval (InputChanged inx val next) = modify (_inputs <<< ix inx .~ val) $> next
+eval (Remove inx next) = forgetInx inx $> next
+eval (Focused mbInx next) = do
+  clearBlurred do
+    forceRerender
+    F.for_ mbInx focusInx
+  pure next
+eval (Blurred inx next) = do
+  modify $ _blurred ?~ inx
+  sendAfter (Milliseconds 200.0) $ action $ Focused M.Nothing
+  pure next
+eval (RememberEl inx el next) = modify (_elements %~ Map.insert inx el) $> next
+eval (GetValues continue) =
+  gets _.inputs <#> Map.values <#> F.foldMap pure <#> continue
+
+
+forgetInx
+  :: Int
+  -> UserShareDSL Unit
+forgetInx inx = do
+  modify $ _inputs %~ Map.delete inx
+  modify $ _elements %~ Map.delete inx
+
+focusInx
+  :: Int
+  -> UserShareDSL Unit
+focusInx inx =
+  gets _.elements
+    <#> Map.lookup inx
+    >>= F.traverse_ (liftEff <<< focus)
+
+clearBlurred
+  :: UserShareDSL Unit
+  -> UserShareDSL Unit
+clearBlurred act =
+  gets _.blurred >>= F.traverse_ \bix -> do
+    val <-
+      gets _.inputs
+      <#> Map.lookup bix
+      <#> M.fromMaybe ""
+    when (val == "") $ forgetInx bix
+    modify $ _blurred .~ M.Nothing
+    act

--- a/src/SlamData/Form/Select.purs
+++ b/src/SlamData/Form/Select.purs
@@ -146,3 +146,7 @@ instance decodeJsonSelect :: (DecodeJson a) => DecodeJson (Select a) where
          <$> (obj .? "options")
          <*> (obj .? "value")
     pure $ Select r
+
+instance showSelect :: (Show a) => Show (Select a) where
+  show (Select s) =
+    "(Select {options = " <> show s.options <> ", value = " <> show s.value <> "})"

--- a/src/SlamData/Notebook/FileInput/Component.purs
+++ b/src/SlamData/Notebook/FileInput/Component.purs
@@ -101,7 +101,7 @@ eval q =
       modify (_ { showFiles = shouldShowFiles })
       when shouldShowFiles $ do
         idToken <- liftEff' Auth.retrieveIdToken
-        perms <- liftEff' Auth.retrievePermissions
+        perms <- liftEff' Auth.retrievePermissionTokens
         let
           fileProducer =
             FT.hoistFreeT liftH $

--- a/src/SlamData/Notebook/StyleLoader.purs
+++ b/src/SlamData/Notebook/StyleLoader.purs
@@ -1,3 +1,19 @@
+{-
+Copyright 2016 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
 module SlamData.Notebook.StyleLoader where
 
 import Prelude

--- a/src/SlamData/Render/CSS.purs
+++ b/src/SlamData/Render/CSS.purs
@@ -368,3 +368,15 @@ sqlMountAddVarPairButton = className "sql-mount-add-var-pair-button"
 
 fileAction :: ClassName
 fileAction = className "file-action"
+
+permissionsCheckboxes :: ClassName
+permissionsCheckboxes = className "permissions-checkboxes"
+
+tokenGeneratorForm :: ClassName
+tokenGeneratorForm = className "token-generator-form"
+
+cancelInputRunIcon :: ClassName
+cancelInputRunIcon = className "cancel-input-run-icon"
+
+userShareForm :: ClassName
+userShareForm = className "user-share-form"

--- a/src/SlamData/SignIn/Menu/Component/State.purs
+++ b/src/SlamData/SignIn/Menu/Component/State.purs
@@ -1,4 +1,3 @@
-
 {-
 Copyright 2016 SlamData, Inc.
 

--- a/src/Utils/DOM.purs
+++ b/src/Utils/DOM.purs
@@ -34,8 +34,11 @@ import Unsafe.Coerce (unsafeCoerce)
 elementToHTMLElement :: Element -> HTMLElement
 elementToHTMLElement = unsafeCoerce
 
-querySelector :: forall e. String -> HTMLElement ->
-                 Eff (dom :: DOM|e) (Maybe HTMLElement)
+querySelector
+  :: forall e
+   . String
+  -> HTMLElement
+  -> Eff (dom :: DOM|e) (Maybe HTMLElement)
 querySelector str htmlEl =
   map (toMaybe >>> map elementToHTMLElement)
   $ P.querySelector str $ elementToParentNode $ htmlElementToElement htmlEl

--- a/src/Utils/Random.purs
+++ b/src/Utils/Random.purs
@@ -28,9 +28,11 @@ import Data.Tuple (Tuple(..), snd)
 
 -- | Getting random element from any `Foldable` in any `MonadEff`
 -- | Returns `Nothing` if foldable is empty
-randomIn :: forall a m f e.
-            (Foldable f, Monad m, FunctorEff (random :: RANDOM|e) m) =>
-            f a -> m (Maybe a)
+randomIn
+  :: forall a m f e
+   . (Foldable f, Monad m, FunctorEff (random :: RANDOM|e) m)
+  => f a
+  -> m (Maybe a)
 randomIn fa =
   map snd $ foldl foldFn (pure $ Tuple zero Nothing) fa
   where
@@ -40,13 +42,16 @@ randomIn fa =
     prob <- liftEff random
     pure case ma of
       Tuple _ Nothing -> Tuple prob $ Just a
-      Tuple p (Just b) -> if prob > p
-                          then Tuple prob $ Just a
-                          else Tuple p $ Just b
+      Tuple p (Just b) ->
+        if prob > p
+          then Tuple prob $ Just a
+          else Tuple p $ Just b
 
 
 -- | same as `randomIn` but returns `mempty` instead of `Nothing`
-randomInM :: forall a m f e.
-                (Foldable f, Monad m, FunctorEff (random :: RANDOM|e) m, Monoid a) =>
-                f a -> m a
+randomInM
+  :: forall a m f e
+   . (Foldable f, Monad m, FunctorEff (random :: RANDOM|e) m, Monoid a)
+   => f a
+   -> m a
 randomInM fa = fromMaybe mempty <$> randomIn fa

--- a/src/Utils/SessionStorage.purs
+++ b/src/Utils/SessionStorage.purs
@@ -1,3 +1,19 @@
+{-
+Copyright 2016 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
 module Utils.SessionStorage
   ( setSessionStorage
   , getSessionStorage


### PR DESCRIPTION
This is growing bigger and bigger. 

+ Decomposed `liftWithCanceler` added `sendAfter` to `Halogen.Component.Utils`
+ Renamed `Permission --> PermissionToken`
+ Added headers 
+ Added permission selector component (SD-1400)
+ Added code share component (SD-1397) 
+ Added user share component (SD-1398) 
+ Added confirm dialog component (SD-1402) 
+ Added two mocks (they are marked as mocks) 

I think cascade select and tree map select  (SD-1399 and SD-1401) should live in slamdata/purescript-halogen-selects. 

@garyb please, review