### PR TITLE
next action card more card

### DIFF
--- a/less/main.less
+++ b/less/main.less
@@ -636,6 +636,30 @@ div.loading-message.alert.alert-info {
 //     border-bottom: 1px solid #f0f0f0;
 // }
 
+.download-type-selector {
+    width: 60px;
+        height: 160px;
+        background-color: #f0f0f0;
+        img {
+            width: 32px;
+            height: 32px;
+            padding: 6px;
+            background-color: #aaa;
+            cursor: pointer;
+            margin-left: 16px;
+            margin-top: 8px;
+            left: 50%;
+            &.active, &:hover {
+                background-color: #337ab7;
+            }
+        }
+}
+
+.download-configuration {
+        margin-left: 60px;
+        padding-top: 10px;
+    }
+
 div.viz-card-editor {
     min-height: 160px;
     padding-left: 15px;

--- a/src/SlamData/Workspace/Card/JTable/Component/State.purs
+++ b/src/SlamData/Workspace/Card/JTable/Component/State.purs
@@ -191,7 +191,7 @@ toModel st =
 
 fromModel :: Model -> State
 fromModel m =
-  spy $ initialState
+  initialState
     { page = Right <$> m.page
     , pageSize = Right <$> m.pageSize
     }

--- a/src/SlamData/Workspace/Card/Next/Component/Query.purs
+++ b/src/SlamData/Workspace/Card/Next/Component/Query.purs
@@ -16,21 +16,18 @@ limitations under the License.
 
 module SlamData.Workspace.Card.Next.Component.Query where
 
-import Prelude
-import Data.Functor.Coproduct (Coproduct())
+import SlamData.Prelude
 import Data.Lens (TraversalP(), wander)
-import Data.Maybe (Maybe())
 import SlamData.Workspace.Card.Common.EvalQuery (CardEvalQuery())
 import SlamData.Workspace.Card.CardType (CardType())
 
+
 data Query a
   = AddCard CardType a
-  | SetAvailableTypes (Array CardType) a
-  | SetMessage (Maybe String) a
+
 
 _AddCardType :: forall a. TraversalP (Query a) CardType
 _AddCardType = wander \f s → case s of
   AddCard cty next → flip AddCard next <$> f cty
-  _ → pure s
 
-type QueryP = Coproduct CardEvalQuery Query
+type QueryP = CardEvalQuery ⨁ Query

--- a/src/SlamData/Workspace/Deck/Component/Query.purs
+++ b/src/SlamData/Workspace/Deck/Component/Query.purs
@@ -49,7 +49,7 @@ data Query a
   | StartSliding (Event MouseEvent) a
   | StopSlidingAndSnap (Event MouseEvent) a
   | UpdateSliderPosition (Event MouseEvent) a
-  | SetNextActionCardElement (Maybe HTMLElement) a
+  | SetCardElement (Maybe HTMLElement) a
   | StopSliderTransition a
 
 type QueryP = OpaqueQuery Query

--- a/src/SlamData/Workspace/Deck/Indicator/Component.purs
+++ b/src/SlamData/Workspace/Deck/Indicator/Component.purs
@@ -90,7 +90,11 @@ portToStatus (Just p) = case p of
 
 eval ∷ Query ~> DSL
 eval (UpdatePortList ports next) = do
-  H.modify (_icons .~ (Arr.reverse $ snd $ foldl foldFn (false × [ ]) ports))
+  H.modify
+     $ _icons .~ (Arr.drop one
+                  $ Arr.reverse
+                  $ snd
+                  $ foldl foldFn (false × [ ]) ports)
   pure next
   where
   foldFn ∷ Boolean × (Array Status) → Maybe Port → Boolean × (Array Status)


### PR DESCRIPTION
https://slamdata.atlassian.net/browse/SD-1628

+ next action card has `top` id now. 
+ next action card is special indeed, because it's not serializable
+ Changed `nextActionCardElement` to `cardElementWidth` 

Couple things I'm a bit unsure
+ Maybe it would be better to have `data CardId = CardId Int | ErrorId | NextActionId` with `top == NextActionId` and `bottom == CardId` 
+ `VarMap` port can be used as input by `APIResults` and `Markdown` this is a bit weird but probably OK.
+ I accidently used quasar advanced and it works much slower -- changes available next actions propagate only after card evaluated. How should we handle this if we really want next action card be a card? Additional case in `EvalQuery`? 

@garyb please, review