### PR TITLE
Remove status bar / card running tracking

### DIFF
--- a/less/deck.less
+++ b/less/deck.less
@@ -190,7 +190,7 @@
 }
 
 .sd-card-ace {
-  height: ~"calc(100% - 4rem)";
+  height: ~"calc(100% - 2rem)";
 }
 
 *[aria-grabbed="true"] {

--- a/less/deck/api-card.less
+++ b/less/deck/api-card.less
@@ -1,5 +1,5 @@
 .sd-card-api {
-  min-height: ~"calc(100% - 4rem)";
+  min-height: ~"calc(100% - 2rem)";
   padding: 0.5rem;
 
   table {

--- a/less/deck/download-options-card.less
+++ b/less/deck/download-options-card.less
@@ -1,5 +1,5 @@
 .sd-card-download-options {
-    height: ~"calc(100% - 4rem)";
+    height: ~"calc(100% - 2rem)";
     > div { height: 100%; }
     div.load-message.alert {
         height: 100%;

--- a/less/deck/open-resource-card.less
+++ b/less/deck/open-resource-card.less
@@ -1,6 +1,6 @@
 .sd-card-open-resource {
 
-  height: ~"calc(100% - 4rem)";
+  height: ~"calc(100% - 2rem)";
 
   > div { height: 100% }
 

--- a/less/deck/search-card.less
+++ b/less/deck/search-card.less
@@ -1,5 +1,5 @@
 .sd-card-search {
-  height: ~"calc(100% - 4rem)";
+  height: ~"calc(100% - 2rem)";
 
   img {
     width: 16px;

--- a/less/deck/table-card.less
+++ b/less/deck/table-card.less
@@ -1,5 +1,5 @@
 .sd-card-table {
-  height: ~"calc(100% - 4rem)";
+  height: ~"calc(100% - 2rem)";
   overflow: auto;
 
   table {

--- a/less/deck/viz-card.less
+++ b/less/deck/viz-card.less
@@ -1,5 +1,5 @@
 .sd-card-viz {
-    height: ~"calc(100% - 4rem)";
+    height: ~"calc(100% - 2rem)";
     > div { height: 100%; }
     div.loading-message.alert.alert-info {
         height: 100%;

--- a/src/SlamData/Workspace/Card/Component/Query.purs
+++ b/src/SlamData/Workspace/Card/Component/Query.purs
@@ -43,7 +43,6 @@ import SlamData.Prelude
 
 import Data.Lens (PrismP, prism')
 import Data.Lens.Prism.Coproduct (_Left, _Right)
-import Data.Time (Milliseconds)
 
 import DOM.HTML.Types (HTMLElement)
 
@@ -74,26 +73,19 @@ import SlamData.Workspace.Card.Viz.Component.Query as Viz
 
 -- | The common query algebra for a card.
 -- |
--- | - `RunCard` is captured by the deck and used to call `UpdateCard` on
--- |   the card that raised it, passing in an input value if one is required.
 -- | - `UpdateCard` accepts an input value from a parent card if one is
 -- |   required, performs any necessary actions to evalute the card and update
 -- |   its state, and then returns its own output value.
 -- | - `RefreshCard` is captured by the deck and goes to the root of the
 -- |   current card's dependencies and updates the cards downwards from there.
 data CardQuery a
-  = RunCard a
-  | StopCard a
-  | UpdateCard CardEvalInput (Maybe Port) a
-  | RefreshCard a
-  | Tick Milliseconds a
+  = UpdateCard CardEvalInput (Maybe Port) a
   | GetOutput (Maybe Port → a)
   | SaveCard CardId CardType (Card.Model → a)
   | LoadCard Card.Model a
   | SetCardAccessType Na.AccessType a
   | UpdateDimensions a
   | SetHTMLElement (Maybe HTMLElement) a
-
 
 type CardQueryP = Coproduct CardQuery (ChildF Unit InnerCardQuery)
 

--- a/src/SlamData/Workspace/Card/Component/Render.purs
+++ b/src/SlamData/Workspace/Card/Component/Render.purs
@@ -17,26 +17,18 @@ limitations under the License.
 module SlamData.Workspace.Card.Component.Render
   ( CardHTML
   , header
-  , statusBar
   ) where
 
 import SlamData.Prelude
 
-import Data.Int (fromNumber)
-import Data.Time (Seconds(..), Milliseconds(..), toSeconds)
-
 import Halogen (ParentHTML)
-import Halogen.HTML.Events.Indexed as E
 import Halogen.HTML.Indexed as H
 import Halogen.HTML.Properties.Indexed as P
 import Halogen.HTML.Properties.Indexed.ARIA as ARIA
-import Halogen.Themes.Bootstrap3 as B
 
-import SlamData.Workspace.Card.Component.Query (CardQuery(..), InnerCardQuery)
+import SlamData.Workspace.Card.Component.Query (CardQuery, InnerCardQuery)
 import SlamData.Workspace.Card.Component.State (CardState, AnyCardState)
-import SlamData.Workspace.Card.RunState (RunState(..), isRunning)
 import SlamData.Effects (Slam)
-import SlamData.Render.Common (glyph)
 import SlamData.Render.CSS as CSS
 import SlamData.Workspace.Card.CardType (CardType, cardName, cardGlyph, controllable)
 
@@ -59,61 +51,3 @@ header cty cs =
           [ P.class_ CSS.cardName ]
           [ H.text $ cardName cty ]
       ]
-
-cardBlocked ∷ CardState → Boolean
-cardBlocked cs = false -- TODO: this should be redundant -gb
-
-hasMessages ∷ CardState → Boolean
-hasMessages cs = false -- TODO: this _is_ redundant -gb
-
-statusBar ∷ Boolean → CardState → CardHTML
-statusBar hasResults cs =
-  H.div
-    [ P.classes [CSS.cardEvalLine] ]
-    $ [ H.button
-          [ P.classes [B.btn, B.btnPrimary, button.className]
-          , E.onClick (E.input_ $ if isRunning cs.runState
-                                  then StopCard
-                                  else RunCard)
-          , P.title button.label
-          , P.disabled $ cardBlocked cs
-          , ARIA.label button.label
-          ]
-          [ glyph button.glyph ]
-      , H.div
-          [ P.class_ CSS.statusText ]
-          [ H.text $ if cardBlocked cs
-                       then ""
-                       else runStatusMessage cs.runState ]
-      ]
-  where
-
-  button =
-    if isRunning cs.runState
-    then { className: CSS.stopButton, glyph: B.glyphiconStop, label: "Stop" }
-    else { className: CSS.playButton, glyph: B.glyphiconRefresh, label: "Refresh" }
-
-runStatusMessage ∷ RunState → String
-runStatusMessage RunInitial = ""
-runStatusMessage (RunElapsed t) =
-  "Running for " ⊕ printSeconds t ⊕ "..."
-runStatusMessage (RunFinished t) =
-  "Finished: took " ⊕ printMilliseconds t ⊕ "."
-
-printSeconds ∷ Milliseconds → String
-printSeconds t = case toSeconds t of
-  Seconds s → maybe "0" show (fromNumber (Math.floor s)) ⊕ "s"
-
-printMilliseconds ∷ Milliseconds → String
-printMilliseconds (Milliseconds ms) =
-  maybe "0" show (fromNumber (Math.floor ms)) ⊕ "ms"
-
-refreshButton ∷ CardHTML
-refreshButton =
-  H.button
-    [ P.title "Refresh card content"
-    , ARIA.label "Refresh card content"
-    , P.classes [CSS.refreshButton]
-    , E.onClick (E.input_ RefreshCard)
-    ]
-    [ glyph B.glyphiconRefresh ]

--- a/src/SlamData/Workspace/Card/Component/State.purs
+++ b/src/SlamData/Workspace/Card/Component/State.purs
@@ -20,10 +20,7 @@ module SlamData.Workspace.Card.Component.State
   , initialCardState
   , _accessType
   , _visibility
-  , _runState
-  , _tickStopper
   , _output
-  , _canceler
   , _element
   , AnyCardState
   , _AceState
@@ -45,8 +42,6 @@ module SlamData.Workspace.Card.Component.State
 
 import SlamData.Prelude
 
-import Control.Monad.Aff (Canceler)
-
 import Data.Lens (LensP, lens, PrismP, prism')
 import Data.Visibility (Visibility(..))
 
@@ -54,7 +49,7 @@ import DOM.HTML.Types (HTMLElement)
 
 import Halogen (ParentState)
 
-import SlamData.Effects (Slam, SlamDataEffects)
+import SlamData.Effects (Slam)
 import SlamData.Workspace.AccessType (AccessType(..))
 import SlamData.Workspace.Card.Ace.Component.State as Ace
 import SlamData.Workspace.Card.API.Component.State as API
@@ -70,7 +65,6 @@ import SlamData.Workspace.Card.Markdown.Component.State as Markdown
 import SlamData.Workspace.Card.Next.Component.State as Next
 import SlamData.Workspace.Card.OpenResource.Component.State as Open
 import SlamData.Workspace.Card.Port (Port)
-import SlamData.Workspace.Card.RunState (RunState(..))
 import SlamData.Workspace.Card.Save.Component.State as Save
 import SlamData.Workspace.Card.Search.Component.State as Search
 import SlamData.Workspace.Card.Viz.Component.State as Viz
@@ -86,10 +80,7 @@ import SlamData.Workspace.Card.Viz.Component.State as Viz
 type CardState =
   { accessType ∷ AccessType
   , visibility ∷ Visibility
-  , runState ∷ RunState
-  , tickStopper ∷ Slam Unit
   , output ∷ Maybe Port
-  , canceler ∷ Canceler SlamDataEffects
   , element ∷ Maybe HTMLElement
   }
 
@@ -100,10 +91,7 @@ initialCardState ∷ CardState
 initialCardState =
   { accessType: Editable
   , visibility: Visible
-  , runState: RunInitial
-  , tickStopper: pure unit
   , output: Nothing
-  , canceler: mempty
   , element: Nothing
   }
 
@@ -113,20 +101,11 @@ _accessType = lens _.accessType (_ { accessType = _ })
 _visibility ∷ LensP CardState Visibility
 _visibility = lens _.visibility (_ { visibility = _ })
 
-_runState ∷ LensP CardState RunState
-_runState = lens _.runState (_ { runState = _ })
-
-_tickStopper ∷ LensP CardState (Slam Unit)
-_tickStopper = lens _.tickStopper (_ { tickStopper = _ })
-
 -- | The last output value computed for the card. This may not be up to date
 -- | with the exact state of the card, but is the most recent result from when
 -- | the card was evaluated.
 _output ∷ LensP CardState (Maybe Port)
 _output = lens _.output (_ { output = _ })
-
-_canceler ∷ LensP CardState (Canceler SlamDataEffects)
-_canceler = lens _.canceler _{canceler = _}
 
 _element ∷ LensP CardState (Maybe HTMLElement)
 _element = lens _.element _{element = _}

--- a/src/SlamData/Workspace/Deck/Component.purs
+++ b/src/SlamData/Workspace/Deck/Component.purs
@@ -409,21 +409,7 @@ mkShareURL varMap = do
     loc ⊕ "/" ⊕ workspaceUrl ⊕ mkWorkspaceHash p (WA.Load AT.ReadOnly) varMap
 
 peekCards ∷ ∀ a. CardSlot → CardQueryP a → DeckDSL Unit
-peekCards (CardSlot cardId) = peekCard cardId ⨁ peekCardInner cardId
-
--- | Peek on the card component to observe actions from the card control
--- | buttons.
-peekCard ∷ ∀ a. CardId → CardQuery a → DeckDSL Unit
-peekCard cardId = case _ of
-  RunCard _ → runCard cardId
-  RefreshCard _ → traverse_ runCard =<< H.gets (map _.cardId ∘ Array.head ∘ _.modelCards)
-  StopCard _ → do
-    -- TODO: does it even make sense to have a stop action on cards anymore?
-    -- I don't think there's a button for it anyway. Maybe the deck as a whole
-    -- should be stoppable via an action on the back? -gb
-    H.modify $ DCS.removePendingCard cardId
-    runPendingCards
-  _ → pure unit
+peekCards (CardSlot cardId) = const (pure unit) ⨁ peekCardInner cardId
 
 showDialog ∷ Dialog.Dialog → DeckDSL Unit
 showDialog =


### PR DESCRIPTION
There's no point tracking the eval running state of the cards anymore, since the deck is in control of evaluation, and most cards just update their state in `EvalCard` now.

This also removes the remnants of the ability to cancel evaluation, but that also wasn't working, and again needs to be done at the deck level.