### PR TITLE
Fix stale active card reference

### DIFF
--- a/src/SlamData/Workspace/Deck/Component/State.purs
+++ b/src/SlamData/Workspace/Deck/Component/State.purs
@@ -375,12 +375,15 @@ aceSetupMode SQLMode = querySetup
 -- | state.
 removeCards ∷ S.Set CardId → State → State
 removeCards cardIds st = st
-    { cards = A.filter f st.cards
+    { cards = cards
+    , activeCardIndex = A.length cards - 1
     , cardTypes = foldl (flip M.delete) st.cardTypes cardIds'
     , dependencies = M.fromList $ L.filter g $ M.toList st.dependencies
     , pendingCards = S.difference st.pendingCards cardIds
     }
   where
+  cards = A.filter f st.cards
+
   cardIds' ∷ S.Set CardId
   cardIds' = cardIds ⊕ foldMap (flip findDescendants st) cardIds
 

--- a/src/SlamData/Workspace/Deck/Gripper.purs
+++ b/src/SlamData/Workspace/Deck/Gripper.purs
@@ -21,8 +21,6 @@ module SlamData.Workspace.Deck.Gripper
   ) where
 
 import Data.Array as Array
-import Data.List (List)
-import Data.List as List
 import Halogen as H
 import Halogen.HTML.Core (ClassName)
 import Halogen.HTML.Elements.Indexed as HH
@@ -45,12 +43,12 @@ import Data.Bifoldable (bifoldMap)
 
 data GripperDef = Previous Boolean | Next Boolean
 
-gripperDefsForCardId :: List CardDef -> Maybe CardId -> Tuple GripperDef GripperDef
+gripperDefsForCardId :: Array CardDef -> Maybe CardId -> Tuple GripperDef GripperDef
 gripperDefsForCardId cards cardId =
   Tuple (Previous previousCardAvailable) (Next nextCardAvailable)
   where
   previousCardAvailable =
-    cardId /= (_.id <$> List.head cards)
+    cardId /= (_.id <$> Array.head cards)
   nextCardAvailable =
     isJust cardId
 

--- a/src/SlamData/Workspace/Deck/Slider.purs
+++ b/src/SlamData/Workspace/Deck/Slider.purs
@@ -30,8 +30,8 @@ import DOM.HTML.Types (HTMLElement)
 import Data.Int as Int
 import Data.Lens (LensP)
 import Data.Lens.Setter ((.~))
-import Data.List ((..))
-import Data.List as List
+import Data.Array ((..))
+import Data.Array as Array
 import Data.Ord (max, min)
 import Data.Tuple as Tuple
 import Halogen as H
@@ -72,7 +72,7 @@ render virtualState visible =
          *> (cardSliderTransitionCSS state.sliderTransition)
      ]
        ⊕ (guard (not visible) $> (HP.class_ ClassNames.invisible)))
-    ((List.fromList (map (Tuple.uncurry (renderCard state)) (List.zip state.cards (0 .. List.length state.cards)))) ⊕ [ renderNextActionCard state ])
+    ((map (Tuple.uncurry (renderCard state)) (Array.zip state.cards (0 .. Array.length state.cards))) ⊕ [ renderNextActionCard state ])
   where
     state = State.runVirtualState virtualState
 
@@ -118,9 +118,9 @@ getCardWidth :: DeckDSL (Maybe Number)
 getCardWidth =
   traverse getBoundingClientWidth =<< H.gets _.nextActionCardElement
 
-getCardIdByIndex :: List.List CardDef -> Int -> Maybe CardId
+getCardIdByIndex :: Array CardDef -> Int -> Maybe CardId
 getCardIdByIndex cards =
-  map _.id <<< List.index cards
+  map _.id <<< Array.index cards
 
 snapActiveCardIndexByTranslationAndCardWidth :: Int -> Number -> Number -> Int -> Int
 snapActiveCardIndexByTranslationAndCardWidth numberOfCards translateX cardWidth
@@ -136,7 +136,7 @@ offsetCardSpacing = add $ cardSpacingGridSquares * Config.gridPx
 
 snapActiveCardIndex :: VirtualState -> Int
 snapActiveCardIndex virtualState =
-  maybe id (snapActiveCardIndexByTranslationAndCardWidth (List.length st.cards) st.sliderTranslateX) st.initialSliderCardWidth st.activeCardIndex
+  maybe id (snapActiveCardIndexByTranslationAndCardWidth (Array.length st.cards) st.sliderTranslateX) st.initialSliderCardWidth st.activeCardIndex
   where
   st = State.runVirtualState virtualState
 
@@ -245,7 +245,7 @@ renderNextActionCard state =
     ([ HP.key ("next-action-card")
      , HP.classes [ ClassNames.card ]
      , HP.ref (H.action <<< Query.SetNextActionCardElement)
-     , style $ cardPositionCSS (List.length state.cards)
+     , style $ cardPositionCSS (Array.length state.cards)
      ]
        ⊕ (guard (shouldHideNextActionCard state) $> (HP.class_ ClassNames.invisible))
     )

--- a/test/src/Test/SlamData/Feature/Test/FlexibleVisualization.purs
+++ b/test/src/Test/SlamData/Feature/Test/FlexibleVisualization.purs
@@ -19,7 +19,7 @@ module Test.SlamData.Feature.Test.FlexibleVisualation where
 import Prelude
 
 import Data.String as Str
-import Test.Feature.Log (successMsg, errorMsg)
+import Test.Feature.Log (successMsg)
 import Test.Feature.Scenario (scenario)
 import Test.SlamData.Feature.Expectations as Expect
 import Test.SlamData.Feature.Interactions as Interact
@@ -63,7 +63,7 @@ expectedNebraskaChartImages =
 
 test :: SlamFeature Unit
 test =
-  apiVizScenario "Make embeddable patients-city charts" ["https://slamdata.atlassian.net/browse/SD-1616"] do
+  apiVizScenario "Make embeddable patients-city charts" [] do
     tryRepeatedlyTo $ script """
       var run = function() {
         var __init = echarts.init;
@@ -111,7 +111,6 @@ test =
     Interact.accessWorkspaceWithModifiedURL (Str.replace "NE" "CO")
     Expect.lastEChartOptions chartOptions_CO_gender
     successMsg "Successfully created flexible patient chart"
-    errorMsg "This scenario succeeded, but is known to fail non-deterministically"
 
 chartOptions_CO :: String
 chartOptions_CO =

--- a/test/src/Test/SlamData/Feature/Test/Markdown.purs
+++ b/test/src/Test/SlamData/Feature/Test/Markdown.purs
@@ -186,7 +186,7 @@ test = do
     Expect.cardsInTableColumnInLastCardToNotEq 2 "type" "Silver"
     successMsg "Ok, Filtered query results with fields"
 
-  mdScenario "Filter query results by changing field values" ["https://slamdata.atlassian.net/browse/SD-1605"] do
+  mdScenario "Filter query results by changing field values" [] do
     Interact.insertMdCardInLastDeck
     Interact.provideMdInLastMdCard $ joinWith "\n\n"
       [ "discipline = __ (!``SELECT discipline FROM `/test-mount/testDb/olympics` LIMIT 1``)"
@@ -219,4 +219,3 @@ test = do
     Expect.cardsInTableColumnInLastCardToBeGT 8 "year" "1950"
     Expect.cardsInTableColumnInLastCardToNotEq 8 "type" "Gold"
     successMsg "Ok, Filtered query results by changing field values"
-    Test.Feature.Log.errorMsg "This scenario passed but is known to fail non-deterministically"

--- a/test/src/Test/SlamData/Feature/Test/SaveCard.purs
+++ b/test/src/Test/SlamData/Feature/Test/SaveCard.purs
@@ -2,7 +2,7 @@ module Test.SlamData.Feature.Test.SaveCard where
 
 import SlamData.Prelude
 
-import Test.Feature.Log (successMsg, errorMsg)
+import Test.Feature.Log (successMsg)
 import Test.Feature.Scenario (scenario)
 import Test.SlamData.Feature.Expectations as Expect
 import Test.SlamData.Feature.Interactions as Interact
@@ -21,7 +21,7 @@ saveCardScenario =
 
 test ∷ SlamFeature Unit
 test =
-  saveCardScenario "Save card output to file" ["https://slamdata.atlassian.net/browse/SD-1616"] do
+  saveCardScenario "Save card output to file" [] do
     Interact.insertQueryCardInLastDeck
     Interact.provideQueryInLastQueryCard
       "SELECT measureOne, measureTwo from `/test-mount/testDb/flatViz`"
@@ -39,4 +39,3 @@ test =
     Interact.insertJTableCardInLastDeck
     Expect.tableColumnsAre ["measureOne", "measureTwo"]
     successMsg "Successfully saved data source card output to file"
-    errorMsg "This scenario passed but is known to fail non-deterministically"

--- a/test/src/Test/SlamData/Feature/Test/Search.purs
+++ b/test/src/Test/SlamData/Feature/Test/Search.purs
@@ -18,7 +18,7 @@ module Test.SlamData.Feature.Test.Search where
 
 import Prelude
 import Control.Apply ((*>))
-import Test.Feature.Log (successMsg, errorMsg)
+import Test.Feature.Log (successMsg)
 import Test.SlamData.Feature.Expectations as Expect
 import Test.SlamData.Feature.Monad (SlamFeature)
 import Test.SlamData.Feature.Interactions as Interact
@@ -46,7 +46,7 @@ test = do
     Expect.cardsInTableColumnInLastCardToContain 10 "city" "SPRINGFIELD"
     successMsg "Successfully searched for a city"
 
-  searchScenario "Search within results" ["https://slamdata.atlassian.net/browse/SD-1616"] do
+  searchScenario "Search within results" [] do
     Interact.insertExploreCardInLastDeck
     Interact.selectFileForLastExploreCard "/test-mount/testDb/zips"
     Interact.accessNextCardInLastDeck
@@ -60,7 +60,6 @@ test = do
     Expect.cardsInTableColumnInLastCardToContain 2 "city" "SPRINGFIELD"
     Expect.cardsInTableColumnInLastCardToContain 2 "state" "OR"
     successMsg "Successfully searched within results"
-    errorMsg "This scenario passed but is known to fail non-deterministically"
 
   searchScenario "Search with field names" [] do
     --Given.aDocument "/test-mount/testDb/zips"


### PR DESCRIPTION
This should fix the major non-determinism issues we were seeing in the feature tests. It should also prevent some issues with stale active card references that we were likely to run into in the future. 

The fix is basically a move from using a `CardId` as an active card reference to using an index.

I feel like this is kinda hacky. At the moment probably makes slamdata do unnecessary work by going from an id to an index and then back again in some places so look out for those. I it might have other implications that I haven't thought of too.

I've run the tests twenty times locally and on Travis about four times. It seems to work so fingers crossed! It certainly fixes the issue I mentioned in the comment on https://slamdata.atlassian.net/browse/SD-1616.

Keep in mind when running the feature tests locally that they are sensitive to mouse events especially `mouseleave`. I suspect that this could be a cause of some local non-determinism. 

I wonder if there is a way to disable real input in WebDriver.