### PR TITLE
SD-1645: Recursive Decks

### DIFF
--- a/src/Halogen/Component/Opaque/Unsafe.purs
+++ b/src/Halogen/Component/Opaque/Unsafe.purs
@@ -1,0 +1,63 @@
+{-
+Copyright 2016 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
+-- | NOTE: This module lets you create recursive hierarchies of components,
+-- | but is ultimately unsound. To trigger the unsound behavior, one would need
+-- | to construct multiple components that share the *same parent algebra* yet
+-- | with *different child algebras*. Then one could potentially *peek* on
+-- | such a component, and then issue the query to another component. If it
+-- | happened that this query was indeed a child query, it would be possible
+-- | to fail at run time.
+-- |
+-- | We do not provide anyway to construct such bad queries, but since it is
+-- | possible to observe and reissue them, it is unsafe.
+
+module Halogen.Component.Opaque.Unsafe
+ ( opaque
+ , opaqueState
+ , opaqueQuery
+ , runOpaqueQuery
+ , peekOpaqueQuery
+ , OpaqueState
+ , OpaqueQuery
+ ) where
+
+import Prelude
+import Data.Functor.Coproduct (coproduct, left)
+import Halogen (ParentState, ParentQuery, Component, parentState)
+import Unsafe.Coerce (unsafeCoerce)
+
+foreign import data OpaqueState :: * -> *
+
+foreign import data OpaqueQuery :: (* -> *) -> * -> *
+
+opaque
+  :: forall s s' f f' g p
+   . Component (ParentState s s' f f' g p) (ParentQuery f f' p) g
+  -> Component (OpaqueState s) (OpaqueQuery f) g
+opaque = unsafeCoerce
+
+opaqueState :: forall s. s -> OpaqueState s
+opaqueState = unsafeCoerce <<< parentState
+
+opaqueQuery :: forall f a. f a -> OpaqueQuery f a
+opaqueQuery = unsafeCoerce <<< left
+
+runOpaqueQuery :: forall f a r. r -> (f a -> r) -> OpaqueQuery f a -> r
+runOpaqueQuery nil f = coproduct f (const nil) <<< unsafeCoerce
+
+peekOpaqueQuery :: forall f a m. (Monad m) => (f a -> m Unit) -> OpaqueQuery f a -> m Unit
+peekOpaqueQuery = runOpaqueQuery (pure unit)

--- a/src/SlamData/Workspace/Card/Factory.purs
+++ b/src/SlamData/Workspace/Card/Factory.purs
@@ -40,25 +40,26 @@ import SlamData.Workspace.Card.Query.Eval (queryEval, querySetup)
 import SlamData.Workspace.Card.Save.Component (saveCardComponent)
 import SlamData.Workspace.Card.Search.Component (searchComponent)
 import SlamData.Workspace.Card.Viz.Component (vizComponent)
+import SlamData.Workspace.Deck.Component.Cycle (DeckComponent)
 
-cardTypeComponent ∷ CardType → CardId → BrowserFeatures → CardComponent
-cardTypeComponent (Ace mode) _ _ = aceComponent { mode, evaluator, setup }
+cardTypeComponent ∷ CardType → CardId → BrowserFeatures → DeckComponent → CardComponent
+cardTypeComponent (Ace mode) _ _ _ = aceComponent { mode, evaluator, setup }
   where
   evaluator = aceEvalMode mode
   setup = aceSetupMode mode
-cardTypeComponent Search _ _ = searchComponent
-cardTypeComponent Viz _ _ = vizComponent
-cardTypeComponent Chart _ _ = chartComponent
-cardTypeComponent Markdown cardId bf = markdownComponent cardId bf
-cardTypeComponent JTable _ _ = jtableComponent
-cardTypeComponent Download _ _ = downloadComponent
-cardTypeComponent API _ _ = apiComponent
-cardTypeComponent APIResults _ _ = apiResultsComponent
-cardTypeComponent NextAction _ _ = nextCardComponent
-cardTypeComponent Save _ _ = saveCardComponent
-cardTypeComponent OpenResource _ _ = openResourceComponent
-cardTypeComponent DownloadOptions _ _ = DOpts.comp
-cardTypeComponent ErrorCard _ _ = Error.comp
+cardTypeComponent Search _ _ _ = searchComponent
+cardTypeComponent Viz _ _ _ = vizComponent
+cardTypeComponent Chart _ _ _ = chartComponent
+cardTypeComponent Markdown cardId bf _ = markdownComponent cardId bf
+cardTypeComponent JTable _ _ _ = jtableComponent
+cardTypeComponent Download _ _ _ = downloadComponent
+cardTypeComponent API _ _ _ = apiComponent
+cardTypeComponent APIResults _ _ _ = apiResultsComponent
+cardTypeComponent NextAction _ _ _ = nextCardComponent
+cardTypeComponent Save _ _ _ = saveCardComponent
+cardTypeComponent OpenResource _ _ _ = openResourceComponent
+cardTypeComponent DownloadOptions _ _ _ = DOpts.comp
+cardTypeComponent ErrorCard _ _ _ = Error.comp
 
 aceEvalMode ∷ AceMode → AceEvaluator
 aceEvalMode MarkdownMode = markdownEval

--- a/src/SlamData/Workspace/Component.purs
+++ b/src/SlamData/Workspace/Component.purs
@@ -29,6 +29,7 @@ import Data.Path.Pathy as Pathy
 
 import Halogen as H
 import Halogen.Component.ChildPath (injSlot, injQuery)
+import Halogen.Component.Opaque.Unsafe (opaqueQuery)
 import Halogen.HTML.Core (ClassName, className)
 import Halogen.HTML.Events.Indexed as HE
 import Halogen.HTML.Indexed as HH
@@ -131,7 +132,7 @@ rootDeck ∷ UP.DirPath → WorkspaceDSL (Either String DeckId)
 rootDeck path = map (map DeckId) $ Model.getRoot (path </> Pathy.file "index")
 
 queryDeck ∷ ∀ a. Deck.Query a → WorkspaceDSL (Maybe a)
-queryDeck = H.query' cpDeck unit ∘ left
+queryDeck = H.query' cpDeck unit ∘ opaqueQuery
 
 querySignIn ∷ ∀ a. SignIn.Query a → WorkspaceDSL Unit
 querySignIn =

--- a/src/SlamData/Workspace/Component/Query.purs
+++ b/src/SlamData/Workspace/Component/Query.purs
@@ -23,6 +23,7 @@ import Data.List as L
 
 import Halogen as H
 import Halogen.Component.ChildPath (injSlot, injQuery)
+import Halogen.Component.Opaque.Unsafe (opaqueQuery)
 
 import SlamData.Workspace.AccessType (AccessType)
 import SlamData.Workspace.Component.ChildSlot (ChildQuery, ChildSlot, cpDeck)
@@ -52,7 +53,7 @@ toDeck =
   right
     ∘ H.ChildF (injSlot cpDeck unit)
     ∘ injQuery cpDeck
-    ∘ left
+    ∘ opaqueQuery
     ∘ H.action
 
 fromDeck ∷ ∀ a. (∀ i. (a → i) → Deck.Query i) → QueryP a
@@ -60,5 +61,5 @@ fromDeck r =
   right
     $ H.ChildF (injSlot cpDeck unit)
     $ injQuery cpDeck
-    $ left
+    $ opaqueQuery
     $ H.request r

--- a/src/SlamData/Workspace/Deck/Component/Cycle.purs
+++ b/src/SlamData/Workspace/Deck/Component/Cycle.purs
@@ -1,0 +1,28 @@
+{-
+Copyright 2016 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
+module SlamData.Workspace.Deck.Component.Cycle where
+
+import SlamData.Prelude
+
+import Halogen as H
+import SlamData.Effects (Slam)
+import SlamData.Workspace.Deck.Component.Query (QueryP)
+import SlamData.Workspace.Deck.Component.State (StateP)
+
+type DeckComponent = H.Component StateP QueryP Slam
+
+type DeckThunk = Unit → { component ∷ DeckComponent, initialState ∷ StateP }

--- a/src/SlamData/Workspace/Deck/Component/Query.purs
+++ b/src/SlamData/Workspace/Deck/Component/Query.purs
@@ -24,12 +24,11 @@ import SlamData.Prelude
 import Data.BrowserFeatures as BF
 import DOM.HTML.Types (HTMLElement)
 
-import Halogen (ChildF)
+import Halogen.Component.Opaque.Unsafe (OpaqueQuery)
 import Halogen.HTML.Events.Types (Event, MouseEvent)
 
 import SlamData.Workspace.AccessType as AT
 import SlamData.Workspace.Card.Port.VarMap as Port
-import SlamData.Workspace.Deck.Component.ChildSlot (ChildSlot, ChildQuery)
 import SlamData.Workspace.Deck.DeckId (DeckId)
 
 import Utils.Path as UP
@@ -53,4 +52,4 @@ data Query a
   | SetNextActionCardElement (Maybe HTMLElement) a
   | StopSliderTransition a
 
-type QueryP = Coproduct Query (ChildF ChildSlot ChildQuery)
+type QueryP = OpaqueQuery Query

--- a/src/SlamData/Workspace/Deck/Component/State.purs
+++ b/src/SlamData/Workspace/Deck/Component/State.purs
@@ -77,7 +77,7 @@ import Data.StrMap as SM
 
 import DOM.HTML.Types (HTMLElement)
 
-import Halogen as H
+import Halogen.Component.Opaque.Unsafe (OpaqueState)
 import Halogen.Component.Utils.Debounced (DebounceTrigger)
 
 import SlamData.Effects (Slam)
@@ -88,14 +88,13 @@ import SlamData.Workspace.Card.CardType (CardType(..))
 import SlamData.Workspace.Card.Model as Card
 import SlamData.Workspace.Card.Port.VarMap as Port
 
-import SlamData.Workspace.Deck.Component.ChildSlot (ChildSlot, ChildState, ChildQuery)
 import SlamData.Workspace.Deck.Component.Query (Query)
 import SlamData.Workspace.Deck.DeckId (DeckId, deckIdToString)
 import SlamData.Workspace.Deck.Model as Model
 
 import Utils.Path (DirPath)
 
-type StateP = H.ParentState State ChildState Query ChildQuery Slam ChildSlot
+type StateP = OpaqueState State
 
 data StateMode
   = Loading

--- a/src/SlamData/Workspace/Deck/Slider.purs
+++ b/src/SlamData/Workspace/Deck/Slider.purs
@@ -58,6 +58,7 @@ import SlamData.Workspace.Card.Factory (cardTypeComponent)
 import SlamData.Workspace.Card.Next.Component as Next
 import SlamData.Workspace.Deck.Common (DeckHTML, DeckDSL)
 import SlamData.Workspace.Deck.Component.ChildSlot as ChildSlot
+import SlamData.Workspace.Deck.Component.Cycle (DeckComponent)
 import SlamData.Workspace.Deck.Component.Query (Query)
 import SlamData.Workspace.Deck.Component.Query as DCQ
 import SlamData.Workspace.Deck.Component.State (VirtualState, State, CardDef)
@@ -67,8 +68,8 @@ import SlamData.Workspace.Deck.Gripper as Gripper
 import Utils.CSS as CSSUtils
 import Utils.DOM (getBoundingClientRect)
 
-render ∷ VirtualState → Boolean → DeckHTML
-render vstate visible =
+render ∷ DeckComponent → VirtualState → Boolean → DeckHTML
+render comp vstate visible =
   HH.div
     ([ HP.key "deck-cards"
      , HP.classes [ ClassNames.cardSlider ]
@@ -78,7 +79,7 @@ render vstate visible =
          *> (cardSliderTransitionCSS state.sliderTransition)
      ]
        ⊕ (guard (not visible) $> (HP.class_ ClassNames.invisible)))
-    ((map (Tuple.uncurry (renderCard vstate)) (Array.zip state.cards (0 .. Array.length state.cards))) ⊕ [ renderNextActionCard vstate ])
+    ((map (Tuple.uncurry (renderCard comp vstate)) (Array.zip state.cards (0 .. Array.length state.cards))) ⊕ [ renderNextActionCard vstate ])
   where
     state = DCS.runVirtualState vstate
 
@@ -231,8 +232,8 @@ cardSpacingGridSquares = 2.0
 cardSpacingPx ∷ Number
 cardSpacingPx = cardSpacingGridSquares * Config.gridPx
 
-renderCard ∷ VirtualState → CardDef → Int → DeckHTML
-renderCard vstate cardDef index =
+renderCard ∷ DeckComponent → VirtualState → CardDef → Int → DeckHTML
+renderCard comp vstate cardDef index =
   HH.div
     [ HP.key ("card" ⊕ CardId.cardIdToString cardDef.id)
     , HP.classes [ ClassNames.card ]
@@ -250,7 +251,7 @@ renderCard vstate cardDef index =
   state = DCS.runVirtualState vstate
   slotId = ChildSlot.CardSlot cardDef.id
   cardComponent =
-    { component: cardTypeComponent cardDef.ty cardDef.id state.browserFeatures
+    { component: cardTypeComponent cardDef.ty cardDef.id state.browserFeatures comp
     , initialState:
         H.parentState
           Card.initialCardState { accessType = state.accessType }


### PR DESCRIPTION
This uses the opaque component machinery to break the cycle in types when trying to make a recursive components. Consequently, Decks can only be peeked at the top-level, as everything else is now `Private`.

To allow child cards to introduce a recursive deck, we thread the deck's component spec through as an argument.

I wanted to go ahead and lock this down so we don't introduce any stuff that might cause cycle headaches.