### PR TITLE
Tweak card slider CSS for simpler positioning

### DIFF
--- a/less/deck.less
+++ b/less/deck.less
@@ -39,21 +39,23 @@
 }
 
 .sd-card-slider {
-  clear: both;
-  display: block;
-  height: calc(18 * @grid-size);
-  max-height: calc(18 * @grid-size);
+  position: absolute;
+  top: @grid-size;
+  bottom: @grid-size;
+  width: 100%;
 }
 
 .sd-card {
   background: white;
-  overflow: auto;
   float: left;
+  position: absolute;
+  top: 0;
   height: 100%;
-}
+  width: 100%;
 
-.sd-card:not(:last-child) {
-  margin-right: calc(2 * @grid-size);
+  > div {
+    height: 100%;
+  }
 }
 
 .sd-card-gripper, .sd-card-gripper-last {
@@ -101,8 +103,8 @@
 }
 
 .deck-card {
-  max-height: 100%;
-  overflow-y: auto;
+  height: 100%;
+  overflow: auto;
 }
 
 *[aria-grabbed="true"] {

--- a/src/Halogen/Component/Utils/Debounced.purs
+++ b/src/Halogen/Component/Utils/Debounced.purs
@@ -1,3 +1,19 @@
+{-
+Copyright 2016 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
 module Halogen.Component.Utils.Debounced
   ( module Utils.Debounced
   , DebounceTrigger

--- a/src/SlamData/FileSystem/Dialog/Permissions/Component.purs
+++ b/src/SlamData/FileSystem/Dialog/Permissions/Component.purs
@@ -1,3 +1,19 @@
+{-
+Copyright 2016 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
 module SlamData.FileSystem.Dialog.Permissions.Component
   ( comp
   , module SlamData.FileSystem.Dialog.Permissions.Component.State

--- a/src/SlamData/FileSystem/Dialog/Permissions/Component/Install.purs
+++ b/src/SlamData/FileSystem/Dialog/Permissions/Component/Install.purs
@@ -1,3 +1,19 @@
+{-
+Copyright 2016 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
 module SlamData.FileSystem.Dialog.Permissions.Component.Install where
 
 import SlamData.Prelude

--- a/src/SlamData/FileSystem/Dialog/Permissions/Component/Query.purs
+++ b/src/SlamData/FileSystem/Dialog/Permissions/Component/Query.purs
@@ -1,3 +1,19 @@
+{-
+Copyright 2016 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
 module SlamData.FileSystem.Dialog.Permissions.Component.Query where
 
 import SlamData.Prelude

--- a/src/SlamData/FileSystem/Dialog/Permissions/Component/Render.purs
+++ b/src/SlamData/FileSystem/Dialog/Permissions/Component/Render.purs
@@ -1,3 +1,19 @@
+{-
+Copyright 2016 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
 module SlamData.FileSystem.Dialog.Permissions.Component.Render
   ( render
   ) where

--- a/src/SlamData/FileSystem/Dialog/Permissions/Component/State.purs
+++ b/src/SlamData/FileSystem/Dialog/Permissions/Component/State.purs
@@ -1,3 +1,19 @@
+{-
+Copyright 2016 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
 module SlamData.FileSystem.Dialog.Permissions.Component.State where
 
 import SlamData.Prelude

--- a/src/SlamData/Header/Component.purs
+++ b/src/SlamData/Header/Component.purs
@@ -1,3 +1,19 @@
+{-
+Copyright 2016 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
 module SlamData.Header.Component where
 
 import SlamData.Prelude

--- a/src/SlamData/Header/Gripper/Component.purs
+++ b/src/SlamData/Header/Gripper/Component.purs
@@ -1,3 +1,19 @@
+{-
+Copyright 2016 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
 module SlamData.Header.Gripper.Component where
 
 import SlamData.Prelude

--- a/src/SlamData/Workspace/Card/DownloadOptions/Component.purs
+++ b/src/SlamData/Workspace/Card/DownloadOptions/Component.purs
@@ -1,3 +1,19 @@
+{-
+Copyright 2016 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
 module SlamData.Workspace.Card.DownloadOptions.Component where
 
 import SlamData.Prelude

--- a/src/SlamData/Workspace/Card/DownloadOptions/Component/Query.purs
+++ b/src/SlamData/Workspace/Card/DownloadOptions/Component/Query.purs
@@ -1,3 +1,19 @@
+{-
+Copyright 2016 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
 module SlamData.Workspace.Card.DownloadOptions.Component.Query where
 
 import SlamData.Prelude

--- a/src/SlamData/Workspace/Card/DownloadOptions/Component/State.purs
+++ b/src/SlamData/Workspace/Card/DownloadOptions/Component/State.purs
@@ -1,3 +1,19 @@
+{-
+Copyright 2016 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
 module SlamData.Workspace.Card.DownloadOptions.Component.State where
 
 import SlamData.Prelude

--- a/src/SlamData/Workspace/Card/Error/Component.purs
+++ b/src/SlamData/Workspace/Card/Error/Component.purs
@@ -1,3 +1,19 @@
+{-
+Copyright 2016 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
 module SlamData.Workspace.Card.Error.Component where
 
 import SlamData.Prelude

--- a/src/SlamData/Workspace/Card/Error/Component/Query.purs
+++ b/src/SlamData/Workspace/Card/Error/Component/Query.purs
@@ -1,3 +1,19 @@
+{-
+Copyright 2016 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
 module SlamData.Workspace.Card.Error.Component.Query
   ( Query(..)
   , QueryP

--- a/src/SlamData/Workspace/Card/Error/Component/State.purs
+++ b/src/SlamData/Workspace/Card/Error/Component/State.purs
@@ -1,3 +1,19 @@
+{-
+Copyright 2016 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
 module SlamData.Workspace.Card.Error.Component.State
   ( State
   , initialState

--- a/src/SlamData/Workspace/Card/Next/Component.purs
+++ b/src/SlamData/Workspace/Card/Next/Component.purs
@@ -1,3 +1,19 @@
+{-
+Copyright 2016 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
 module SlamData.Workspace.Card.Next.Component
  ( nextCardComponent
  , module SlamData.Workspace.Card.Next.Component.State

--- a/src/SlamData/Workspace/Card/Next/Component/Query.purs
+++ b/src/SlamData/Workspace/Card/Next/Component/Query.purs
@@ -1,3 +1,19 @@
+{-
+Copyright 2016 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
 module SlamData.Workspace.Card.Next.Component.Query where
 
 import Prelude

--- a/src/SlamData/Workspace/Card/Next/Component/State.purs
+++ b/src/SlamData/Workspace/Card/Next/Component/State.purs
@@ -1,3 +1,19 @@
+{-
+Copyright 2016 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
 module SlamData.Workspace.Card.Next.Component.State where
 
 import Prelude

--- a/src/SlamData/Workspace/Card/OpenResource/Component.purs
+++ b/src/SlamData/Workspace/Card/OpenResource/Component.purs
@@ -1,3 +1,19 @@
+{-
+Copyright 2016 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
 module SlamData.Workspace.Card.OpenResource.Component
   ( openResourceComponent
   , module SlamData.Workspace.Card.OpenResource.Component.Query

--- a/src/SlamData/Workspace/Card/OpenResource/Component/Query.purs
+++ b/src/SlamData/Workspace/Card/OpenResource/Component/Query.purs
@@ -1,3 +1,19 @@
+{-
+Copyright 2016 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
 module SlamData.Workspace.Card.OpenResource.Component.Query where
 
 import SlamData.Prelude

--- a/src/SlamData/Workspace/Card/OpenResource/Component/State.purs
+++ b/src/SlamData/Workspace/Card/OpenResource/Component/State.purs
@@ -1,3 +1,19 @@
+{-
+Copyright 2016 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
 module SlamData.Workspace.Card.OpenResource.Component.State where
 
 import SlamData.Prelude

--- a/src/SlamData/Workspace/Card/Save/Component.purs
+++ b/src/SlamData/Workspace/Card/Save/Component.purs
@@ -1,3 +1,19 @@
+{-
+Copyright 2016 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
 module SlamData.Workspace.Card.Save.Component
   ( saveCardComponent
   , module SlamData.Workspace.Card.Save.Component.State

--- a/src/SlamData/Workspace/Card/Save/Component/Query.purs
+++ b/src/SlamData/Workspace/Card/Save/Component/Query.purs
@@ -1,3 +1,19 @@
+{-
+Copyright 2016 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
 module SlamData.Workspace.Card.Save.Component.Query where
 
 import SlamData.Prelude

--- a/src/SlamData/Workspace/Card/Save/Component/State.purs
+++ b/src/SlamData/Workspace/Card/Save/Component/State.purs
@@ -1,3 +1,19 @@
+{-
+Copyright 2016 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
 module SlamData.Workspace.Card.Save.Component.State where
 
 import Data.Lens (LensP, lens)

--- a/src/SlamData/Workspace/Deck/BackSide/Component.purs
+++ b/src/SlamData/Workspace/Deck/BackSide/Component.purs
@@ -1,3 +1,19 @@
+{-
+Copyright 2016 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
 module SlamData.Workspace.Deck.BackSide.Component where
 
 import SlamData.Prelude

--- a/src/SlamData/Workspace/Deck/Component.purs
+++ b/src/SlamData/Workspace/Deck/Component.purs
@@ -47,7 +47,6 @@ import DOM.HTML.Location as Location
 
 import Halogen as H
 import Halogen.Component.Utils.Debounced (fireDebouncedQuery')
-import Halogen.HTML.CSS.Indexed (style)
 import Halogen.HTML.Events.Indexed as HE
 import Halogen.HTML.Indexed as HH
 import Halogen.HTML.Properties.Indexed as HP
@@ -151,9 +150,7 @@ render vstate =
        ]
          ⊕ ((guard $ not visible) $> (HP.class_ CSS.invisible)))
       [ HH.div
-          [ HP.classes [ CSS.card ]
-          , style $ Slider.cardWidthCSS 1
-          ]
+          [ HP.classes [ CSS.card ] ]
           (Gripper.renderGrippers
              visible
              (isJust state.initialSliderX)

--- a/src/SlamData/Workspace/Deck/Component/ChildSlot.purs
+++ b/src/SlamData/Workspace/Deck/Component/ChildSlot.purs
@@ -1,3 +1,19 @@
+{-
+Copyright 2016 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
 module SlamData.Workspace.Deck.Component.ChildSlot where
 
 import SlamData.Prelude

--- a/src/Utils/CSS.purs
+++ b/src/Utils/CSS.purs
@@ -1,3 +1,19 @@
+{-
+Copyright 2016 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
 module Utils.CSS where
 
 import Prelude
@@ -13,6 +29,9 @@ calc s = "calc(" ++ s ++ ")"
 
 width :: String -> CSS
 width = key (fromString "width")
+
+left :: String -> CSS
+left = key (fromString "left")
 
 transform :: String -> CSS
 transform = key (fromString "transform")


### PR DESCRIPTION
This allows us to use position and widths based on `100%` for the cards, rather than having to calculate the width and position of everything relative to the number of cards in the slider.

It also fixes the weird sizing issue with the card back.

@beckyconning this one's best for you to look at most likely!