### PR TITLE
filesystem app header

### DIFF
--- a/src/SlamData/Config.purs
+++ b/src/SlamData/Config.purs
@@ -27,8 +27,8 @@ browserUrl = baseUrl <> "index.html"
 notebookUrl :: String
 notebookUrl = baseUrl <> "notebook.html"
 
-searchTimeout :: Int
-searchTimeout = 500
+searchTimeout :: Number
+searchTimeout = 500.0
 
 slamDataHome :: String
 slamDataHome = baseUrl <> "index.html"

--- a/src/SlamData/FileSystem/Component/Install.purs
+++ b/src/SlamData/FileSystem/Component/Install.purs
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+   http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -21,7 +21,7 @@ import SlamData.Prelude
 import Data.Either.Nested (Either5)
 import Data.Functor.Coproduct.Nested (Coproduct5)
 
-import Halogen (ChildF(..), ParentState, ParentDSL, Action, action)
+import Halogen (ChildF(..), ParentState, Action, action)
 import Halogen.Component.ChildPath (ChildPath, cpL, cpR, (:>), injSlot, injQuery)
 
 import SlamData.Effects (Slam)
@@ -31,7 +31,7 @@ import SlamData.FileSystem.Component.State (State)
 import SlamData.FileSystem.Dialog.Component as Dialog
 import SlamData.FileSystem.Listing.Component as Listing
 import SlamData.FileSystem.Search.Component as Search
-import SlamData.SignIn.Component as SignIn
+import SlamData.Header.Component as Header
 
 type ChildState =
   Either5
@@ -39,7 +39,7 @@ type ChildState =
     Search.State
     Breadcrumbs.State
     Dialog.StateP
-    SignIn.StateP
+    Header.StateP
 
 type ChildQuery =
   Coproduct5
@@ -47,79 +47,76 @@ type ChildQuery =
     Search.Query
     Breadcrumbs.Query
     Dialog.QueryP
-    SignIn.QueryP
+    Header.QueryP
 
-type ChildSlot = Either5 Unit Unit Unit Unit Unit
+type ChildSlot =
+  Either5
+    Unit
+    Unit
+    Unit
+    Unit
+    Unit
 
 cpListing
-  :: ChildPath
-       Listing.StateP ChildState
-       Listing.QueryP ChildQuery
-       Unit ChildSlot
+  ∷ ChildPath
+      Listing.StateP ChildState
+      Listing.QueryP ChildQuery
+      Unit ChildSlot
 cpListing = cpL :> cpL :> cpL :> cpL
 
 cpSearch
-  :: ChildPath
-       Search.State ChildState
-       Search.Query ChildQuery
-       Unit ChildSlot
+  ∷ ChildPath
+      Search.State ChildState
+      Search.Query ChildQuery
+      Unit ChildSlot
 cpSearch = cpL :> cpL :> cpL :> cpR
 
 cpBreadcrumbs
-  :: ChildPath
-       Breadcrumbs.State ChildState
-       Breadcrumbs.Query ChildQuery
-       Unit ChildSlot
+  ∷ ChildPath
+      Breadcrumbs.State ChildState
+      Breadcrumbs.Query ChildQuery
+      Unit ChildSlot
 cpBreadcrumbs = cpL :> cpL :> cpR
 
 cpDialog
-  :: ChildPath
-       Dialog.StateP ChildState
-       Dialog.QueryP ChildQuery
-       Unit ChildSlot
+  ∷ ChildPath
+      Dialog.StateP ChildState
+      Dialog.QueryP ChildQuery
+      Unit ChildSlot
 cpDialog = cpL :> cpR
 
-cpSignIn
-  :: ChildPath
-       SignIn.StateP ChildState
-       SignIn.QueryP ChildQuery
-       Unit ChildSlot
-cpSignIn = cpR
+cpHeader
+  ∷ ChildPath
+      Header.StateP ChildState
+      Header.QueryP ChildQuery
+      Unit ChildSlot
+cpHeader = cpR
 
-toFs :: Action Query -> QueryP Unit
-toFs = left <<< action
+toFs ∷ Action Query → QueryP Unit
+toFs = left ∘ action
 
-toListing :: Action Listing.Query -> QueryP Unit
+toListing ∷ Action Listing.Query → QueryP Unit
 toListing =
   right
-    <<< ChildF (injSlot cpListing unit)
-    <<< injQuery cpListing
-    <<< left
-    <<< action
+    ∘ ChildF (injSlot cpListing unit)
+    ∘ injQuery cpListing
+    ∘ left
+    ∘ action
 
-toSearch :: Action Search.Query -> QueryP Unit
+toSearch ∷ Action Search.Query → QueryP Unit
 toSearch =
   right
-    <<< ChildF (injSlot cpSearch unit)
-    <<< injQuery cpSearch
-    <<< action
+    ∘ ChildF (injSlot cpSearch unit)
+    ∘ injQuery cpSearch
+    ∘ action
 
-toDialog :: Action Dialog.Query -> QueryP Unit
+toDialog ∷ Action Dialog.Query → QueryP Unit
 toDialog =
   right
-    <<< ChildF (injSlot cpDialog unit)
-    <<< injQuery cpDialog
-    <<< left
-    <<< action
-
-toSignIn :: Action SignIn.Query -> QueryP Unit
-toSignIn =
-  right
-    <<< ChildF (injSlot cpSignIn unit)
-    <<< injQuery cpSignIn
-    <<< left
-    <<< action
+    ∘ ChildF (injSlot cpDialog unit)
+    ∘ injQuery cpDialog
+    ∘ left
+    ∘ action
 
 type StateP = ParentState State ChildState Query ChildQuery Slam ChildSlot
 type QueryP = Coproduct Query (ChildF ChildSlot ChildQuery)
-type Algebra = ParentDSL State ChildState Query ChildQuery Slam ChildSlot

--- a/src/SlamData/Notebook/Deck/Component/State.purs
+++ b/src/SlamData/Notebook/Deck/Component/State.purs
@@ -117,7 +117,7 @@ type State =
   , path ∷ Maybe DirPath
   , browserFeatures ∷ BrowserFeatures
   , viewingCard ∷ Maybe CardId
-  , saveTrigger ∷ Maybe (Query Unit → Slam Unit)
+  , saveTrigger ∷ Maybe DebounceTrigger
   , runTrigger ∷ Maybe DebounceTrigger
   , pendingCards ∷ S.Set CardId
   , globalVarMap ∷ Port.VarMap

--- a/test/src/Test/Feature.purs
+++ b/test/src/Test/Feature.purs
@@ -8,6 +8,7 @@ module Test.Feature
   , checkWithProperties
   , click
   , clickWithProperties
+  , clickNotRepeatedly
   , copy
   , expectDownloadedTextFileToMatchFile
   , expectNotPresented
@@ -496,6 +497,9 @@ click xPath = clickWithProperties Map.empty xPath
 clickAll ∷ ∀ eff o. XPath → Feature eff o Unit
 clickAll xPath = clickAllWithProperties Map.empty xPath
 
+clickNotRepeatedly ∷ ∀ eff o. XPath → Feature eff o Unit
+clickNotRepeatedly xPath = clickWithPropertiesNotRepeatedly Map.empty xPath
+
 -- | Hover over the node found with the provided XPath.
 hover ∷ ∀ eff o. XPath → Feature eff o Unit
 hover xPath = hoverWithProperties Map.empty xPath
@@ -576,7 +580,9 @@ provideFieldValueWithPropertiesUntilExpectedValue
 provideFieldValueWithPropertiesUntilExpectedValue properties expectedValue xPath value  =
   tryRepeatedlyTo $ action *> (later smallWaitTime expectation)
   where
-  action = provideFieldValueElement value =<< findWithPropertiesNotRepeatedly properties xPath
+  action =
+    provideFieldValueElement value
+      =<< findWithPropertiesNotRepeatedly properties xPath
   expectation =
     expectPresentedWithPropertiesNotRepeatedly
       (updateProperty "value" (Just expectedValue) properties)
@@ -587,6 +593,15 @@ provideFieldValueWithPropertiesUntilExpectedValue properties expectedValue xPath
 selectFromDropdownWithProperties ∷ ∀ eff o. Properties → XPath → String → Feature eff o Unit
 selectFromDropdownWithProperties properties xPath text =
   tryRepeatedlyTo $ selectFromDropdownElement text =<< findWithProperties properties xPath
+
+clickWithPropertiesNotRepeatedly
+  ∷ ∀ eff o
+  . Properties
+  → XPath
+  → Feature eff o Unit
+clickWithPropertiesNotRepeatedly properties =
+  clickEl <=< findWithPropertiesNotRepeatedly properties
+
 
 -- | Click node with the provided properties or attributes found with the
 -- | provided XPath.
@@ -616,7 +631,8 @@ hoverWithProperties properties =
 -- | properties found with the provided XPath.
 provideFileInputValueWithProperties ∷ ∀ eff o. Properties → XPath → FilePath → Feature eff o Unit
 provideFileInputValueWithProperties properties xPath filePath =
-  tryRepeatedlyTo $ sendKeysEl filePath =<< findWithPropertiesNotRepeatedly properties xPath
+  tryRepeatedlyTo $ sendKeysEl filePath
+    =<< findWithPropertiesNotRepeatedly properties xPath
 
 -- | Navigate to the URL presented in the field with the provided attributes or
 -- | properties found with the providied Xath.

--- a/test/src/Test/SlamData/Feature/Test/File.purs
+++ b/test/src/Test/SlamData/Feature/Test/File.purs
@@ -30,16 +30,16 @@ fileScenario
    → Array String
    → SlamFeature Unit
    → SlamFeature Unit
-fileScenario = scenario "File" (Interact.browseRootFolderOld)
+fileScenario = scenario "File" (Interact.browseRootFolder)
 
 defaultAfterFile ∷ SlamFeature Unit
-defaultAfterFile = Interact.browseRootFolderOld
+defaultAfterFile = Interact.browseRootFolder
 
 afterRename ∷ SlamFeature Unit
 afterRename = Interact.deleteFile "Ϡ⨁⟶≣ΜϞ"
 
 afterMove ∷ SlamFeature Unit
-afterMove = Interact.browseTestFolderOld *> Interact.deleteFile "Medical data"
+afterMove = Interact.browseTestFolder *> Interact.deleteFile "Medical data"
 
 afterUpload ∷ SlamFeature Unit
 afterUpload = Interact.deleteFile "array-wrapped.json"
@@ -47,13 +47,13 @@ afterUpload = Interact.deleteFile "array-wrapped.json"
 afterAccessSharingUrl ∷ SlamFeature Unit
 afterAccessSharingUrl =
   Interact.launchSlamData
-    *> Interact.browseTestFolderOld
+    *> Interact.browseTestFolder
     *> Interact.deleteFile "Untitled Notebook.slam"
 
 test ∷ SlamFeature Unit
 test = do
   fileScenario afterRename "Rename a folder" [] do
-    Interact.browseTestFolderOld
+    Interact.browseTestFolder
     Interact.createFolder
     Interact.renameFile "Untitled Folder" "Patients"
     Expect.file "Patients"
@@ -64,7 +64,7 @@ test = do
     successMsg "Successfully renamed a folder"
 
   fileScenario afterMove "Move a folder" [] do
-    Interact.browseTestFolderOld
+    Interact.browseTestFolder
     Interact.createFolder
     Interact.renameFile "Untitled Folder" "Medical data"
     Interact.createFolder
@@ -77,7 +77,7 @@ test = do
     successMsg "Successfully moved a folder"
 
   fileScenario defaultAfterFile "Delete a folder" [] do
-    Interact.browseTestFolderOld
+    Interact.browseTestFolder
     Interact.createFolder
     Interact.deleteFile "Untitled Folder"
     Expect.noFile "Untitled Folder"
@@ -89,18 +89,18 @@ test = do
     successMsg "Successfully deleted a folder"
 
   fileScenario defaultAfterFile "Navigate back using breadcrumbs" [] do
-    Interact.browseTestFolderOld
+    Interact.browseTestFolder
     Interact.accessBreadcrumb "test-mount"
     Interact.accessBreadcrumb "Home"
     Expect.file "test-mount"
     successMsg "Successfully navigated back using breadcrumbs"
 
   fileScenario afterUpload "Upload a file" [] do
-    Interact.browseTestFolderOld
+    Interact.browseTestFolder
     Interact.uploadFile "test/array-wrapped.json"
     Expect.resourceOpenedInLastExploreCard "/test-mount/testDb/array-wrapped.json"
     Interact.browseRootFolder
-    Interact.browseTestFolderOld
+    Interact.browseTestFolder
     Expect.file "array-wrapped.json"
     successMsg "Successfully uploaded file"
 
@@ -112,7 +112,7 @@ test = do
     successMsg "Succesfully searched for a file"
 
   fileScenario defaultAfterFile "Access sharing URL for a file" [] do
-    Interact.browseTestFolderOld
+    Interact.browseTestFolder
     Interact.shareFile "smallZips"
     Interact.accessSharingUrl
     Expect.resourceOpenedInLastExploreCard "/test-mount/testDb/smallZips"
@@ -129,14 +129,14 @@ test = do
     warnMsg "SD-1538, we don't know if notebook has been saved already"
     later 1000 $ pure unit
     Interact.browseRootFolder
-    Interact.browseTestFolderOld
+    Interact.browseTestFolder
     Interact.shareFile "Untitled Notebook.slam"
     Interact.accessSharingUrl
     Expect.textInFormCard "Quarterly"
     successMsg "Successfully accessed sharing URL for a notebook"
 
   fileScenario defaultAfterFile "Download file as CSV" [] do
-    Interact.browseTestFolderOld
+    Interact.browseTestFolder
     Interact.downloadFileAsCSV "smallZips"
     Expect.downloadedTextFileToMatchFile
       "tmp/test/downloads"
@@ -145,7 +145,7 @@ test = do
     successMsg "Successfully downloaded file as CSV"
 
   fileScenario defaultAfterFile "Download file as JSON" [] do
-    Interact.browseTestFolderOld
+    Interact.browseTestFolder
     Interact.downloadFileAsJSON "smallZips"
     Expect.downloadedTextFileToMatchFile
       "tmp/test/downloads"

--- a/test/src/Test/SlamData/Feature/Test/Markdown.purs
+++ b/test/src/Test/SlamData/Feature/Test/Markdown.purs
@@ -31,7 +31,7 @@ mdScenario =
     "Markdown"
     (Interact.createNotebookInTestFolder "Markdown")
     (Interact.deleteFileInTestFolder "Untitled Notebook.slam"
-       *> Interact.browseRootFolderOld)
+       *> Interact.browseRootFolder)
 
 test :: SlamFeature Unit
 test = do

--- a/test/src/Test/SlamData/Feature/Test/SaveCard.purs
+++ b/test/src/Test/SlamData/Feature/Test/SaveCard.purs
@@ -16,7 +16,7 @@ saveCardScenario =
     (Interact.createNotebookInTestFolder "Save card")
     (Interact.deleteFileInTestFolder "Untitled Notebook.slam"
      ≫ Interact.deleteFile "временный файл"
-     ≫ Interact.browseRootFolderOld
+     ≫ Interact.browseRootFolder
     )
 
 test ∷ SlamFeature Unit

--- a/test/src/Test/SlamData/Feature/Test/Search.purs
+++ b/test/src/Test/SlamData/Feature/Test/Search.purs
@@ -30,7 +30,7 @@ searchScenario =
     "Search"
     (Interact.createNotebookInTestFolder "Search")
     (Interact.deleteFileInTestFolder "Untitled Notebook.slam"
-       *> Interact.browseRootFolderOld)
+       *> Interact.browseRootFolder)
 
 test :: SlamFeature Unit
 test = do


### PR DESCRIPTION
https://slamdata.atlassian.net/browse/SD-1581

<img width="787" alt="2016-04-27 23 32 43" src="https://cloud.githubusercontent.com/assets/10245930/14867262/62c26b3c-0cd0-11e6-8127-6cb1bae09a38.png">

+ Changed header in filesystem app to same with draftboard.
+ Refactored search. `Canceler/timeout` -> `debouncedProducer`, `These String String` -> `String` for name. 
+ Fixed path handling issue in search. (It seems that it hasn't been working for long but initially the idea was to show current path in search string) 
+ A bit more unicode
+ Tests. That `alt` stuff means: "try to click open header or click go home until we're in root folder". Not sure that this is right implementation, but I was thinking about going to root folder exactly this. 

@jonsterling could you take a look, please? 
