### PR TITLE
deck dialogs

### DIFF
--- a/less/deck.less
+++ b/less/deck.less
@@ -129,3 +129,4 @@
 @import "deck/save-card";
 @import "deck/search-card";
 @import "deck/table-card";
+@import "deck/dialog";

--- a/less/deck/dialog.less
+++ b/less/deck/dialog.less
@@ -1,0 +1,37 @@
+.deck-dialog-wrapper {
+    height: 100%;
+    margin-top: 24px;
+    padding-bottom: 48px;
+    .deck-dialog {
+        height: 100%;
+        background: white;
+        padding-left: 20px;
+        padding-right: 20px;
+        .deck-dialog-error, .deck-dialog-embed {
+            height: 100%;
+        }
+        h4 { padding-top: 20px }
+        .deck-dialog-body {
+            height: ~"calc(100% - 100px)";
+        }
+        .deck-dialog-footer {
+            position: absolute;
+            bottom: 36px;
+            button {
+                margin-right: 20px;
+            }
+        }
+        .deck-dialog-embed {
+            .deck-dialog-body form {
+                height: 100%;
+                .form-group {
+                    height: 100%;
+                    textarea {
+                        resize: none;
+                        height: ~"calc(100% - 20px)";
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/SlamData/Dialog/Error/Component.purs
+++ b/src/SlamData/Dialog/Error/Component.purs
@@ -31,10 +31,28 @@ newtype State = State String
 
 newtype Query a = Dismiss a
 
-comp :: H.Component State Query Slam
+comp ∷ H.Component State Query Slam
 comp = H.component { render, eval }
 
-render :: State -> H.ComponentHTML Query
+nonModalComp ∷ H.Component State Query Slam
+nonModalComp = H.component { render: nonModalRender, eval }
+
+nonModalRender ∷ State → H.ComponentHTML Query
+nonModalRender (State message) =
+  HH.div [ HP.classes [ HH.className "deck-dialog-error" ] ]
+    [ HH.h4_ [ HH.text "Error" ]
+    , HH.div [ HP.classes [ HH.className "deck-dialog-body", B.alert, B.alertDanger ] ]
+        [ HH.text message ]
+    , HH.div [ HP.classes [ HH.className "deck-dialog-footer" ] ]
+        [ HH.button
+            [ HP.classes [ B.btn ]
+            , HE.onClick (HE.input_ Dismiss)
+            ]
+            [ HH.text "Dismiss" ]
+        ]
+    ]
+
+render ∷ State → H.ComponentHTML Query
 render (State message) =
   modalDialog
     [ modalHeader "Error"
@@ -51,5 +69,5 @@ render (State message) =
         ]
     ]
 
-eval :: Natural Query (H.ComponentDSL State Query Slam)
+eval ∷ Query ~> (H.ComponentDSL State Query Slam)
 eval (Dismiss next) = pure next

--- a/src/SlamData/Workspace/Component/ChildSlot.purs
+++ b/src/SlamData/Workspace/Component/ChildSlot.purs
@@ -18,35 +18,30 @@ module SlamData.Workspace.Component.ChildSlot where
 
 import SlamData.Prelude
 
-import Halogen.Component.ChildPath (ChildPath, cpL, cpR, (:>))
+import Halogen.Component.ChildPath (ChildPath, cpL, cpR)
 
-import SlamData.Workspace.Dialog.Component as Dialog
 import SlamData.Workspace.Deck.Component as Deck
 import SlamData.Header.Component as Header
 
-type ChildQuery = Dialog.QueryP ⨁ Deck.QueryP ⨁ Header.QueryP
+type ChildQuery =
+  Deck.QueryP ⨁ Header.QueryP
 
-type ChildState = Dialog.StateP ⊹ Deck.StateP ⊹ Header.StateP
+type ChildState =
+  Deck.StateP ⊹ Header.StateP
 
-type ChildSlot = Unit ⊹ Unit ⊹ Unit
-
-cpDialog
-  ∷ ChildPath
-      Dialog.StateP ChildState
-      Dialog.QueryP ChildQuery
-      Unit ChildSlot
-cpDialog = cpL
+type ChildSlot =
+  Unit ⊹ Unit
 
 cpDeck
   ∷ ChildPath
       Deck.StateP ChildState
       Deck.QueryP ChildQuery
       Unit ChildSlot
-cpDeck = cpR :> cpL
+cpDeck = cpL
 
 cpHeader
   ∷ ChildPath
       Header.StateP ChildState
       Header.QueryP ChildQuery
       Unit ChildSlot
-cpHeader = cpR :> cpR
+cpHeader = cpR

--- a/src/SlamData/Workspace/Deck/Component/ChildSlot.purs
+++ b/src/SlamData/Workspace/Deck/Component/ChildSlot.purs
@@ -24,25 +24,26 @@ import SlamData.Workspace.Card.Component (CardQueryP, CardStateP)
 import SlamData.Workspace.Card.CardId (CardId)
 import SlamData.Workspace.Deck.BackSide.Component as Back
 import SlamData.Workspace.Deck.Indicator.Component as Indicator
+import SlamData.Workspace.Deck.Dialog.Component as Dialog
 
 newtype CardSlot = CardSlot CardId
 
-derive instance genericCardSlot :: Generic CardSlot
-instance eqCardSlot :: Eq CardSlot where eq = gEq
-instance ordCardSlot :: Ord CardSlot where compare = gCompare
+derive instance genericCardSlot ∷ Generic CardSlot
+instance eqCardSlot ∷ Eq CardSlot where eq = gEq
+instance ordCardSlot ∷ Ord CardSlot where compare = gCompare
 
 type BackSideSlot = Unit
 
 type IndicatorSlot = Unit
 
 type ChildSlot =
-  CardSlot ⊹ BackSideSlot ⊹ IndicatorSlot
+  CardSlot ⊹ Unit ⊹ Unit ⊹ Unit
 
 type ChildQuery =
-  CardQueryP ⨁ Back.Query ⨁ Indicator.Query
+  CardQueryP ⨁ Back.Query ⨁ Indicator.Query ⨁ Dialog.QueryP
 
 type ChildState =
-  CardStateP ⊹ Back.State ⊹ Indicator.State
+  CardStateP ⊹ Back.State ⊹ Indicator.State ⊹ Dialog.StateP
 
 
 cpCard
@@ -56,12 +57,19 @@ cpBackSide
   ∷ ChildPath
       Back.State ChildState
       Back.Query ChildQuery
-      BackSideSlot ChildSlot
+      Unit ChildSlot
 cpBackSide = cpR :> cpL
 
 cpIndicator
   ∷ ChildPath
       Indicator.State ChildState
       Indicator.Query ChildQuery
-      IndicatorSlot ChildSlot
-cpIndicator = cpR :> cpR
+      Unit ChildSlot
+cpIndicator = cpR :> cpR :> cpL
+
+cpDialog
+  ∷ ChildPath
+      Dialog.StateP ChildState
+      Dialog.QueryP ChildQuery
+      Unit ChildSlot
+cpDialog = cpR :> cpR :> cpR

--- a/src/SlamData/Workspace/Deck/Component/Query.purs
+++ b/src/SlamData/Workspace/Deck/Component/Query.purs
@@ -28,8 +28,6 @@ import Halogen (ChildF)
 import Halogen.HTML.Events.Types (Event, MouseEvent)
 
 import SlamData.Workspace.AccessType as AT
-import SlamData.Workspace.Card.CardId as CID
-import SlamData.Workspace.Card.CardType as CT
 import SlamData.Workspace.Card.Port.VarMap as Port
 import SlamData.Workspace.Deck.Component.ChildSlot (ChildSlot, ChildQuery)
 import SlamData.Workspace.Deck.DeckId (DeckId)
@@ -37,10 +35,8 @@ import SlamData.Workspace.Deck.DeckId (DeckId)
 import Utils.Path as UP
 
 data Query a
-  = AddCard CT.CardType a
-  | RunActiveCard a
+  = RunActiveCard a
   | RunPendingCards a
-  | GetPath (Maybe UP.DirPath → a)
   | SetName String a
   | SetAccessType AT.AccessType a
   | ExploreFile BF.BrowserFeatures UP.FilePath a
@@ -50,10 +46,7 @@ data Query a
   | Reset BF.BrowserFeatures UP.DirPath (Maybe DeckId) a
   | GetGlobalVarMap (Port.VarMap → a)
   | SetGlobalVarMap Port.VarMap a
-  | FindCardParent CID.CardId (Maybe CID.CardId → a)
-  | GetCardType CID.CardId (Maybe CT.CardType → a)
   | FlipDeck a
-  | GetActiveCardId (Maybe CID.CardId → a)
   | StartSliding (Event MouseEvent) a
   | StopSlidingAndSnap (Event MouseEvent) a
   | UpdateSliderPosition (Event MouseEvent) a

--- a/src/SlamData/Workspace/Deck/Component/State.purs
+++ b/src/SlamData/Workspace/Deck/Component/State.purs
@@ -17,6 +17,7 @@ limitations under the License.
 module SlamData.Workspace.Deck.Component.State
   ( StateP
   , State
+  , DisplayMode(..)
   , StateMode(..)
   , CardDef
   , CardConstructor
@@ -36,7 +37,7 @@ module SlamData.Workspace.Deck.Component.State
   , _pendingCards
   , _failingCards
   , _stateMode
-  , _backsided
+  , _displayMode
   , _initialSliderX
   , _initialSliderCardWidth
   , _sliderTransition
@@ -136,6 +137,13 @@ instance ordVirtualIndex ∷ Ord VirtualIndex where
   compare (VirtualIndex i) (VirtualIndex j) =
     compare i j
 
+data DisplayMode
+  = Normal
+  | Backside
+  | Dialog
+
+derive instance eqDisplayMode ∷ Eq DisplayMode
+
 -- | The deck state. See the corresponding lenses for descriptions of
 -- | the fields.
 type State =
@@ -155,7 +163,7 @@ type State =
   , failingCards ∷ S.Set CardId
   , globalVarMap ∷ Port.VarMap
   , stateMode ∷ StateMode
-  , backsided ∷ Boolean
+  , displayMode ∷ DisplayMode
   , initialSliderX ∷ Maybe Number
   , initialSliderCardWidth ∷ Maybe Number
   , sliderTransition ∷ Boolean
@@ -188,7 +196,7 @@ initialDeck browserFeatures =
   , pendingCards: S.empty
   , failingCards: S.empty
   , stateMode: Ready
-  , backsided: false
+  , displayMode: Normal
   , initialSliderX: Nothing
   , initialSliderCardWidth: Nothing
   , sliderTransition: false
@@ -261,9 +269,9 @@ _failingCards = lens _.failingCards _{failingCards = _}
 _stateMode ∷ LensP State StateMode
 _stateMode = lens _.stateMode _{stateMode = _}
 
--- | Is `true` if backside of deck is displayed
-_backsided ∷ ∀ a r. LensP {backsided ∷ a |r} a
-_backsided = lens _.backsided _{backsided = _}
+-- | backsided, dialog or normal (card)
+_displayMode ∷ ∀ a r. LensP {displayMode ∷ a |r} a
+_displayMode = lens (_.displayMode) (_{displayMode = _})
 
 -- | The x position of the card slider at the start of the slide interaction in
 -- | pixels. If `Nothing` slide interaction is not in progress.
@@ -533,7 +541,7 @@ fromModel browserFeatures path deckId { cards, dependencies, name } state =
     ((state
         { accessType = ReadOnly
         , activeCardIndex = VirtualIndex $ A.length cardDefs - 1 -- fishy!
-        , backsided = false
+        , displayMode = Normal
         , browserFeatures = browserFeatures
         , cardTypes = foldl addCardIdTypePair M.empty cards
         , cards = cardDefs

--- a/src/SlamData/Workspace/Deck/Dialog/Embed/Component.purs
+++ b/src/SlamData/Workspace/Deck/Dialog/Embed/Component.purs
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -}
 
-module SlamData.Workspace.Dialog.Embed.Component where
+module SlamData.Workspace.Deck.Dialog.Embed.Component where
 
 import SlamData.Prelude
 
@@ -35,14 +35,13 @@ import Halogen.HTML.Properties.Indexed as HP
 import Halogen.HTML.Renderer.String (renderHTML)
 import Halogen.Themes.Bootstrap3 as B
 
-import SlamData.Dialog.Render (modalDialog, modalHeader, modalBody, modalFooter)
 import SlamData.Effects (Slam)
 import SlamData.Workspace.Card.Port.VarMap as Port
 import SlamData.Render.CSS as Rc
 
 type State =
-  { url :: String
-  , varMap :: Port.VarMap
+  { url ∷ String
+  , varMap ∷ Port.VarMap
   }
 
 data Query a
@@ -50,19 +49,19 @@ data Query a
   | InitZClipboard String (Maybe HTMLElement) a
   | Dismiss a
 
-comp :: H.Component State Query Slam
+comp ∷ H.Component State Query Slam
 comp = H.component { render, eval }
 
-render :: State -> H.ComponentHTML Query
+render ∷ State → H.ComponentHTML Query
 render { url, varMap } =
-  modalDialog
-    [ modalHeader "Embed card"
-    , modalBody $
-        HH.form
+  HH.div [ HP.classes [ HH.className "deck-dialog-embed" ] ]
+    [ HH.h4_ [ HH.text  "Embed card" ]
+    , HH.div [ HP.classes [ HH.className "deck-dialog-body" ] ]
+        [ HH.form
           [ CP.nonSubmit ]
           [ HH.div
               [ HP.classes [ B.formGroup ]
-              , HE.onClick $ HE.input (SelectElement <<< _.target)
+              , HE.onClick $ HE.input (SelectElement ∘ _.target)
               ]
               [ HH.textarea
                   [ HP.classes [ B.formControl, Rc.embedBox ]
@@ -71,100 +70,108 @@ render { url, varMap } =
                   ]
               ]
           ]
-    , modalFooter
+        ]
+    , HH.div [ HP.classes [ HH.className "deck-dialog-footer" ] ]
         [ HH.button
+            [ HP.classes [ B.btn ]
+            , HE.onClick (HE.input_ Dismiss)
+            ]
+            [ HH.text "Dismiss" ]
+        , HH.button
             [ HP.id_ "copy-button"
             , HP.classes [ B.btn, B.btnPrimary ]
             , HE.onClick (HE.input_ Dismiss)
-            , HP.ref (H.action <<< InitZClipboard code)
+            , HP.ref (H.action ∘ InitZClipboard code)
             ]
             [ HH.text "Copy"
             ]
         ]
     ]
+
+
   where
-  code :: String
+  code ∷ String
   code =
     renderHTML $
       HH.script
         [ HP.mediaType { type: "text", subtype: "javascript", parameters: [] } ]
         [ HH.text javascriptCode ]
 
-  statements :: Array String -> String
-  statements = foldl (\m x -> m <> x <> ";\n") ""
+  statements ∷ Array String → String
+  statements = foldl (\m x → m ⊕ x ⊕ ";\n") ""
 
-  wrapJS :: Array String -> String
-  wrapJS xs = "\n" <> statements [ applyJS (absJS [] xs) [] ]
+  wrapJS ∷ Array String → String
+  wrapJS xs = "\n" ⊕ statements [ applyJS (absJS [] xs) [] ]
 
-  absJS :: Array String -> Array String -> String
+  absJS ∷ Array String → Array String → String
   absJS args xs =
     parens $
-      "function" <> parens (commaSep args) <> "{\n"
-        <> statements (indent <$> xs)
-        <> "}"
+      "function" ⊕ parens (commaSep args) ⊕ "{\n"
+        ⊕ statements (indent <$> xs)
+        ⊕ "}"
 
-  indent :: String -> String
-  indent x = "    " <> x
+  indent ∷ String → String
+  indent x = "    " ⊕ x
 
-  parens :: String -> String
-  parens x = "(" <> x <> ")"
+  parens ∷ String → String
+  parens x = "(" ⊕ x ⊕ ")"
 
-  applyJS :: String -> Array String -> String
+  applyJS ∷ String → Array String → String
   applyJS f xs =
-    f <> parens (commaSep xs)
+    f ⊕ parens (commaSep xs)
 
-  commaSep :: Array String -> String
+  commaSep ∷ Array String → String
   commaSep = F.intercalate ","
 
-  declVar :: String -> String -> String
-  declVar k v = "var " <> k <> " = " <> v
+  declVar ∷ String → String → String
+  declVar k v = "var " ⊕ k ⊕ " = " ⊕ v
 
-  quotes :: String -> String
-  quotes x = "\"" <> x <> "\""
+  quotes ∷ String → String
+  quotes x = "\"" ⊕ x ⊕ "\""
 
-  escapeQuotes :: String -> String
+  escapeQuotes ∷ String → String
   escapeQuotes =
     Rx.replace
       (Rx.regex "\"" $ Rx.noFlags { global = true })
       "\\\""
 
-  javascriptCode :: String
+  javascriptCode ∷ String
   javascriptCode =
     wrapJS $
       decls varMap
-        <> [ writeIFrame ]
+        ⊕ [ writeIFrame ]
 
-  writeIFrame :: String
+  writeIFrame ∷ String
   writeIFrame =
     applyJS "document.writeln"
       [ iframeHTML
       ]
 
-  iframeSource :: String
+  iframeSource ∷ String
   iframeSource =
-    url <>
+    url ⊕
       if SM.isEmpty varMap
          then ""
-         else "/?" <> F.intercalate "&" (printArg <$> SM.keys varMap)
+         else "/?" ⊕ F.intercalate "&" (printArg <$> SM.keys varMap)
     where
       printArg k =
-        k <> "=\" +" <> k <> "+ \""
+        k ⊕ "=\" +" ⊕ k ⊕ "+ \""
 
-  iframeHTML :: String
+  iframeHTML ∷ String
   iframeHTML =
     quotes $
       "<iframe src=\\\""
-        <> iframeSource
-        <> "\\\" width=\\\"100%\\\" height=\\\"100%\\\" frameborder=\\\"0\\\">"
-        <> "</iframe>"
+        ⊕ iframeSource
+        ⊕ "\\\" width=\\\"100%\\\" height=\\\"100%\\\" frameborder=\\\"0\\\">"
+        ⊕ "</iframe>"
 
-  decls :: Port.VarMap -> Array String
+  decls ∷ Port.VarMap → Array String
   decls =
-    SM.foldMap \k v ->
+    SM.foldMap \k v →
       [ declVar k $ quotes $ Global.encodeURIComponent $ Port.renderVarMapValue v
       ]
 
-eval :: Natural Query (H.ComponentDSL State Query Slam)
+eval ∷ Natural Query (H.ComponentDSL State Query Slam)
 eval (Dismiss next) = pure next
 eval (InitZClipboard code (Just htmlEl) next) = do
   let el = htmlElementToElement htmlEl

--- a/src/SlamData/Workspace/Deck/Slider.purs
+++ b/src/SlamData/Workspace/Deck/Slider.purs
@@ -80,7 +80,7 @@ stateStartSliding mouseEvent cardWidth =
   (DCS._initialSliderX .~ Just mouseEvent.screenX)
     ∘ (DCS._initialSliderCardWidth .~ cardWidth)
     ∘ (DCS._sliderTransition .~ false)
-    ∘ (DCS._backsided .~ false)
+    ∘ (DCS._displayMode .~ DCS.Normal)
 
 startSliding ∷ Event MouseEvent → DeckDSL Unit
 startSliding mouseEvent =


### PR DESCRIPTION
fixes https://slamdata.atlassian.net/browse/SD-1626

<img width="937" alt="2016-05-18 18 53 23" src="https://cloud.githubusercontent.com/assets/10245930/15366129/975c68c8-1d2b-11e6-8a91-e5a647414558.png">
<img width="927" alt="2016-05-18 18 53 39" src="https://cloud.githubusercontent.com/assets/10245930/15366130/975d1d86-1d2b-11e6-8340-8183d3f6da8b.png">
<img width="937" alt="2016-05-18 18 54 34" src="https://cloud.githubusercontent.com/assets/10245930/15366131/975e2a8c-1d2b-11e6-88fa-931a58815022.png">

+ Moved `Dialog` from `Workspace` to `Deck`
+ Changed `backsided` in deck's state to `displayMode`. This can be `Normal` for card, `Backside` and `Dialog`. 

@garyb please, review. I hope that I've ported your changes correctly. 