### PR TITLE
download and download-options resize

### DIFF
--- a/less/deck.less
+++ b/less/deck.less
@@ -235,3 +235,5 @@
 @import "deck/dialog";
 @import "deck/viz-card";
 @import "deck/chart-card";
+@import "deck/download-options-card";
+@import "deck/download-card";

--- a/less/deck/download-card.less
+++ b/less/deck/download-card.less
@@ -1,25 +1,8 @@
 .sd-card-download {
-
-  .download-type-selector {
-
-    position: absolute;
-    left: 0;
-    width: 60px;
-    height: 160px;
-    background-color: #f0f0f0;
-
-    img {
-        width: 32px;
-        height: 32px;
-        padding: 4px;
-        background-color: #aaa;
-        cursor: pointer;
-        margin-left: 16px;
-        margin-top: 8px;
-        left: 50%;
-        &.active, &:hover {
-            background-color: #337ab7;
-        }
+    position: relative;
+    text-align: center;
+    .download-button {
+        margin-top: 18px;
+        border-radius: 0;
     }
-  }
 }

--- a/less/deck/download-options-card.less
+++ b/less/deck/download-options-card.less
@@ -1,0 +1,80 @@
+.sd-card-download-options {
+    height: ~"calc(100% - 4rem)";
+    > div { height: 100%; }
+    div.load-message.alert {
+        height: 100%;
+        margin-top: 0;
+        margin-bottom: 0;
+    }
+    .card-input {
+        &-maximum-lod.download-card-editor {
+            padding:0;
+            height: 100%;
+            position: relative;
+            div.download-type-selector {
+                width: 60px;
+                height: 100%;
+                background-color: #f0f0f0;
+                position: absolute;
+                left: 0;
+                img {
+                    width: 32px;
+                    height: 32px;
+                    padding: 6px;
+                    background-color: #aaa;
+                    cursor: pointer;
+                    margin-left: 16px;
+                    margin-top: 8px;
+                    left: 50%;
+                    &.active, &:hover {
+                                  background-color: #337ab7;
+                              }
+                }
+            }
+            .download-configuration {
+                width: ~"calc(100% - 60px - 12px)";
+                position: absolute;
+                left: 60px;
+                padding-left: 6px;
+                padding-right: 6px;
+                padding-top: 12px;
+                .download-json-options {
+                    width: 100%;
+                    margin-top: 0;
+                    padding-top: 0;
+                    > div {
+                        padding-bottom: 12px;
+                        padding-top: 12px;
+                        border-bottom: 1px solid #ccc;
+                    }
+                }
+                .download-csv-delimiters {
+                    border-bottom: 1px solid #ccc;
+                    padding-top: 12px;
+                    padding-bottom: 12px;
+                    margin-top: 0;
+                    margin-bottom: 0;
+                }
+            }
+        }
+
+        &-minimum-lod {
+            height: 100%;
+            button {
+                height: 100px;
+                width: 150px;
+                background: white;
+                border: 1px black solid;
+                color: black;
+                position: relative;
+                left: 50%;
+                margin-left: -75px;
+                margin-top: 10px;
+                i.glyphicon {
+                    display: block;
+                    font-size: 26pt;
+                }
+            }
+        }
+    }
+}

--- a/less/download-card.less
+++ b/less/download-card.less
@@ -1,9 +1,0 @@
-a.btn.btn-primary.download-button {
-    width: 160px;
-    position: relative;
-    left: 50%;
-    margin-left: -80px;
-    margin-top: 24px;
-    margin-bottom: 24px;
-    font-size: 26px;
-}

--- a/less/main.less
+++ b/less/main.less
@@ -628,8 +628,10 @@ div.loading-message.alert.alert-info {
     font-size: 28px;
 }
 
-.download-type-selector {
-    width: 60px;
+.modal {
+
+    .download-type-selector {
+        width: 60px;
         height: 160px;
         background-color: #f0f0f0;
         img {
@@ -645,13 +647,13 @@ div.loading-message.alert.alert-info {
                 background-color: #337ab7;
             }
         }
-}
+    }
 
-.download-configuration {
+    .download-configuration {
         margin-left: 60px;
         padding-top: 10px;
     }
-
+}
 div.viz-card-editor {
     min-height: 160px;
     padding-left: 15px;
@@ -673,13 +675,6 @@ div.viz-card-editor {
                 background-color: #337ab7;
             }
         }
-    }
-    .download-type-selector img {
-        padding: 4px;
-    }
-    .download-configuration {
-        margin-left: 60px;
-        padding-top: 10px;
     }
 }
 

--- a/src/SlamData/Workspace/Card/Download/Component/State.purs
+++ b/src/SlamData/Workspace/Card/Download/Component/State.purs
@@ -14,12 +14,39 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -}
 
-module SlamData.Workspace.Card.Download.Component.State where
+module SlamData.Workspace.Card.Download.Component.State
+  ( State
+  , initialState
+  , _url
+  , _levelOfDetails
+  , _fileName
+  ) where
 
 import SlamData.Prelude
 
+import Data.Lens (LensP, lens)
 
-type State = String
+import SlamData.Workspace.LevelOfDetails (LevelOfDetails(..))
 
-initialState :: State
-initialState = ""
+type State =
+  { url ∷ String
+  , levelOfDetails ∷ LevelOfDetails
+  , fileName ∷ String
+  }
+
+
+_url ∷ ∀ a r. LensP {url ∷ a | r} a
+_url = lens (_.url) (_{url = _})
+
+_levelOfDetails ∷ ∀ a r. LensP {levelOfDetails ∷ a|r} a
+_levelOfDetails = lens (_.levelOfDetails) (_{levelOfDetails = _})
+
+_fileName ∷ ∀ a r. LensP {fileName ∷ a |r} a
+_fileName = lens (_.fileName) (_{fileName = _})
+
+initialState ∷ State
+initialState =
+  { url: ""
+  , fileName: ""
+  , levelOfDetails: High
+  }

--- a/src/SlamData/Workspace/Card/DownloadOptions/Component.purs
+++ b/src/SlamData/Workspace/Card/DownloadOptions/Component.purs
@@ -25,20 +25,22 @@ import Halogen as H
 import Halogen.HTML.Events.Indexed as HE
 import Halogen.HTML.Indexed as HH
 import Halogen.HTML.Properties.Indexed as HP
+import Halogen.HTML.Properties.Indexed.ARIA as ARIA
 import Halogen.Themes.Bootstrap3 as B
 
 import SlamData.Workspace.Card.Common.EvalQuery as Ec
 import SlamData.Workspace.Card.Component as Cc
 import SlamData.Workspace.Card.Component (makeCardComponent, makeQueryPrism, _DownloadOptionsState, _DownloadOptionsQuery)
 import SlamData.Workspace.Card.DownloadOptions.Component.Query (QueryP, Query(..))
-import SlamData.Workspace.Card.DownloadOptions.Component.State (State, _compress, _options, _source, initialState, encode, decode)
+import SlamData.Workspace.Card.DownloadOptions.Component.State (State, _compress, _options, _source, initialState, encode, decode, _levelOfDetails)
 import SlamData.Render.CSS as Rc
 import SlamData.Effects (Slam)
 import SlamData.Download.Model as D
 import SlamData.Download.Render as Rd
 import SlamData.Workspace.Card.CardType (CardType(DownloadOptions))
 import SlamData.Workspace.Card.Port as P
-import SlamData.Render.Common (row)
+import SlamData.Workspace.LevelOfDetails (LevelOfDetails(..))
+import SlamData.Render.Common (glyph)
 
 type HTML = H.ComponentHTML QueryP
 type DSL = H.ComponentDSL State QueryP Slam
@@ -54,27 +56,63 @@ comp = makeCardComponent
 
 render ∷ State → HTML
 render state =
+  HH.div_
+    [ renderHighLOD state
+    , renderLowLOD state
+    ]
+
+renderHighLOD ∷ State → HTML
+renderHighLOD state =
   case state.source of
     Nothing →
       HH.div
-        [ HP.classes [ B.alert, B.alertDanger ] ]
+        [ HP.classes
+            $ [ B.alert, B.alertDanger ]
+            ⊕ hideClasses
+        ]
         [ HH.text "The current input cannot be downloaded" ]
     Just _ →
       HH.div
-        [ HP.classes [ Rc.downloadCardEditor ] ]
+        [ HP.classes
+            $ [ Rc.downloadCardEditor
+              , HH.className "card-input-maximum-lod"
+              ]
+            ⊕ hideClasses
+        ]
         [ renderDownloadTypeSelector state
         , renderDownloadConfiguration state
         ]
+  where
+  hideClasses = guard (state.levelOfDetails ≠ High) $> B.hidden
+
+renderLowLOD ∷ State → HTML
+renderLowLOD state =
+  HH.div
+    [ HP.classes
+        $ [ HH.className "card-input-minimum-lod" ]
+        ⊕ hideClasses
+    ]
+    [ HH.button
+      [ ARIA.label "Expand to see download options"
+      , HP.title "Expand to see download options"
+      , HP.disabled true
+      ]
+      [ glyph B.glyphiconDownloadAlt
+      , HH.text "Please, expand to see options"
+      ]
+    ]
+
+  where
+  hideClasses = guard (state.levelOfDetails ≠ Low) $> B.hidden
+
 
 renderDownloadConfiguration ∷ State → HTML
 renderDownloadConfiguration state =
   HH.div
     [ HP.classes [ Rc.downloadConfiguration ] ]
     $ [ either optionsCSV optionsJSON state.options ]
-    ⊕ [ row
-          [ HH.div [ HP.classes [ B.colXs4 ] ] [ compress state ]
-          ]
-      ]
+    ⊕ [ compress state ]
+
 
 optionsCSV ∷ D.CSVOptions → HTML
 optionsCSV = Rd.optionsCSV (\lens v → right ∘ (ModifyCSVOpts (lens .~ v)))
@@ -130,7 +168,13 @@ cardEval (Ec.NotifyStopCard next) = pure next
 cardEval (Ec.Save k) = map (k ∘ encode) H.get
 cardEval (Ec.Load json next) = for_ (decode json) H.set $> next
 cardEval (Ec.SetCanceler _ next) = pure next
-cardEval (Ec.SetDimensions _ next) = pure next
+cardEval (Ec.SetDimensions dims next) = do
+  H.modify
+    $ _levelOfDetails
+    .~ if dims.width < 648.0 ∨ dims.height < 240.0
+         then Low
+         else High
+  pure next
 
 downloadOptsEval ∷ Query ~> DSL
 downloadOptsEval (SetOutput ty next) = do

--- a/src/SlamData/Workspace/Card/DownloadOptions/Component/State.purs
+++ b/src/SlamData/Workspace/Card/DownloadOptions/Component/State.purs
@@ -22,6 +22,8 @@ import Data.Argonaut (Json, (:=), (~>), (.?), decodeJson, jsonEmptyObject)
 import Data.Lens (LensP, lens)
 import Data.Path.Pathy as Pathy
 import SlamData.Download.Model as D
+import SlamData.Workspace.LevelOfDetails (LevelOfDetails(..))
+
 
 import Utils.Path as PU
 
@@ -29,6 +31,7 @@ type State =
   { compress ∷ Boolean
   , options ∷ Either D.CSVOptions D.JSONOptions
   , source ∷ Maybe PU.FilePath
+  , levelOfDetails ∷ LevelOfDetails
   }
 
 initialState ∷ State
@@ -36,6 +39,7 @@ initialState =
   { compress: false
   , options: Left D.initialCSVOptions
   , source: Nothing
+  , levelOfDetails: High
   }
 
 _compress ∷ ∀ a r. LensP {compress ∷ a|r} a
@@ -47,6 +51,8 @@ _options = lens (_.options) (_{options = _})
 _source ∷ ∀ a r. LensP {source ∷ a|r} a
 _source = lens (_.source) (_{source = _})
 
+_levelOfDetails ∷ ∀ a r. LensP {levelOfDetails ∷ a|r} a
+_levelOfDetails = lens (_.levelOfDetails) (_{levelOfDetails = _})
 
 encode :: State -> Json
 encode s
@@ -60,7 +66,8 @@ decode = decodeJson >=> \obj → do
   compress ← obj .? "compress"
   options ← obj .? "options"
   source ← traverse parsePath =<< obj .? "source"
-  pure { compress, options, source }
+  let levelOfDetails = High
+  pure { compress, options, source, levelOfDetails }
 
 parsePath ∷ String → Either String PU.FilePath
 parsePath =

--- a/test/src/Test/SlamData/Property/Workspace/Card/DownloadOptions/Component/State.purs
+++ b/test/src/Test/SlamData/Property/Workspace/Card/DownloadOptions/Component/State.purs
@@ -9,6 +9,7 @@ import Prelude
 import Data.Bifunctor (bimap)
 import Data.Either (Either(..))
 import SlamData.Workspace.Card.DownloadOptions.Component.State as M
+import SlamData.Workspace.LevelOfDetails as LOD
 
 import Test.Property.Utils.Path (runArbFilePath)
 import Test.SlamData.Property.Download.Model (runArbCSVOptions, runArbJSONOptions)
@@ -21,7 +22,7 @@ runArbState (ArbState s) = s
 
 instance arbitraryArbState :: Arbitrary ArbState where
   arbitrary = do
-    r <- { compress: _, options: _, source: _ }
+    r <- { compress: _, options: _, source: _, levelOfDetails: LOD.High}
          <$> arbitrary
          <*> (map (bimap runArbCSVOptions runArbJSONOptions) arbitrary)
          <*> (map (map runArbFilePath) arbitrary)


### PR DESCRIPTION
https://slamdata.atlassian.net/browse/SD-1457
https://slamdata.atlassian.net/browse/SD-1455

![cities](https://cloud.githubusercontent.com/assets/10245930/15912676/f7e274e0-2d92-11e6-9c0c-5c48de3237ad.png)
![cities-cities](https://cloud.githubusercontent.com/assets/10245930/15912674/f7df1372-2d92-11e6-9b8b-5fda26362509.png)
![dopt-json](https://cloud.githubusercontent.com/assets/10245930/15912673/f7de7458-2d92-11e6-876e-af14d017a113.png)
![dopts](https://cloud.githubusercontent.com/assets/10245930/15912675/f7e171f8-2d92-11e6-9da3-3503d631260d.png)
![dopts-csv](https://cloud.githubusercontent.com/assets/10245930/15912672/f7dda87a-2d92-11e6-8da9-ea1a29c334ab.png)

+ Download card calculate width of its text and add all paddings to determine if it should use low details version. 
+ Download options card uses constant parameters. 

@jonsterling Please, review