### PR TITLE
Sd 1534

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -59,7 +59,7 @@
     "purescript-node-streams": "^0.3.0",
     "purescript-platform": "^0.4.0",
     "purescript-strongcheck": "^0.14.7",
-    "purescript-webdriver": "^0.17.0"
+    "purescript-webdriver": "^0.18.0"
   },
   "resolutions": {
     "purescript-profunctor-lenses": "^0.4.2"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "gulp-purescript": "^0.8.0",
     "gulp-replace": "^0.5.4",
     "gulp-run": "^1.6.12",
-    "gulp-replace": "^0.5.4",
     "gulp-trimlines": "^1.0.0",
     "minimist": "^1.2.0",
     "mongodb": "^2.1.1",
@@ -42,8 +41,9 @@
     "purescript": "^0.8.2",
     "rimraf": "^2.4.3",
     "run-sequence": "^1.1.5",
-    "selenium-webdriver": "=2.48.2",
-    "webpack-stream": "^2.1.0"
+    "selenium-webdriver": "=2.53.1",
+    "webpack-stream": "^2.1.0",
+    "pngparse": "^2.0.1"
   },
   "dependencies": {
     "easyimage": "^2.1.0",

--- a/src/Halogen/Component/Utils.purs
+++ b/src/Halogen/Component/Utils.purs
@@ -22,7 +22,7 @@ import Control.Coroutine.Aff (produce)
 import Control.Coroutine.Stalling as SCR
 import Control.Monad.Aff (Aff, Canceler, forkAff, later', runAff)
 import Control.Monad.Aff.AVar (AVAR, makeVar, putVar, takeVar)
-import Control.Monad.Aff.Free (Affable, fromAff)
+import Control.Monad.Aff.Free (class Affable, fromAff)
 import Control.Monad.Eff.Class (liftEff)
 
 import Data.Either as E

--- a/src/SlamData/Notebook/Cell/Chart/ChartOptions/Line.purs
+++ b/src/SlamData/Notebook/Cell/Chart/ChartOptions/Line.purs
@@ -21,6 +21,8 @@ import SlamData.Prelude
 import Data.Argonaut (JCursor)
 import Data.Array ((!!), cons)
 import Data.Array as A
+import Data.Foldable as F
+import Data.Function (on)
 import Data.Lens (view)
 import Data.List (List(..), replicate, length)
 import Data.List as L
@@ -35,14 +37,24 @@ import SlamData.Notebook.Cell.Chart.Axis as Ax
 import SlamData.Notebook.Cell.Chart.ChartConfiguration (ChartConfiguration)
 import SlamData.Notebook.Cell.Chart.ChartOptions.Common (Key, ChartAxises, commonNameMap, keyCategory, colors, mixAxisLabelAngleAndFontSize, buildChartAxises, mkKey)
 
+import Utils (stringToNumber)
+
 type LabeledPointPairs = M.Map Key (Tuple (Array Number) (Array Number))
-type LineData = M.Map Key (Tuple Number Number)
+type LineData = L.List (Tuple Key (Tuple Number Number))
 
-lineData :: ChartAxises -> LineData
+lineData :: ChartAxises → LineData
 lineData axises =
-  aggregatePairs firstAgg secondAgg
-  $ lineRawData dimensions firstSeries secondSeries firstValues secondValues M.empty
-
+  let
+    lr =
+      lineRawData
+        dimensions
+        firstSeries
+        secondSeries
+        firstValues
+        secondValues
+        M.empty
+  in
+    aggregatePairs firstAgg secondAgg lr
   where
   firstAgg :: Aggregation
   firstAgg = fromMaybe Sum $ join (axises.aggregations !! 0)
@@ -65,10 +77,10 @@ lineData axises =
   secondValues :: List (Maybe Number)
   secondValues = fromMaybe nothings $ axises.measures !! 1
 
-  nothings :: forall a. List (Maybe a)
+  nothings :: ∀ a. List (Maybe a)
   nothings = flip replicate Nothing $ maxLen firstValues dimensions
 
-  maxLen :: forall a b. List a -> List b -> Int
+  maxLen :: ∀ a b. List a → List b → Int
   maxLen lstA lstB =
     let lA = length lstA
         lB = length lstB
@@ -76,9 +88,13 @@ lineData axises =
 
 
 lineRawData
-  :: List (Maybe String) -> List (Maybe String) -> List (Maybe String)
-  -> List (Maybe Number) -> List (Maybe Number)
-  -> LabeledPointPairs -> LabeledPointPairs
+  :: List (Maybe String)
+   → List (Maybe String)
+   → List (Maybe String)
+   → List (Maybe Number)
+   → List (Maybe Number)
+   → LabeledPointPairs
+   → LabeledPointPairs
 lineRawData Nil _ _ _ _ acc = acc
 lineRawData _ Nil _ _ _ acc = acc
 lineRawData _ _ Nil _ _ acc = acc
@@ -92,8 +108,8 @@ lineRawData
   (Cons mbFirstValue firstValues)
   (Cons mbSecondValue secondValues)
   acc =
-  lineRawData dims firstSeries secondSeries firstValues secondValues
-  $ M.alter (alterFn $ Tuple firstVal secondVal) key acc
+    lineRawData dims firstSeries secondSeries firstValues secondValues
+    $ M.alter (alterFn $ Tuple firstVal secondVal) key acc
   where
   firstVal :: Number
   firstVal = fromMaybe zero mbFirstValue
@@ -105,43 +121,51 @@ lineRawData
   key = mkKey dimension mbFirstSerie mbSecondSerie
 
   alterFn
-    :: Tuple Number Number -> Maybe (Tuple (Array Number) (Array Number))
-    -> Maybe (Tuple (Array Number) (Array Number))
+    :: Tuple Number Number → Maybe (Tuple (Array Number) (Array Number))
+    → Maybe (Tuple (Array Number) (Array Number))
   alterFn (Tuple v1 v2) acc =
     case fromMaybe (Tuple [] []) acc of
-      Tuple v1s v2s -> pure $ Tuple (cons v1 v1s) (cons v2 v2s)
+      Tuple v1s v2s → pure $ Tuple (cons v1 v1s) (cons v2 v2s)
 
 
-aggregatePairs :: Aggregation -> Aggregation -> LabeledPointPairs -> LineData
-aggregatePairs fAgg sAgg = map $ bimap (runAggregation fAgg) (runAggregation sAgg)
+aggregatePairs :: Aggregation → Aggregation → LabeledPointPairs → LineData
+aggregatePairs fAgg sAgg lp =
+  M.toList $ map (bimap (runAggregation fAgg) (runAggregation sAgg)) lp
 
 buildLine
-  :: M.Map JCursor Ax.Axis -> Int -> Int -> ChartConfiguration -> EC.Option
+  :: M.Map JCursor Ax.Axis
+   → Int
+   → Int
+   → ChartConfiguration
+   → EC.Option
 buildLine axises angle size conf = case axisSeriesPair of
-  Tuple xAxis series ->
-    EC.Option EC.optionDefault { series = Just $ map Just series
-                         , xAxis = Just $ EC.OneAxis $ EC.Axis
-                                   $ mixAxisLabelAngleAndFontSize angle size xAxis
-                         , yAxis = Just yAxis
-                         , tooltip = Just tooltip
-                         , legend = Just $ mkLegend series
-                         , color = Just colors
-                         , grid = Just $ EC.Grid EC.gridDefault
-                           { y2 = Just $ EC.Percent 15.0
-                           }
-                         }
+  Tuple xAxis series →
+    EC.Option EC.optionDefault
+      { series = Just $ map Just series
+      , xAxis =
+          Just $ EC.OneAxis $ EC.Axis
+          $ mixAxisLabelAngleAndFontSize angle size xAxis
+      , yAxis = Just yAxis
+      , tooltip = Just tooltip
+      , legend = Just $ mkLegend series
+      , color = Just colors
+      , grid = Just $ EC.Grid EC.gridDefault
+          { y2 = Just $ EC.Percent 15.0
+          }
+      }
   where
-  mkLegend :: Array EC.Series -> EC.Legend
+  mkLegend :: Array EC.Series → EC.Legend
   mkLegend ss =
-    EC.Legend EC.legendDefault { "data" = Just $ map EC.legendItemDefault $ extractNames ss }
+    EC.Legend EC.legendDefault
+      { "data" = Just $ map EC.legendItemDefault $ extractNames ss }
 
   tooltip :: EC.Tooltip
   tooltip = EC.Tooltip $ EC.tooltipDefault { trigger = Just EC.TriggerItem }
 
-  extractNames :: Array EC.Series -> Array String
-  extractNames ss = A.nub $A.catMaybes $ map extractName ss
+  extractNames :: Array EC.Series → Array String
+  extractNames ss = A.nub $ A.catMaybes $ map extractName ss
 
-  extractName :: EC.Series -> Maybe String
+  extractName :: EC.Series → Maybe String
   extractName (EC.LineSeries r) = r.common.name
   extractName _ = Nothing
 
@@ -149,7 +173,16 @@ buildLine axises angle size conf = case axisSeriesPair of
   xAxisConfig = getXAxisConfig axises conf
 
   extracted :: LineData
-  extracted = lineData $ buildChartAxises axises conf
+  extracted =
+    L.sortBy (mkSortFn `on` (fst >>> keyCategory))
+      $ lineData $ buildChartAxises axises conf
+
+  mkSortFn
+    :: String → String → Ordering
+  mkSortFn =
+    case (conf.dimensions !! 0) >>= view _value >>= flip M.lookup axises of
+      Just (Ax.ValAxis _) → compare `on` stringToNumber
+      _ → compare
 
   yAxis :: EC.Axises
   yAxis =
@@ -163,44 +196,48 @@ buildLine axises angle size conf = case axisSeriesPair of
   axisSeriesPair :: Tuple EC.AxisRec (Array EC.Series)
   axisSeriesPair = mkSeries (needTwoAxises axises conf) xAxisConfig extracted
 
-needTwoAxises :: M.Map JCursor Ax.Axis -> ChartConfiguration -> Boolean
+needTwoAxises :: M.Map JCursor Ax.Axis → ChartConfiguration → Boolean
 needTwoAxises axises conf =
   isJust $ (conf.measures !! 1) >>= view _value >>= flip M.lookup axises
 
 getXAxisConfig
   :: M.Map JCursor Ax.Axis
-  -> ChartConfiguration
-  -> Tuple EC.AxisType (Maybe EC.Interval)
+  → ChartConfiguration
+  → Tuple EC.AxisType (Maybe EC.Interval)
 getXAxisConfig axises conf =
   case (conf.dimensions !! 0) >>= view _value >>= flip M.lookup axises of
-    Just (Ax.TimeAxis _) -> Tuple EC.TimeAxis $ Just $ EC.Custom zero
-    Just (Ax.ValAxis _) -> Tuple EC.ValueAxis Nothing
-    _ -> Tuple EC.CategoryAxis $ Just $ EC.Custom zero
+    Just (Ax.TimeAxis _) → Tuple EC.TimeAxis $ Just $ EC.Custom zero
+    Just (Ax.ValAxis _) → Tuple EC.CategoryAxis Nothing
+    _ → Tuple EC.CategoryAxis $ Just $ EC.Custom zero
 
 mkSeries
   :: Boolean
-  -> Tuple EC.AxisType (Maybe EC.Interval)
-  -> LineData
-  -> Tuple EC.AxisRec (Array EC.Series)
-mkSeries needTwoAxis (Tuple ty interval_) lData = Tuple xAxis series
+   → Tuple EC.AxisType (Maybe EC.Interval)
+   → LineData
+   → Tuple EC.AxisRec (Array EC.Series)
+mkSeries needTwoAxis (Tuple ty interval_) lData =
+  Tuple xAxis series
   where
   xAxis :: EC.AxisRec
-  xAxis = EC.axisDefault { "type" = Just ty
-                                 , "data" = Just $ map EC.CommonAxisData catVals
-                                 , axisTick = Just $ EC.AxisTick EC.axisTickDefault
-                                   { interval = interval_
-                                   }
-                                 }
+  xAxis =
+    EC.axisDefault
+      { "type" = Just ty
+      , "data" = Just $ map EC.CommonAxisData catVals
+      , axisTick =
+          Just $ EC.AxisTick EC.axisTickDefault
+            { interval = interval_
+            }
+      }
 
   catVals :: Array String
   catVals = A.nub $ map keyCategory keysArray
 
   keysArray :: Array Key
-  keysArray = L.fromList $ M.keys lData
+  keysArray = F.foldMap (pure <<< fst) lData
 
   series :: Array EC.Series
   series = case group of
-    Tuple firsts seconds ->
+    Tuple firsts seconds →
       L.fromList $
       (map firstSerie $ M.toList firsts)
       <> (if needTwoAxis
@@ -209,46 +246,47 @@ mkSeries needTwoAxis (Tuple ty interval_) lData = Tuple xAxis series
          )
 
   group :: Tuple (Map String (Array Number)) (Map String (Array Number))
-  group = bimap nameMap nameMap $ splitSeries $ L.fromList $ M.toList lData
+  group = bimap nameMap nameMap $ splitSeries $ L.fromList lData
 
   splitSeries
     :: Array (Tuple Key (Tuple Number Number))
-    -> Tuple (Array (Tuple Key Number)) (Array (Tuple Key Number))
+    → Tuple (Array (Tuple Key Number)) (Array (Tuple Key Number))
   splitSeries src =
-    foldl (\(Tuple firsts seconds) (Tuple k (Tuple f s)) ->
+    foldl (\(Tuple firsts seconds) (Tuple k (Tuple f s)) →
             Tuple (A.cons (Tuple k f) firsts) (A.cons (Tuple k s) seconds))
     (Tuple [] []) src
 
-  nameMap :: Array (Tuple Key Number) -> Map String (Array Number)
+  nameMap :: Array (Tuple Key Number) → Map String (Array Number)
   nameMap = commonNameMap fillEmpties catVals
 
-  arrKeys :: Array (Map String Number) -> Array String
+  arrKeys :: Array (Map String Number) → Array String
   arrKeys ms = A.nub $ A.concat (L.fromList <<< M.keys <$> ms)
 
-  fillEmpties :: Array (Map String Number) -> Array (Map String Number)
+  fillEmpties :: Array (Map String Number) → Array (Map String Number)
   fillEmpties ms =
     let ks = arrKeys ms
-    in map (\m -> foldl fill m ks) ms
+    in map (\m → foldl fill m ks) ms
 
-  fill :: Map String Number -> String -> Map String Number
+  fill :: Map String Number → String → Map String Number
   fill m key = M.alter (maybe (Just 0.0) Just) key m
 
-  firstSerie :: Tuple String (Array Number) -> EC.Series
+  firstSerie :: Tuple String (Array Number) → EC.Series
   firstSerie = serie 0.0
 
-  secondSerie :: Tuple String (Array Number) -> EC.Series
+  secondSerie :: Tuple String (Array Number) → EC.Series
   secondSerie = serie 1.0
 
-  serie :: Number -> Tuple String (Array Number) -> EC.Series
+  serie :: Number → Tuple String (Array Number) → EC.Series
   serie ix (Tuple name nums) =
-    EC.LineSeries { common: if name == ""
-                         then EC.universalSeriesDefault
-                         else EC.universalSeriesDefault { "name" = Just name }
-               , lineSeries: EC.lineSeriesDefault
-                   { "data" = Just $ map simpleData nums
-                   , yAxisIndex = Just ix
-                   }
-               }
+    EC.LineSeries
+      { common: if name == ""
+                then EC.universalSeriesDefault
+                else EC.universalSeriesDefault { "name" = Just name }
+      , lineSeries: EC.lineSeriesDefault
+          { "data" = Just $ map simpleData nums
+          , yAxisIndex = Just ix
+          }
+      }
 
-  simpleData :: Number -> EC.ItemData
+  simpleData :: Number → EC.ItemData
   simpleData n = EC.Value $ EC.Simple n

--- a/src/Utils/LocalStorage.purs
+++ b/src/Utils/LocalStorage.purs
@@ -24,7 +24,7 @@ import Prelude
 
 import Control.Bind ((>=>))
 import Control.Monad.Eff (Eff)
-import Control.Monad.Eff.Class (MonadEff, liftEff)
+import Control.Monad.Eff.Class (class MonadEff, liftEff)
 
 import Data.Argonaut (class DecodeJson, class EncodeJson, decodeJson, jsonParser, encodeJson, printJson)
 import Data.Either (Either(..))

--- a/test/src/Test/SlamData/Feature/Expectations.purs
+++ b/test/src/Test/SlamData/Feature/Expectations.purs
@@ -147,6 +147,8 @@ lastChartScreenshotToMatchAny
   -> SlamFeature Unit
 lastChartScreenshotToMatchAny =
   expectScreenshotToMatchAny
+    "test/image/diff.png"
+    0.2
     (XPath.last $ XPath.anywhere $ XPaths.chartContainer)
     "test/image/actual.png"
 

--- a/test/src/Test/SlamData/Feature/Main.purs
+++ b/test/src/Test/SlamData/Feature/Main.purs
@@ -1,3 +1,4 @@
+
 module Test.SlamData.Feature.Main where
 
 import SlamData.Prelude
@@ -31,7 +32,7 @@ import Node.Stream (Readable, Duplex, pipe, onDataString, onClose)
 
 import Selenium (setFileDetector, quit)
 import Selenium.Browser (Browser(..), str2browser)
-import Selenium.Builder (withCapabilities, browser, build)
+import Selenium.Builder (withCapabilities, browser, build, usingServer)
 import Selenium.Capabilities (Capabilities)
 import Selenium.FFProfile (setStringPreference, setBoolPreference, setIntPreference, buildFFProfile)
 import Selenium.Monad (setWindowSize)
@@ -101,6 +102,7 @@ runTests config =
     driver <- build $ do
       browser br
       traverse_ SL.buildSauceLabs msauceConfig
+      usingServer "http://127.0.0.1:4444/wd/hub"
       withCapabilities downloadCapabilities
 
 

--- a/test/src/Test/Utils.js
+++ b/test/src/Test/Utils.js
@@ -1,0 +1,34 @@
+// module Test.Utils
+
+exports.nonWhite = function(fp) {
+    return function(cb, eb) {
+        try {
+            var fs = require("fs"),
+                PNG = require("pngparse");
+            return PNG.parseFile(fp, function(err, id) {
+                if (err) return eb(err);
+                var x,
+                    y,
+                    idx,
+                    isWhite,
+                    count = 0;
+                for (x = 0; x < id.width; x++) {
+                    for (y = 0; y < id.height; y++) {
+                        isWhite = id.getPixel(x, y) == 0xFFFFFFCC;
+                        if (!isWhite) {
+                            count = count + 1;
+                        }
+                    }
+                }
+                return cb({
+                    count: count,
+                    percent: 100 * count / (id.width * id.height)
+                });
+            });
+        }
+        catch (e) {
+            return eb(e);
+        }
+    };
+
+};


### PR DESCRIPTION
+ The source of problem of https://slamdata.atlassian.net/browse/SD-1534 isn't nested data but type of x-axis. It should be `category` even if there are numbers. 
+ Sorting data for line chart. (`"10" > "2"` for value axes) 
+ Updated webdriver dependencies. 
+ Changed logic of screenshot comparison, now it says that screenshots are equal if there is less than 0.2% different pixels. This probably should probably live in test-framework lib after we extract it. 

@jonsterling please, review