### PR TITLE
Specialise `cardsOfType` for the API card

### DIFF
--- a/src/SlamData/Workspace/Deck/Component.purs
+++ b/src/SlamData/Workspace/Deck/Component.purs
@@ -291,7 +291,7 @@ eval (SetGlobalVarMap m next) = do
   st ← H.get
   when (m ≠ st.globalVarMap) do
     H.modify $ DCS._globalVarMap .~ m
-    traverse_ runCard $ DCS.cardsOfType CT.API st
+    traverse_ runCard $ DCS.apiCards st
   pure next
 eval (FlipDeck next) = do
   updateBackSide

--- a/src/SlamData/Workspace/Deck/Component/State.purs
+++ b/src/SlamData/Workspace/Deck/Component/State.purs
@@ -49,7 +49,7 @@ module SlamData.Workspace.Deck.Component.State
   , findLastRealCard
   , addPendingCard
   , removePendingCard
-  , cardsOfType
+  , apiCards
   , fromModel
   , deckPath
   , deckPath'
@@ -300,13 +300,12 @@ findLastRealCard state =
 findLastCardType ∷ State → Maybe CT.CardType
 findLastCardType { displayCards } = Card.modelCardType ∘ _.model <$> A.last displayCards
 
--- TODO: should this be displayCards? - js
-cardsOfType ∷ CT.CardType → State → Array CardId
-cardsOfType cardType =
+apiCards ∷ State → Array CardId
+apiCards =
   _.modelCards ⋙ A.mapMaybe cardTypeMatches ⋙ foldMap pure
   where
   cardTypeMatches { cardId: cid, model } =
-    if Card.modelCardType model ≡ cardType
+    if Card.modelCardType model ≡ CT.API
        then Just cid
        else Nothing
 


### PR DESCRIPTION
This is only used in one place, and it wasn’t clear which set of cards it should operate on as a general function. When specialised, it becomes obvious.