### PR TITLE
Allow for more flexible asset naming in get-quasar.js

### DIFF
--- a/script/get-quasar.js
+++ b/script/get-quasar.js
@@ -60,7 +60,7 @@ function downloadQuasar(quasarOptions, token, destFile, k) {
   fetchReleaseInfo(quasarOptions, function (info) {
     var assets =
       info.assets.filter(function (asset) {
-        return asset.name.indexOf("web") === 0
+        return asset.name.indexOf("web") !== -1
       });
 
     var asset = assets[0];


### PR DESCRIPTION
We recently renamed the artifacts being published for quasar-advanced.