### PR TITLE
Clean up some old eval stuff

### DIFF
--- a/src/SlamData/Render/CSS.purs
+++ b/src/SlamData/Render/CSS.purs
@@ -202,9 +202,6 @@ statusText = className "status-text"
 cardFailures ∷ ClassName
 cardFailures = className "card-failures"
 
-cardMessages ∷ ClassName
-cardMessages = className "card-messages"
-
 cardBlockedMessage ∷ ClassName
 cardBlockedMessage = className "card-blocked-message"
 

--- a/src/SlamData/Workspace/Card/Common/EvalQuery.purs
+++ b/src/SlamData/Workspace/Card/Common/EvalQuery.purs
@@ -33,20 +33,20 @@ import Halogen (ParentDSL, ComponentDSL)
 import Halogen.Component.Utils as Hu
 
 import SlamData.Effects (Slam, SlamDataEffects)
-import SlamData.Workspace.Card.Eval.CardEvalT (CardEvalInput, CardEvalResult, CardEvalT, runCardEvalT, temporaryOutputResource)
+import SlamData.Workspace.Card.Eval.CardEvalT (CardEvalInput, CardEvalT, runCardEvalT, temporaryOutputResource)
 import SlamData.Workspace.Card.Port as Port
 
 -- | The query algebra shared by the inner parts of a card component.
 -- |
--- | - `EvalCard` is a command sent from the deck that runs the card. An
--- |   optional input value (the output from another card) is provided, and a
--- |   continuation for the evaluation result to be returned to.
--- |         TODO: update these notes -js
--- |
+-- | - `EvalCard` is a command sent from the deck when a card component needs
+-- |   updating during the evaluation process. An input value from the previous
+-- |   card in the deck is provided, along with the output from the card's model
+-- |   evaluator. The card cannot return a new port value, it's eval is only
+-- |   allowed to update the card component state.
 -- | - `NotifyRunCard` allows the card to notify the deck that it should be
 -- |   run - the card cannot run itself directly.
 data CardEvalQuery a
-  = EvalCard CardEvalInput (Maybe Port.Port) a -- (CardEvalResult → a)
+  = EvalCard CardEvalInput (Maybe Port.Port) a
   | NotifyRunCard a
   | NotifyStopCard a
   | SetCanceler (Canceler SlamDataEffects) a

--- a/src/SlamData/Workspace/Card/Component/Query.purs
+++ b/src/SlamData/Workspace/Card/Component/Query.purs
@@ -81,14 +81,11 @@ import SlamData.Workspace.Card.Viz.Component.Query as Viz
 -- |   its state, and then returns its own output value.
 -- | - `RefreshCard` is captured by the deck and goes to the root of the
 -- |   current card's dependencies and updates the cards downwards from there.
--- | - `ToggleMessages` is used to toggle the visibility of the status/error
--- |   messages generated while evaluating the card.
 data CardQuery a
   = RunCard a
   | StopCard a
   | UpdateCard CardEvalInput (Maybe Port) a
   | RefreshCard a
-  | ToggleMessages a
   | Tick Milliseconds a
   | GetOutput (Maybe Port → a)
   | SaveCard CardId CardType (Card.Model → a)

--- a/src/SlamData/Workspace/Card/Component/Render.purs
+++ b/src/SlamData/Workspace/Card/Component/Render.purs
@@ -22,10 +22,8 @@ module SlamData.Workspace.Card.Component.Render
 
 import SlamData.Prelude
 
-import Data.Array as A
 import Data.Int (fromNumber)
 import Data.Time (Seconds(..), Milliseconds(..), toSeconds)
-import Data.Visibility (Visibility(..))
 
 import Halogen (ParentHTML)
 import Halogen.HTML.Events.Indexed as E
@@ -63,10 +61,10 @@ header cty cs =
       ]
 
 cardBlocked ∷ CardState → Boolean
-cardBlocked cs = false -- TODO: this may be redundant?
+cardBlocked cs = false -- TODO: this should be redundant -gb
 
 hasMessages ∷ CardState → Boolean
-hasMessages cs = not $ A.null cs.messages
+hasMessages cs = false -- TODO: this _is_ redundant -gb
 
 statusBar ∷ Boolean → CardState → CardHTML
 statusBar hasResults cs =
@@ -87,11 +85,7 @@ statusBar hasResults cs =
           [ H.text $ if cardBlocked cs
                        then ""
                        else runStatusMessage cs.runState ]
-      , H.div
-          [ P.classes [B.pullRight, CSS.cardControls] ]
-          $ A.catMaybes [ toggleMessageButton cs ]
       ]
-    ⊕ statusMessages cs
   where
 
   button =
@@ -123,38 +117,3 @@ refreshButton =
     , E.onClick (E.input_ RefreshCard)
     ]
     [ glyph B.glyphiconRefresh ]
-
-toggleMessageButton ∷ CardState → Maybe CardHTML
-toggleMessageButton cs@{ messages, messageVisibility } =
-  if not (hasMessages cs)
-  then Nothing
-  else Just $
-    H.button
-      [ P.title label
-      , ARIA.label label
-      , E.onClick (E.input_ ToggleMessages)
-      ]
-      [ glyph if isCollapsed then B.glyphiconEyeOpen else B.glyphiconEyeClose ]
-  where
-  label = if isCollapsed then "Show messages" else "Hide messages"
-  isCollapsed = messageVisibility ≡ Invisible
-
-statusMessages ∷ CardState → Array (CardHTML)
-statusMessages cs@{ messages, messageVisibility }
-  | cardBlocked cs =
-      [ H.div
-        [ P.classes [ CSS.cardBlockedMessage ] ]
-        [ H.div_ [ H.text "There are errors in parent cards" ] ]
-      ]
-  | otherwise =
-      if not (hasMessages cs)
-      then []
-      else
-        [ H.div [ P.classes classes ] $ if isCollapsed then [] else map message messages
-        ]
-  where
-  isCollapsed = messageVisibility ≡ Invisible
-  classes = [CSS.cardMessages] ⊕ if isCollapsed then [CSS.collapsed] else []
-
-message ∷ String → CardHTML
-message = H.pre_ ∘ pure ∘ H.text

--- a/src/SlamData/Workspace/Card/Component/State.purs
+++ b/src/SlamData/Workspace/Card/Component/State.purs
@@ -22,9 +22,6 @@ module SlamData.Workspace.Card.Component.State
   , _visibility
   , _runState
   , _tickStopper
-  , _messages
-  , _messageVisibility
-  , _hasRun
   , _output
   , _canceler
   , _element
@@ -86,19 +83,11 @@ import SlamData.Workspace.Card.Viz.Component.State as Viz
 -- |   all - used when embedding a single card in another page.
 -- | - `runState` tracks whether the card has run yet, is running, or has
 -- |   completed running.
--- | - `messages` is the informational messages generated
--- |   during evaluation.
--- | - `messageVisibility` determines whether the messages should be shown or
--- |   not.
--- | - `hasRun` tracks whether the card has been run.
 type CardState =
   { accessType ∷ AccessType
   , visibility ∷ Visibility
   , runState ∷ RunState
   , tickStopper ∷ Slam Unit
-  , messages ∷ Array String
-  , messageVisibility ∷ Visibility
-  , hasRun ∷ Boolean
   , output ∷ Maybe Port
   , canceler ∷ Canceler SlamDataEffects
   , element ∷ Maybe HTMLElement
@@ -113,9 +102,6 @@ initialCardState =
   , visibility: Visible
   , runState: RunInitial
   , tickStopper: pure unit
-  , messages: []
-  , messageVisibility: Invisible
-  , hasRun: false
   , output: Nothing
   , canceler: mempty
   , element: Nothing
@@ -132,15 +118,6 @@ _runState = lens _.runState (_ { runState = _ })
 
 _tickStopper ∷ LensP CardState (Slam Unit)
 _tickStopper = lens _.tickStopper (_ { tickStopper = _ })
-
-_messages ∷ LensP CardState (Array String)
-_messages = lens _.messages (_ { messages = _ })
-
-_messageVisibility ∷ LensP CardState Visibility
-_messageVisibility = lens _.messageVisibility (_ { messageVisibility = _ })
-
-_hasRun ∷ LensP CardState Boolean
-_hasRun = lens _.hasRun (_ { hasRun = _ })
 
 -- | The last output value computed for the card. This may not be up to date
 -- | with the exact state of the card, but is the most recent result from when

--- a/src/SlamData/Workspace/Card/Markdown/Eval.purs
+++ b/src/SlamData/Workspace/Card/Markdown/Eval.purs
@@ -23,7 +23,6 @@ import Control.Monad.Eff.Class as Eff
 import Control.Monad.Eff.Exception as Exn
 import Control.Monad.Error.Class as Err
 import Control.Monad.State.Trans as State
-import Control.Monad.Writer.Class as WC
 
 import Data.Array as A
 import Data.Date as D
@@ -63,7 +62,6 @@ markdownEval
 markdownEval { cardId, path } str = do
   result ← lift ∘ AffF.fromAff ∘ Aff.attempt ∘ evalEmbeddedQueries path cardId $ SDP.parseMd str
   doc ← either (Err.throwError ∘ Exn.message) pure result
-  WC.tell [ "Exported fields: " ⊕ S.joinWith ", " (findFields doc) ]
   pure $ Port.SlamDown doc
 
 findFields

--- a/src/SlamData/Workspace/Card/Model.purs
+++ b/src/SlamData/Workspace/Card/Model.purs
@@ -37,15 +37,12 @@ import SlamData.Workspace.Card.Viz.Model as Viz
 import SlamData.Workspace.Card.DownloadOptions.Component.State as DO
 
 -- | `cardType` and `cardId` characterize what is this card and where is it
--- | `hasRun` is flag for routing process, if it's `hasRun` we probably should
--- | rerun it after loading
 -- | `state` is card state, it's already encoded to `Json` to keep `Card` type a bit
 -- | simpler. I.e. it can hold markdown texts or viz options
 type Model =
   { cardId :: CID.CardId
   , cardType :: CT.CardType
   , inner :: J.Json
-  , hasRun :: Boolean
   }
 
 encode :: Model -> J.Json
@@ -53,16 +50,14 @@ encode card
    = "cardId" := card.cardId
   ~> "cardType" := card.cardType
   ~> "inner" := card.inner
-  ~> "hasRun" := card.hasRun
   ~> J.jsonEmptyObject
 
 decode :: J.Json -> Either String Model
 decode =
   J.decodeJson >=> \obj ->
-    { cardId: _, cardType: _, hasRun: _, inner: _ }
+    { cardId: _, cardType: _, inner: _ }
       <$> obj .? "cardId"
       <*> obj .? "cardType"
-      <*> obj .? "hasRun"
       <*> obj .? "inner"
 
 -- TODO: this implementation is terrible and fragile. I just happen to know that

--- a/src/SlamData/Workspace/Deck/Common.purs
+++ b/src/SlamData/Workspace/Deck/Common.purs
@@ -50,6 +50,5 @@ wrappedDeck rect deckId = emptyDeck
     { cardId: CardId 0
     , cardType: CT.Draftboard
     , inner: DBS.encode $ DBS.initialState { decks = Map.singleton deckId rect }
-    , hasRun: false
     }
   }

--- a/src/SlamData/Workspace/Deck/Component/State.purs
+++ b/src/SlamData/Workspace/Deck/Component/State.purs
@@ -264,7 +264,7 @@ addCard' cardType inner st =
     newState = st
       { fresh = st.fresh + one
       , modelCards =
-          let def = { cardId, cardType, inner, hasRun: false }
+          let def = { cardId, cardType, inner }
           in case A.uncons $ A.reverse st.modelCards of
             Nothing → st.modelCards `A.snoc` def
             Just {head, tail} →

--- a/test/src/Test/SlamData/Feature/XPaths.purs
+++ b/test/src/Test/SlamData/Feature/XPaths.purs
@@ -207,10 +207,6 @@ oneErrorMessage ∷ String
 oneErrorMessage =
   XPath.anyWithText "1 error during evaluation."
 
-showMessages ∷ String
-showMessages =
-  XPath.anyWithExactAriaLabel "Show messages"
-
 noFileSelectedMessage ∷ String
 noFileSelectedMessage =
   XPath.anyWithExactText "No file selected"

--- a/test/src/Test/SlamData/Property/Workspace/Card/Model.purs
+++ b/test/src/Test/SlamData/Property/Workspace/Card/Model.purs
@@ -44,8 +44,7 @@ instance arbitraryArbCard :: Arbitrary ArbCard where
     cardId <- runArbCardId <$> arbitrary
     cardType <- runArbCardType <$> arbitrary
     inner <- runArbJson <$> arbitrary
-    hasRun <- arbitrary
-    pure $ ArbCard { cardId, cardType, inner, hasRun }
+    pure $ ArbCard { cardId, cardType, inner }
 
 check :: QC Unit
 check = quickCheck $ runArbCard >>> \model ->
@@ -59,5 +58,4 @@ checkCardEquality model model' =
    [ model.cardId == model'.cardId <?> "cardId mismatch"
    , model.cardType == model'.cardType <?> "cardType mismatch"
    , model.inner == model'.inner <?> "inner mismatch"
-   , model.hasRun == model'.hasRun <?> "hasRun mismatch"
    ]


### PR DESCRIPTION
This removes:
- `messages`
- `hasRun`

and some associated code. I also update the `EvalCard` comment.

Hope this doesn't tread on your toes @jonsterling!

A lot of the message `tell`s are still present as comments, as a reminder that we need to do something with them still: they new cards mostly I think though, for reviewing execution plans / generated SQL.