### PR TITLE
labels, bootstrap in api cells

### DIFF
--- a/less/form-builder.less
+++ b/less/form-builder.less
@@ -1,13 +1,18 @@
 table.form-builder {
+  width: 100%;
   table-layout: fixed;
 
   th, td {
     padding: 5px;
     min-width: 100px;
+
   }
 
   label {
-    padding-left: 5px;
+      padding-left: 5px;
+      width: 80%;
   }
-
+  input[type=checkbox] {
+      margin-right: 6px;
+  }
 }

--- a/src/SlamData/Notebook/Cell/APIResults/Component.purs
+++ b/src/SlamData/Notebook/Cell/APIResults/Component.purs
@@ -33,6 +33,7 @@ import Data.Void as Void
 import Halogen
 import Halogen.HTML.Indexed as H
 import Halogen.HTML.Properties.Indexed as HP
+import Halogen.Themes.Bootstrap3 as B
 
 import SlamData.Notebook.Cell.APIResults.Component.Query
 import SlamData.Notebook.Cell.APIResults.Component.State
@@ -56,14 +57,20 @@ render
   :: State
   -> ComponentHTML QueryP
 render { varMap } =
-  H.table [ HP.class_ $ H.className "form-builder" ] $
+  H.table
+    [ HP.classes [ H.className "form-builder"
+                 , B.table
+                 , B.tableStriped
+                 ]
+    ]
     [ H.thead_
         [ H.tr_
             [ H.th_ [ H.text "Name" ]
             , H.th_ [ H.text "Value" ]
             ]
         ]
-    ] <> SM.foldMap renderItem varMap
+      , H.tbody_ $ SM.foldMap renderItem varMap
+    ]
 
   where
     renderItem :: String -> Port.VarMapValue -> Array (ComponentHTML QueryP)

--- a/src/SlamData/Notebook/FormBuilder/Component.purs
+++ b/src/SlamData/Notebook/FormBuilder/Component.purs
@@ -134,7 +134,9 @@ render { items } =
       :: L.List ItemId
       -> FormBuilderHTML g
     renderTable items =
-      H.table [ HP.class_ $ H.className "form-builder" ] $
+      H.table [ HP.classes [ H.className "form-builder"
+                           ]
+              ]
         [ H.thead_
             [ H.tr_
                 [ H.th_ [ H.text "Name" ]
@@ -142,7 +144,8 @@ render { items } =
                 , H.th_ [ H.text "Default" ]
                 ]
             ]
-        ] <> L.fromList (renderItem <$> items)
+        , H.tbody_ $ L.fromList (renderItem <$> items)
+        ]
 
     renderItem
       :: ItemId


### PR DESCRIPTION
fixes https://slamdata.atlassian.net/browse/SD-1520

This adds labels/aria-labels to `API` cell and styles for `API` and `APIResults` cells. 
Now getting inputs for tests is a bit easier (i.e. `get first element with aria-label "API variable name"` and `select option with value "Number" for element with aria-label "Type of "myVariable" API variable"`) 

<img width="1280" alt="2016-03-16 16 20 15" src="https://cloud.githubusercontent.com/assets/10245930/13813629/a0300d8e-eb93-11e5-964a-03caf24eb421.png">

@garyb please review