### PR TITLE
Backport OIDC fix and update quasar-advanced to backport-444

### DIFF
--- a/quasar-versions.json
+++ b/quasar-versions.json
@@ -6,6 +6,6 @@
 , "quasar-advanced":
     { "owner": "slamdata"
     , "repo": "quasar-advanced"
-    , "tag": "backport-396"
+    , "tag": "backport-444"
     }
 }

--- a/src/SlamData/AuthRedirect/RedirectHashPayload.purs
+++ b/src/SlamData/AuthRedirect/RedirectHashPayload.purs
@@ -35,9 +35,9 @@ import OIDCCryptUtils.Types as OIDC
 
 type RedirectHashPayload =
   { idToken :: OIDC.IdToken
-  , authUser :: Maybe String
+  , authUser :: M.Maybe String
   , state :: OIDC.BoundStateJWS
-  , prompt :: Maybe String
+  , prompt :: M.Maybe String
   }
 
 parameterParser :: P.Parser (T.Tuple String String)

--- a/src/SlamData/AuthRedirect/RedirectHashPayload.purs
+++ b/src/SlamData/AuthRedirect/RedirectHashPayload.purs
@@ -35,9 +35,9 @@ import OIDCCryptUtils.Types as OIDC
 
 type RedirectHashPayload =
   { idToken :: OIDC.IdToken
-  , authUser :: String
+  , authUser :: Maybe String
   , state :: OIDC.BoundStateJWS
-  , prompt :: String
+  , prompt :: Maybe String
   }
 
 parameterParser :: P.Parser (T.Tuple String String)
@@ -60,12 +60,13 @@ uriHashParser :: P.Parser RedirectHashPayload
 uriHashParser = do
   PS.char '#'
   params <- parametersParser
+  let
+    authUser = SM.lookup "authuser" params
+    prompt = SM.lookup "prompt" params
 
   let lookup key = SM.lookup key params # M.maybe (P.fail $ "missing " <> key) pure
   idToken <- lookup "id_token" <#> OIDC.IdToken
-  authUser <- lookup "authuser"
   state <- lookup "state" <#> OIDC.BoundStateJWS
-  prompt <- lookup "prompt"
 
   pure
     { idToken


### PR DESCRIPTION
These changes are to support slamdata cloud working with the WordPress OIDC provider.