### PR TITLE
Sd 1669

### DIFF
--- a/src/SlamData/FileSystem/Component/Install.purs
+++ b/src/SlamData/FileSystem/Component/Install.purs
@@ -18,9 +18,6 @@ module SlamData.FileSystem.Component.Install where
 
 import SlamData.Prelude
 
-import Data.Either.Nested (Either5)
-import Data.Functor.Coproduct.Nested (Coproduct5)
-
 import Halogen (ChildF(..), ParentState, Action, action)
 import Halogen.Component.ChildPath (ChildPath, cpL, cpR, (:>), injSlot, injQuery)
 
@@ -34,63 +31,60 @@ import SlamData.FileSystem.Search.Component as Search
 import SlamData.Header.Component as Header
 
 type ChildState =
-  Either5
-    Listing.StateP
-    Search.State
-    Breadcrumbs.State
-    Dialog.StateP
-    Header.StateP
+  Listing.StateP
+  ⊹ Search.State
+  ⊹ Breadcrumbs.State
+  ⊹ Dialog.StateP
+  ⊹ Header.StateP
 
 type ChildQuery =
-  Coproduct5
-    Listing.QueryP
-    Search.Query
-    Breadcrumbs.Query
-    Dialog.QueryP
-    Header.QueryP
+  Listing.QueryP
+  ⨁ Search.Query
+  ⨁ Breadcrumbs.Query
+  ⨁ Dialog.QueryP
+  ⨁ Header.QueryP
 
 type ChildSlot =
-  Either5
-    Unit
-    Unit
-    Unit
-    Unit
-    Unit
+  Unit
+  ⊹ Unit
+  ⊹ Unit
+  ⊹ Unit
+  ⊹ Unit
 
 cpListing
   ∷ ChildPath
       Listing.StateP ChildState
       Listing.QueryP ChildQuery
       Unit ChildSlot
-cpListing = cpL :> cpL :> cpL :> cpL
+cpListing = cpL
 
 cpSearch
   ∷ ChildPath
       Search.State ChildState
       Search.Query ChildQuery
       Unit ChildSlot
-cpSearch = cpL :> cpL :> cpL :> cpR
+cpSearch = cpR :> cpL
 
 cpBreadcrumbs
   ∷ ChildPath
       Breadcrumbs.State ChildState
       Breadcrumbs.Query ChildQuery
       Unit ChildSlot
-cpBreadcrumbs = cpL :> cpL :> cpR
+cpBreadcrumbs = cpR :> cpR :> cpL
 
 cpDialog
   ∷ ChildPath
       Dialog.StateP ChildState
       Dialog.QueryP ChildQuery
       Unit ChildSlot
-cpDialog = cpL :> cpR
+cpDialog = cpR :> cpR :> cpR :> cpL
 
 cpHeader
   ∷ ChildPath
       Header.StateP ChildState
       Header.QueryP ChildQuery
       Unit ChildSlot
-cpHeader = cpR
+cpHeader = cpR :> cpR :> cpR :> cpR
 
 toFs ∷ Action Query → QueryP Unit
 toFs = left ∘ action
@@ -119,4 +113,4 @@ toDialog =
     ∘ action
 
 type StateP = ParentState State ChildState Query ChildQuery Slam ChildSlot
-type QueryP = Coproduct Query (ChildF ChildSlot ChildQuery)
+type QueryP = Query ⨁ (ChildF ChildSlot ChildQuery)

--- a/src/SlamData/FileSystem/Dialog/Component.purs
+++ b/src/SlamData/FileSystem/Dialog/Component.purs
@@ -19,8 +19,6 @@ module SlamData.FileSystem.Dialog.Component where
 import SlamData.Prelude
 
 import Data.Array (singleton)
-import Data.Either.Nested (Either6)
-import Data.Functor.Coproduct.Nested (Coproduct6, coproduct6)
 
 import Halogen as H
 import Halogen.Component.ChildPath (ChildPath, cpL, cpR, (:>))
@@ -37,10 +35,11 @@ import SlamData.FileSystem.Dialog.Mount.Component as Mount
 import SlamData.FileSystem.Dialog.Rename.Component as Rename
 import SlamData.FileSystem.Dialog.Share.Component as Share
 import SlamData.FileSystem.Dialog.Permissions.Component as Perms
+import SlamData.FileSystem.Dialog.Explore.Component as Explore
 import SlamData.FileSystem.Resource (Resource)
 import SlamData.Render.Common (fadeWhen)
 
-import Utils.Path (DirPath)
+import Utils.Path (DirPath, FilePath)
 
 data Dialog
   = Error String
@@ -49,100 +48,97 @@ data Dialog
   | Mount DirPath String (Maybe MountSettings)
   | Download Resource
   | Permissions Resource
+  | Explore FilePath
 
 type State = Maybe Dialog
 
-initialState :: State
+initialState ∷ State
 initialState = Nothing
 
 data Query a
   = Dismiss a
   | Show Dialog a
 
+
 type ChildState =
-  Either6
-    Mount.StateP
-    Download.State
-    Error.State
-    Share.State
-    Rename.State
-    Perms.StateP
+  Mount.StateP
+  ⊹ Download.State
+  ⊹ Error.State
+  ⊹ Share.State
+  ⊹ Rename.State
+  ⊹ Perms.StateP
+  ⊹ Explore.State
 
 type ChildQuery =
-  Coproduct6
-    Mount.QueryP
-    Download.Query
-    Error.Query
-    Share.Query
-    Rename.Query
-    Perms.QueryP
-
-type MountSlot = Unit
-type DownloadSlot = Unit
-type ErrorSlot = Unit
-type ShareSlot = Unit
-type RenameSlot = Unit
-type PermsSlot = Unit
+  Mount.QueryP
+  ⨁ Download.Query
+  ⨁ Error.Query
+  ⨁ Share.Query
+  ⨁ Rename.Query
+  ⨁ Perms.QueryP
+  ⨁ Explore.Query
 
 type ChildSlot =
-  Either6
-    MountSlot
-    DownloadSlot
-    ErrorSlot
-    ShareSlot
-    RenameSlot
-    PermsSlot
+  Unit ⊹ Unit ⊹ Unit ⊹ Unit ⊹ Unit ⊹ Unit ⊹Unit
 
 cpMount
-  :: ChildPath
+  ∷ ChildPath
        Mount.StateP ChildState
        Mount.QueryP ChildQuery
-       MountSlot ChildSlot
-cpMount = cpL :> cpL :> cpL :> cpL :> cpL
+       Unit ChildSlot
+cpMount = cpL
 
 cpDownload
-  :: ChildPath
+  ∷ ChildPath
        Download.State ChildState
        Download.Query ChildQuery
-       DownloadSlot ChildSlot
-cpDownload = cpL :> cpL :> cpL :> cpL :> cpR
+       Unit ChildSlot
+cpDownload = cpR :> cpL
 
 cpError
-  :: ChildPath
+  ∷ ChildPath
        Error.State ChildState
        Error.Query ChildQuery
-       ErrorSlot ChildSlot
-cpError = cpL :> cpL :> cpL :> cpR
+       Unit ChildSlot
+cpError = cpR :> cpR :> cpL
 
 cpShare
-  :: ChildPath
+  ∷ ChildPath
        Share.State ChildState
        Share.Query ChildQuery
-       ShareSlot ChildSlot
-cpShare = cpL :> cpL :> cpR
+       Unit ChildSlot
+cpShare = cpR :> cpR :> cpR :> cpL
 
 cpRename
-  :: ChildPath
+  ∷ ChildPath
        Rename.State ChildState
        Rename.Query ChildQuery
-       RenameSlot ChildSlot
-cpRename = cpL :> cpR
+       Unit ChildSlot
+cpRename = cpR :> cpR :> cpR :> cpR :> cpL
 
 cpPerms
-  :: ChildPath
+  ∷ ChildPath
        Perms.StateP ChildState
        Perms.QueryP ChildQuery
-       PermsSlot ChildSlot
-cpPerms = cpR
+       Unit ChildSlot
+cpPerms = cpR :> cpR :> cpR :> cpR :> cpR :> cpL
+
+cpExplore
+  ∷ ChildPath
+      Explore.State ChildState
+      Explore.Query ChildQuery
+      Unit ChildSlot
+cpExplore = cpR :> cpR :> cpR :> cpR :> cpR :> cpR
+
 
 type StateP = H.ParentState State ChildState Query ChildQuery Slam ChildSlot
-type QueryP = Coproduct Query (H.ChildF ChildSlot ChildQuery)
+type QueryP = Query ⨁ (H.ChildF ChildSlot ChildQuery)
 type DialogDSL = H.ParentDSL State ChildState Query ChildQuery Slam ChildSlot
 
-comp :: H.Component StateP QueryP Slam
+comp ∷ H.Component StateP QueryP Slam
 comp = H.parentComponent { render, eval, peek: Just (peek <<< H.runChildF) }
 
-render :: State -> H.ParentHTML ChildState Query ChildQuery Slam ChildSlot
+render ∷ State → H.ParentHTML ChildState Query ChildQuery Slam ChildSlot
 render state =
   HH.div
     [ HP.classes ([B.modal] <> fadeWhen (isNothing state))
@@ -151,74 +147,84 @@ render state =
     $ maybe [] (singleton <<< dialog) state
   where
   dialog (Error str) =
-    HH.slot' cpError unit \_ ->
+    HH.slot' cpError unit \_ →
       { component: Error.comp
       , initialState: Error.State str
       }
   dialog (Share str) =
-    HH.slot' cpShare unit \_ ->
+    HH.slot' cpShare unit \_ →
       { component: Share.comp
       , initialState: Share.State str
       }
   dialog (Rename res) =
-    HH.slot' cpRename unit \_ ->
+    HH.slot' cpRename unit \_ →
       { component: Rename.comp
       , initialState: Rename.initialState res
       }
   dialog (Download res) =
-    HH.slot' cpDownload unit \_ ->
+    HH.slot' cpDownload unit \_ →
       { component: Download.comp
       , initialState: Download.initialState res
       }
   dialog (Mount parent name settings) =
-    HH.slot' cpMount unit \_ ->
+    HH.slot' cpMount unit \_ →
       { component: Mount.comp
       , initialState: H.parentState (Mount.initialState parent name settings)
       }
   dialog (Permissions res) =
-    HH.slot' cpPerms unit \_ ->
+    HH.slot' cpPerms unit \_ →
       { component: Perms.comp
       , initialState: H.parentState $ Perms.initialState res
       }
 
-eval :: Natural Query (H.ParentDSL State ChildState Query ChildQuery Slam ChildSlot)
+  dialog (Explore fp) =
+    HH.slot' cpExplore unit \_ →
+      { component: Explore.comp
+      , initialState: Explore.initialState fp
+      }
+
+eval ∷ Natural Query (H.ParentDSL State ChildState Query ChildQuery Slam ChildSlot)
 eval (Dismiss next) = H.set Nothing $> next
 eval (Show d next) = H.set (Just d) $> next
 
 -- | Children can only close dialog. Other peeking in `FileSystem`
-peek :: forall a. ChildQuery a -> DialogDSL Unit
+peek ∷ ∀ a. ChildQuery a → DialogDSL Unit
 peek =
-  coproduct6
-    mountPeek
-    downloadPeek
-    errorPeek
-    sharePeek
-    renamePeek
-    permsPeek
+  mountPeek
+  ⨁ downloadPeek
+  ⨁ errorPeek
+  ⨁ sharePeek
+  ⨁ renamePeek
+  ⨁ permsPeek
+  ⨁ explorePeek
 
-errorPeek :: forall a. Error.Query a -> DialogDSL Unit
+errorPeek ∷ ∀ a. Error.Query a → DialogDSL Unit
 errorPeek (Error.Dismiss _) = H.set Nothing
 
-sharePeek :: forall a. Share.Query a -> DialogDSL Unit
+sharePeek ∷ ∀ a. Share.Query a → DialogDSL Unit
 sharePeek (Share.Dismiss _) = H.set Nothing
 sharePeek _ = pure unit
 
-renamePeek :: forall a. Rename.Query a -> DialogDSL Unit
+renamePeek ∷ ∀ a. Rename.Query a → DialogDSL Unit
 renamePeek (Rename.Dismiss _) = H.set Nothing
 renamePeek _ = pure unit
 
-mountPeek :: forall a. Mount.QueryP a -> DialogDSL Unit
-mountPeek = coproduct go (const (pure unit))
+mountPeek ∷ ∀ a. Mount.QueryP a → DialogDSL Unit
+mountPeek = go ⨁ const (pure unit)
   where
   go (Mount.Dismiss _) = H.set Nothing
   go _ = pure unit
 
-downloadPeek :: forall a. Download.Query a -> DialogDSL Unit
+downloadPeek ∷ ∀ a. Download.Query a → DialogDSL Unit
 downloadPeek (Download.Dismiss _) = H.set Nothing
 downloadPeek _ = pure unit
 
-permsPeek :: forall a. Perms.QueryP a -> DialogDSL Unit
-permsPeek = coproduct go (const (pure unit))
+permsPeek ∷ ∀ a. Perms.QueryP a → DialogDSL Unit
+permsPeek = go ⨁ const (pure unit)
   where
   go (Perms.Dismiss _) = H.set Nothing
   go _ = pure unit
+
+explorePeek ∷ ∀ a. Explore.Query a → DialogDSL Unit
+explorePeek (Explore.Dismiss _) = H.set Nothing
+explorePeek _ = pure unit

--- a/src/SlamData/FileSystem/Dialog/Explore/Component.purs
+++ b/src/SlamData/FileSystem/Dialog/Explore/Component.purs
@@ -1,0 +1,95 @@
+module SlamData.FileSystem.Dialog.Explore.Component where
+
+import SlamData.Prelude
+
+import Data.Lens (LensP, lens, (.~))
+import Data.Path.Pathy as Pt
+
+import Halogen as H
+import Halogen.HTML.Events.Indexed as HE
+import Halogen.HTML.Indexed as HH
+import Halogen.HTML.Properties.Indexed as HP
+import Halogen.HTML.Properties.Indexed.ARIA as ARIA
+import Halogen.Themes.Bootstrap3 as B
+
+import SlamData.Dialog.Render (modalDialog, modalHeader, modalBody, modalFooter)
+import SlamData.Effects (Slam)
+import SlamData.Render.Common (formGroup)
+import SlamData.Config as Config
+
+import Utils.Path as UP
+
+
+type State =
+  { filePath ∷ UP.FilePath
+  , workspaceName ∷ String
+  }
+
+initialState ∷ UP.FilePath → State
+initialState fp =
+  { filePath: fp
+  , workspaceName: Config.newWorkspaceName
+  }
+
+
+_filePath ∷ ∀ a r. LensP {filePath ∷ a |r} a
+_filePath = lens (_.filePath) (_{filePath = _})
+
+_workspaceName ∷ ∀ a r. LensP {workspaceName ∷ a|r} a
+_workspaceName = lens (_.workspaceName) (_{workspaceName = _})
+
+
+data Query a
+  = Explore UP.FilePath String a
+  | NameTyped String a
+  | Dismiss a
+
+comp ∷ H.Component State Query Slam
+comp = H.component { render, eval }
+
+render ∷ State → H.ComponentHTML Query
+render state =
+  modalDialog
+    [ modalHeader "Explore file"
+    , modalBody
+      $ HH.form_
+          [ HH.h4_ [ HH.text
+                       $ "Create a new workspace in "
+                       ⊕ directory
+                       ⊕ " to explore "
+                       ⊕ fileName ]
+          , formGroup
+              [ HH.input [ HP.classes [ B.formControl ]
+                         , HP.value state.workspaceName
+                         , HP.placeholder "New workspace name"
+                         , ARIA.label "New workspace name"
+                         , HE.onValueInput (HE.input NameTyped)
+                         ]
+              ]
+          ]
+    , modalFooter
+        [ HH.button
+            [ HP.classes [ B.btn ]
+            , HE.onClick (HE.input_ Dismiss)
+            , HP.buttonType HP.ButtonButton
+            ]
+            [ HH.text "Cancel" ]
+        , HH.button
+            [ HP.classes [ B.btn, B.btnPrimary ]
+            , HP.disabled $ state.workspaceName == ""
+            , HE.onClick (HE.input_ (Explore state.filePath state.workspaceName))
+            , HP.buttonType HP.ButtonButton
+            , ARIA.label "Explore file"
+            ]
+            [ HH.text "Explore" ]
+        ]
+    ]
+    where
+    anyPath = Right state.filePath
+    directory = Pt.printPath $ UP.getDir anyPath
+    fileName = UP.getNameStr anyPath
+
+eval ∷ Query ~> (H.ComponentDSL State Query Slam)
+eval (Dismiss next) = pure next
+eval (Explore res name next) = pure next
+eval (NameTyped name next) = H.modify (_workspaceName .~ name) $> next

--- a/src/SlamData/FileSystem/Listing/Item.purs
+++ b/src/SlamData/FileSystem/Listing/Item.purs
@@ -18,22 +18,8 @@ module SlamData.FileSystem.Listing.Item where
 
 import SlamData.Prelude
 
-import Control.Monad.Eff (Eff)
-import Control.UI.Browser (setLocation)
-
-import Data.Path.Pathy (printPath)
-
-import DOM (DOM)
-
-import SlamData.Config as Config
 import SlamData.FileSystem.Listing.Sort (Sort)
-import SlamData.FileSystem.Resource (Resource(..), Mount(..), resourcePath, resourceName, sortResource)
-import SlamData.FileSystem.Routing (browseURL)
-import SlamData.FileSystem.Routing.Salt (Salt)
-import SlamData.Workspace.AccessType (AccessType(..), printAccessType)
-
-import Utils.Path (encodeURIPath)
-
+import SlamData.FileSystem.Resource (Resource, resourcePath, resourceName, sortResource)
 
 data Item
   = Item Resource
@@ -41,45 +27,27 @@ data Item
   | ActionsPresentedItem Resource
   | PhantomItem Resource
 
-itemResource :: Item -> Resource
+itemResource ∷ Item → Resource
 itemResource (Item r) = r
 itemResource (SelectedItem r) = r
 itemResource (ActionsPresentedItem r) = r
 itemResource (PhantomItem r) = r
 
-itemURL :: Sort -> Salt -> AccessType -> Resource -> String
-itemURL sort salt act res = case res of
-  File path ->
-    Config.workspaceUrl ++ "#/explore" ++ encodeURIPath (printPath path)
-  Mount (View path) ->
-    Config.workspaceUrl ++ "#/explore" ++ encodeURIPath (printPath path)
-  Workspace path ->
-    Config.workspaceUrl ++ "#" ++ encodeURIPath (printPath path) ++ printAccessType act
-  Directory path ->
-    browseURL Nothing sort salt path
-  Mount (Database path) ->
-    browseURL Nothing sort salt path
-
-
-openItem :: forall e. Resource -> Sort -> Salt -> Eff (dom :: DOM|e) Unit
-openItem res sort salt = setLocation (itemURL sort salt Editable res)
-
-
-sortItem :: Boolean -> Sort -> Item -> Item -> Ordering
+sortItem ∷ Boolean → Sort → Item → Item → Ordering
 sortItem isSearching sort a b =
   sortResource (sortProjection isSearching) sort (itemResource a) (itemResource b)
   where
   sortProjection true = resourcePath
   sortProjection _ = resourceName
 
-instance eqItem :: Eq Item where
-  eq (Item r) (Item r') = r == r'
-  eq (SelectedItem r) (SelectedItem r') = r == r'
-  eq (ActionsPresentedItem r) (ActionsPresentedItem r') = r == r'
-  eq (PhantomItem r) (PhantomItem r') = r == r'
+instance eqItem ∷ Eq Item where
+  eq (Item r) (Item r') = r ≡ r'
+  eq (SelectedItem r) (SelectedItem r') = r ≡ r'
+  eq (ActionsPresentedItem r) (ActionsPresentedItem r') = r ≡ r'
+  eq (PhantomItem r) (PhantomItem r') = r ≡ r'
   eq _ _ = false
 
-instance ordItem :: Ord Item where
+instance ordItem ∷ Ord Item where
   compare (SelectedItem r) (SelectedItem r') = compare r r'
   compare (SelectedItem _) _ = GT
   compare _ (SelectedItem _) = LT

--- a/src/SlamData/FileSystem/Resource.purs
+++ b/src/SlamData/FileSystem/Resource.purs
@@ -18,6 +18,8 @@ module SlamData.FileSystem.Resource
   ( Resource(..)
   , Mount(..)
   , _filePath
+  , _dirPath
+  , _Workspace
   , _name
   , _nameAnyPath
   , _path
@@ -64,7 +66,7 @@ import Data.Argonaut.Encode (class EncodeJson)
 import Data.Foreign (ForeignError(..)) as F
 import Data.Foreign.Class (class IsForeign, readProp) as F
 import Data.Foreign.NullOrUndefined (runNullOrUndefined) as F
-import Data.Lens (lens, LensP, TraversalP, wander)
+import Data.Lens (lens, prism', PrismP, LensP, TraversalP, wander)
 import Data.Path.Pathy ((</>))
 import Data.Path.Pathy as P
 import Data.String as S
@@ -285,6 +287,17 @@ _filePath = wander \f s → case s of
   File fp → File <$> f fp
   Mount (View fp) → map (Mount ∘ View) $ f fp
   _ → pure s
+
+_dirPath ∷ TraversalP Resource PU.DirPath
+_dirPath = wander \f s → case s of
+  Directory dp → Directory <$> f dp
+  Mount (Database dp) → map (Mount ∘ Database) $ f dp
+  _ → pure s
+
+_Workspace ∷ PrismP Resource PU.DirPath
+_Workspace = prism' Workspace case _ of
+  Workspace dp → Just dp
+  _ → Nothing
 
 _path ∷ LensP Resource PU.AnyPath
 _path = lens getPath setPath

--- a/src/SlamData/Workspace/Card/OpenResource/Component.purs
+++ b/src/SlamData/Workspace/Card/OpenResource/Component.purs
@@ -191,8 +191,9 @@ resourceSelected r = do
           updateItems
       H.modify (_selected ?~ fp)
     Left dp → do
-      H.modify (  (_browsing .~ dp)
-                ∘ (_selected .~ Nothing))
+      H.modify
+        $ (_browsing .~ dp)
+        ∘ (_selected .~ Nothing)
       updateItems
   rearrangeItems
 

--- a/src/SlamData/Workspace/Deck/Component.purs
+++ b/src/SlamData/Workspace/Deck/Component.purs
@@ -222,9 +222,9 @@ eval (SetModel deckId model next) = do
   setModel state.path (Just deckId) model
   pure next
 eval (ExploreFile res next) = do
-  setDeckState DCS.initialDeck
   H.modify
-    $ (DCS._path .~ Pathy.parentDir res)
+    $ (DCS._activeCardIndex .~ one)
+    ∘ (DCS.addCard CT.JTable)
     ∘ (DCS.addCard CT.OpenResource)
   H.query' cpCard (CardSlot zero)
     $ right

--- a/test/src/Test/SlamData/Feature/Interactions.purs
+++ b/test/src/Test/SlamData/Feature/Interactions.purs
@@ -37,7 +37,12 @@ mountTestDatabase = do
   Feature.click (XPath.anywhere XPaths.mountButton)
 
 accessFile ∷ String → SlamFeature Unit
-accessFile = Feature.click ∘ XPath.anywhere ∘ XPaths.accessFile
+accessFile =
+  Feature.click ∘ XPath.anywhere ∘ XPaths.accessFile
+
+exploreFile ∷ SlamFeature Unit
+exploreFile =
+  Feature.click $ XPath.anywhere $ XPath.anyWithExactAriaLabel "Explore file"
 
 accessBreadcrumb ∷ String → SlamFeature Unit
 accessBreadcrumb = Feature.click ∘ XPath.anywhere ∘ XPaths.accessBreadcrumb

--- a/test/src/Test/SlamData/Feature/Test/File.purs
+++ b/test/src/Test/SlamData/Feature/Test/File.purs
@@ -99,7 +99,6 @@ test = do
   fileScenario afterUpload "Upload a file" [] do
     Interact.browseTestFolder
     Interact.uploadFile "test/array-wrapped.json"
-    Expect.resourceOpenedInLastExploreCard "/test-mount/testDb/array-wrapped.json"
     Interact.browseRootFolder
     Interact.browseTestFolder
     Expect.file "array-wrapped.json"
@@ -116,7 +115,7 @@ test = do
     Interact.browseTestFolder
     Interact.shareFile "smallZips"
     Interact.accessSharingUrl
-    Expect.resourceOpenedInLastExploreCard "/test-mount/testDb/smallZips"
+    Expect.tableColumnsAre ["city", "loc", "pop", "state"]
     successMsg "Successfully accessed sharing URL for a file"
     Interact.launchSlamData
 

--- a/test/src/Test/SlamData/Feature/Test/SaveCard.purs
+++ b/test/src/Test/SlamData/Feature/Test/SaveCard.purs
@@ -35,7 +35,6 @@ test =
     Expect.tableColumnsAre ["measureOne", "measureTwo"]
     Interact.browseTestFolder
     Interact.accessFile "временный файл"
-    Interact.accessNextCardInLastDeck
-    Interact.insertJTableCardInLastDeck
+    Interact.exploreFile
     Expect.tableColumnsAre ["measureOne", "measureTwo"]
     successMsg "Successfully saved data source card output to file"


### PR DESCRIPTION
Fixes https://slamdata.atlassian.net/browse/SD-1669
and https://slamdata.atlassian.net/browse/SD-1668 

+ Removed explore route and introduced routing action. I think that made concept of exploring a bit cleaner. There is no special thing "exploring file" there is a resume workspace (and it's going to disappear soon) 
+ Files aren't opened after upload, added same flow for uploading as in deletion. 
+ Removed couple `Nested` 
+ Notebook in exploring resume has two cards now. 
+ Sharing files uses `Untitled Workspace.slam` for notebook name. I think we should remove this if we remove exploring completely. But not sure. 

To make it a solution for SD-1668 we can just remove one dialog and use actual handler from `explorePeek` with `Config.newWorkspaceName` instead of provided by dialog. 

This touches a bit `Deck.Component` but only three lines. I hope that's not so bad for @jonsterling's pr

Any suggestion of better headers for the dialog are really appreciated :smile: 

@natefaubion Could you take a look? 