### PR TITLE
resourceExists use sampling for view mounts and metadata for other re…

### DIFF
--- a/src/Quasar/Paths.purs
+++ b/src/Quasar/Paths.purs
@@ -58,6 +58,12 @@ queryUrl =
   </> dir "query"
   </> dir "fs"
 
+compileUrl :: AbsDir Sandboxed
+compileUrl =
+  serviceBaseUrl
+  </> dir "compile"
+  </> dir "fs"
+
 serverInfoUrl :: AbsFile Sandboxed
 serverInfoUrl =
   serviceBaseUrl

--- a/src/SlamData/FileSystem/Resource.purs
+++ b/src/SlamData/FileSystem/Resource.purs
@@ -37,6 +37,7 @@ module SlamData.FileSystem.Resource
   , mkDirectory
   , mkFile
   , mkNotebook
+  , mkViewMount
   , newDatabase
   , newDirectory
   , newFile

--- a/src/SlamData/Notebook/Cell/JTable/Component.purs
+++ b/src/SlamData/Notebook/Cell/JTable/Component.purs
@@ -105,7 +105,6 @@ evalCell (Load json next) = do
   either (const (pure unit)) set $ fromModel <$> Model.decode json
   pure next
 evalCell (SetCanceler _ next) = pure next
-
 -- | Evaluates jtable-specific cell queries.
 evalJTable :: Natural Query (ComponentDSL State QueryP Slam)
 evalJTable (StepPage step next) =

--- a/src/SlamData/Notebook/Cell/Query/Eval.purs
+++ b/src/SlamData/Notebook/Cell/Query/Eval.purs
@@ -72,12 +72,9 @@ queryEval info sql =
           # Auth.authed
           # MT.lift
           >>= E.either EC.throwError pure
-
         (MT.lift $ Auth.authed $ Quasar.resourceExists outputResource)
           >>= \x -> unless x $ EC.throwError "Requested collection doesn't exist"
-
-        F.for_ plan \p ->
-          WC.tell ["Plan: " <> p]
+        F.for_ plan \p -> WC.tell ["Plan: " <> p]
 
         pure $ Port.TaggedResource {resource: outputResource, tag: pure sql}
   where
@@ -89,7 +86,6 @@ queryEval info sql =
 
   tempOutputResource = CEQ.temporaryOutputResource info
   inputResource = R.parent tempOutputResource
-
 
 querySetup :: CEQ.CellSetupInfo -> AceDSL Unit
 querySetup { inputPort, notebookPath } =

--- a/src/SlamData/Notebook/Cell/Search/Component.purs
+++ b/src/SlamData/Notebook/Cell/Search/Component.purs
@@ -145,14 +145,18 @@ cellEval q =
 
         WC.tell ["Generated SQL: " <> sql]
 
-        { plan: plan, outputResource: outputResource } <-
-          Quasar.executeQuery template (M.fromMaybe false info.cachingEnabled) SM.empty inputResource tempOutputResource
+        { plan, outputResource } <-
+          Quasar.executeQuery
+            template
+            (M.fromMaybe false info.cachingEnabled)
+            SM.empty
+            inputResource
+            tempOutputResource
             # Auth.authed
             # NC.liftWithCanceler' >>> MT.lift
             >>= either (\err -> EC.throwError $ "Error in query: " <> err) pure
 
-        F.for_ plan \p ->
-          WC.tell ["Plan: " <> p]
+        F.for_ plan \p -> WC.tell ["Plan: " <> p]
 
         (MT.lift $ NC.liftWithCanceler' $ Auth.authed $ Quasar.resourceExists outputResource)
           >>= \x -> when (not x)


### PR DESCRIPTION
…source type, executeQuery returns view mount if caching is disabled

Ok, now it's ready
+ `executeQuery` returns view mount if caching isn't enabled
+ `resourceExists` try to get sample for views and just checks metadata for other kinds of resources
+ `sample'` works for view mounts and files not just files.

@garyb please review