### PR TITLE
Clean up more old stuff

### DIFF
--- a/src/SlamData/Workspace/Card/Common.purs
+++ b/src/SlamData/Workspace/Card/Common.purs
@@ -20,6 +20,7 @@ module SlamData.Workspace.Card.Common
 
 import SlamData.Prelude
 
+import SlamData.Workspace.AccessType (AccessType)
 import SlamData.Workspace.Card.CardId (CardId)
 import SlamData.Workspace.Deck.DeckId (DeckId)
 import SlamData.Workspace.Deck.DeckLevel (DeckLevel)
@@ -33,4 +34,5 @@ type CardOptions =
   , cardId ∷ CardId
   , deckId ∷ Maybe DeckId
   , level ∷ DeckLevel
+  , accessType ∷ AccessType
   }

--- a/src/SlamData/Workspace/Card/Component.purs
+++ b/src/SlamData/Workspace/Card/Component.purs
@@ -114,7 +114,6 @@ makeCardComponentPart def render =
   eval ∷ Natural CQ.CardQuery CardDSL
   eval (CQ.UpdateCard input output next) = do
     void $ H.query unit (left (H.action (CQ.EvalCard input output)))
-    H.modify $ CS._output .~ output
     pure next
   eval (CQ.SaveCard cardId cardType k) = do
     model ← fromMaybe (Card.cardModelOfType cardType) <$> H.query unit (left (H.request CQ.Save))
@@ -123,8 +122,6 @@ makeCardComponentPart def render =
     H.query unit ∘ left ∘ H.action $ CQ.Load card.model
     sendAfter' (Milliseconds 100.0) (CQ.UpdateDimensions unit)
     pure next
-  eval (CQ.SetCardAccessType at next) =
-    H.modify (CS._accessType .~ at) $> next
   eval (CQ.SetHTMLElement el next) =
     H.modify (CS._element .~ el) $> next
   eval (CQ.UpdateDimensions next) = do

--- a/src/SlamData/Workspace/Card/Component/Query.purs
+++ b/src/SlamData/Workspace/Card/Component/Query.purs
@@ -48,8 +48,6 @@ import DOM.HTML.Types (HTMLElement)
 
 import Halogen (ChildF)
 
-import SlamData.Workspace.AccessType as Na
-
 import SlamData.Workspace.Card.Ace.Component.Query as Ace
 import SlamData.Workspace.Card.API.Component.Query as API
 import SlamData.Workspace.Card.APIResults.Component.Query as APIResults
@@ -82,7 +80,6 @@ data CardQuery a
   = UpdateCard CardEvalInput (Maybe Port) a
   | SaveCard CardId CardType (Card.Model → a)
   | LoadCard Card.Model a
-  | SetCardAccessType Na.AccessType a
   | UpdateDimensions a
   | SetHTMLElement (Maybe HTMLElement) a
 

--- a/src/SlamData/Workspace/Card/Component/State.purs
+++ b/src/SlamData/Workspace/Card/Component/State.purs
@@ -18,8 +18,6 @@ module SlamData.Workspace.Card.Component.State
   ( CardState(..)
   , CardStateP
   , initialCardState
-  , _accessType
-  , _output
   , _element
   , AnyCardState
   , _AceState
@@ -48,7 +46,6 @@ import DOM.HTML.Types (HTMLElement)
 import Halogen (ParentState)
 
 import SlamData.Effects (Slam)
-import SlamData.Workspace.AccessType (AccessType(..))
 import SlamData.Workspace.Card.Ace.Component.State as Ace
 import SlamData.Workspace.Card.API.Component.State as API
 import SlamData.Workspace.Card.APIResults.Component.State as APIResults
@@ -62,23 +59,13 @@ import SlamData.Workspace.Card.JTable.Component.State as JTable
 import SlamData.Workspace.Card.Markdown.Component.State as Markdown
 import SlamData.Workspace.Card.Next.Component.State as Next
 import SlamData.Workspace.Card.OpenResource.Component.State as Open
-import SlamData.Workspace.Card.Port (Port)
 import SlamData.Workspace.Card.Save.Component.State as Save
 import SlamData.Workspace.Card.Search.Component.State as Search
 import SlamData.Workspace.Card.Viz.Component.State as Viz
 
 -- | The common state value for deck cards.
--- |
--- | - `accessType` tracks whether the card is in an editable or read-only
--- |   deck. In the case of read-only decks editor cards are hidden.
--- | - `visibility` is used to specify whether the card should be rendered at
--- |   all - used when embedding a single card in another page.
--- | - `runState` tracks whether the card has run yet, is running, or has
--- |   completed running.
 type CardState =
-  { accessType ∷ AccessType
-  , output ∷ Maybe Port
-  , element ∷ Maybe HTMLElement
+  { element ∷ Maybe HTMLElement
   }
 
 type CardStateP = ParentState CardState AnyCardState CardQuery InnerCardQuery Slam Unit
@@ -86,19 +73,8 @@ type CardStateP = ParentState CardState AnyCardState CardQuery InnerCardQuery Sl
 -- | Creates an initial `CardState` value for an editor card.
 initialCardState ∷ CardState
 initialCardState =
-  { accessType: Editable
-  , output: Nothing
-  , element: Nothing
+  { element: Nothing
   }
-
-_accessType ∷ LensP CardState AccessType
-_accessType = lens _.accessType (_ { accessType = _ })
-
--- | The last output value computed for the card. This may not be up to date
--- | with the exact state of the card, but is the most recent result from when
--- | the card was evaluated.
-_output ∷ LensP CardState (Maybe Port)
-_output = lens _.output (_ { output = _ })
 
 _element ∷ LensP CardState (Maybe HTMLElement)
 _element = lens _.element _{element = _}

--- a/src/SlamData/Workspace/Card/Draftboard/Component.purs
+++ b/src/SlamData/Workspace/Card/Draftboard/Component.purs
@@ -57,7 +57,7 @@ import SlamData.Render.CSS as RC
 import SlamData.Workspace.AccessType as AT
 import SlamData.Workspace.Card.Draftboard.Common (deleteGraph)
 import SlamData.Workspace.Card.Draftboard.Component.Query (Query(..), QueryP, QueryC)
-import SlamData.Workspace.Card.Draftboard.Component.State (State, DeckPosition, initialState, encode, decode, _moving, _accessType, _inserting, modelFromState)
+import SlamData.Workspace.Card.Draftboard.Component.State (State, DeckPosition, initialState, encode, decode, _moving, _inserting, modelFromState)
 import SlamData.Workspace.Card.CardId as CID
 import SlamData.Workspace.Card.CardType as Ct
 import SlamData.Workspace.Card.Model as Card
@@ -109,7 +109,7 @@ render opts state =
         , HC.style bgSize
         , HP.ref (right ∘ H.action ∘ SetElement)
         , HE.onMouseDown \e → pure $
-            guard (AT.isEditable state.accessType && not state.inserting) $>
+            guard (AT.isEditable opts.accessType && not state.inserting) $>
             right (H.action $ AddDeck e)
         ]
         $ map renderDeck (foldl Array.snoc [] $ Map.toList state.decks)
@@ -160,10 +160,7 @@ render opts state =
     CSS.height $ CSS.px $ gridToPx $ size'.height + 1.0
 
 evalCard ∷ Natural Ceq.CardEvalQuery DraftboardDSL
-evalCard (Ceq.EvalCard input output next) = do
-  H.modify $ _accessType .~ input.accessType
-  H.queryAll ∘ opaqueQuery ∘ H.action $ DCQ.SetAccessType input.accessType
-  pure next
+evalCard (Ceq.EvalCard _ _ next) = pure next
 evalCard (Ceq.SetDimensions _ next) = pure next
 evalCard (Ceq.Save k) = map (k ∘ Card.Draftboard ∘ modelFromState) H.get
 evalCard (Ceq.Load card next) = do

--- a/src/SlamData/Workspace/Card/Draftboard/Component/State.purs
+++ b/src/SlamData/Workspace/Card/Draftboard/Component/State.purs
@@ -22,7 +22,6 @@ module SlamData.Workspace.Card.Draftboard.Component.State
   , modelFromState
   , _decks
   , _moving
-  , _accessType
   , _inserting
   , module Model
   ) where
@@ -39,7 +38,6 @@ import Data.Map as Map
 
 import SlamData.Effects (Slam)
 
-import SlamData.Workspace.AccessType as AT
 import SlamData.Workspace.Card.Draftboard.Component.Query (QueryC)
 import SlamData.Workspace.Deck.Component.Query as DCQ
 import SlamData.Workspace.Deck.Component.State as DCS
@@ -51,7 +49,6 @@ type State =
   { decks ∷ Map.Map DeckId Model.DeckPosition
   , moving ∷ Maybe (Tuple DeckId Model.DeckPosition)
   , canvas ∷ Maybe HTMLElement
-  , accessType ∷ AT.AccessType
   , inserting ∷ Boolean
   }
 
@@ -66,7 +63,6 @@ initialState =
   { decks: Map.empty
   , moving: Nothing
   , canvas: Nothing
-  , accessType: AT.Editable
   , inserting: false
   }
 
@@ -89,9 +85,6 @@ _decks = lens _.decks _{ decks = _ }
 
 _moving ∷ LensP State (Maybe (Tuple DeckId Model.DeckPosition))
 _moving = lens _.moving _{ moving = _ }
-
-_accessType ∷ LensP State AT.AccessType
-_accessType = lens _.accessType _{ accessType = _ }
 
 _inserting ∷ LensP State Boolean
 _inserting = lens _.inserting _{ inserting = _ }

--- a/src/SlamData/Workspace/Card/Eval/CardEvalT.purs
+++ b/src/SlamData/Workspace/Card/Eval/CardEvalT.purs
@@ -30,7 +30,6 @@ import Data.Path.Pathy as Path
 import Control.Monad.Error.Class as EC
 import Control.Monad.Except.Trans as ET
 
-import SlamData.Workspace.AccessType as AT
 import SlamData.Workspace.Card.CardId as CID
 import SlamData.Workspace.Card.Port as Port
 import SlamData.Workspace.Card.Port.VarMap as VM
@@ -42,7 +41,6 @@ type CardEvalInput =
   , input ∷ Maybe Port.Port
   , cardId ∷ CID.CardId
   , globalVarMap ∷ VM.VarMap
-  , accessType ∷ AT.AccessType
   }
 
 type CardEvalTP m = ET.ExceptT String m

--- a/src/SlamData/Workspace/Component/Query.purs
+++ b/src/SlamData/Workspace/Component/Query.purs
@@ -31,12 +31,10 @@ import SlamData.Workspace.Deck.DeckId (DeckId)
 import Utils.Path as UP
 
 data Query a
-  = SetAccessType AccessType a
-  | SetGlobalVarMap Port.VarMap a
+  = SetGlobalVarMap Port.VarMap a
   | DismissAll a
   | Reset UP.DirPath a
-  | Load UP.DirPath (Maybe DeckId) a
-  | GetPath (Maybe UP.DirPath → a)
+  | Load UP.DirPath (Maybe DeckId) AccessType a
 
 type QueryP = Coproduct Query (H.ChildF ChildSlot ChildQuery)
 

--- a/src/SlamData/Workspace/Deck/Component/Query.purs
+++ b/src/SlamData/Workspace/Deck/Component/Query.purs
@@ -27,7 +27,6 @@ import DOM.HTML.Types (HTMLElement)
 import Halogen.Component.Opaque.Unsafe (OpaqueQuery)
 import Halogen.HTML.Events.Types (Event, MouseEvent)
 
-import SlamData.Workspace.AccessType as AT
 import SlamData.Workspace.Card.CardId (CardId)
 import SlamData.Workspace.Card.Port.VarMap as Port
 import SlamData.Workspace.Deck.DeckLevel (DeckLevel)
@@ -37,21 +36,16 @@ import SlamData.Workspace.Deck.Model (Deck)
 import Utils.Path as UP
 
 data Query a
-  = RunActiveCard a
-  | RunPendingCards a
+  = RunPendingCards a
   | GetId (Maybe DeckId → a)
-  | GetPath (Maybe UP.DirPath → a)
   | GetParent (Maybe (Tuple DeckId CardId) → a)
   | SetParent (Tuple DeckId CardId) a
-  | SetName String a
-  | SetAccessType AT.AccessType a
   | ExploreFile UP.FilePath a
   | Publish a
   | Load UP.DirPath DeckId DeckLevel a
   | SetModel DeckId Deck DeckLevel a
   | Save a
   | Reset UP.DirPath a
-  | GetGlobalVarMap (Port.VarMap → a)
   | SetGlobalVarMap Port.VarMap a
   | FlipDeck a
   | GrabDeck (Event MouseEvent) a

--- a/src/SlamData/Workspace/Deck/Component/State.purs
+++ b/src/SlamData/Workspace/Deck/Component/State.purs
@@ -27,7 +27,6 @@ module SlamData.Workspace.Deck.Component.State
   , _displayCards
   , _cardsToLoad
   , _activeCardIndex
-  , _name
   , _path
   , _saveTrigger
   , _runTrigger
@@ -111,7 +110,6 @@ type State =
   , displayCards ∷ Array Card.Model
   , cardsToLoad ∷ Set.Set CardId
   , activeCardIndex ∷ Maybe Int
-  , name ∷ Maybe String
   , path ∷ DirPath
   , saveTrigger ∷ Maybe (DebounceTrigger Query Slam)
   , runTrigger ∷ Maybe (DebounceTrigger Query Slam)
@@ -141,7 +139,6 @@ initialDeck path =
   , displayCards: mempty
   , cardsToLoad: mempty
   , activeCardIndex: Nothing
-  , name: Nothing
   , path
   , saveTrigger: Nothing
   , globalVarMap: SM.empty
@@ -190,10 +187,6 @@ _cardsToLoad = lens _.cardsToLoad _{cardsToLoad = _}
 -- | action card.
 _activeCardIndex ∷ ∀ a r. LensP {activeCardIndex ∷ a |r} a
 _activeCardIndex = lens _.activeCardIndex _{activeCardIndex = _}
-
--- | The display name of the deck.
-_name ∷ ∀ a r. LensP {name ∷ a |r} a
-_name = lens _.name _{name = _}
 
 -- | The path to the deck in the filesystem
 _path ∷ ∀ a r. LensP {path ∷ a |r} a
@@ -340,7 +333,7 @@ fromModel
   → Model.Deck
   → State
   → State
-fromModel path deckId { cards, name, parent } state =
+fromModel path deckId { cards, parent } state =
   state
     { activeCardIndex = Nothing
     , displayMode = Normal
@@ -351,7 +344,6 @@ fromModel path deckId { cards, name, parent } state =
     , id = deckId
     , parent = parent
     , initialSliderX = Nothing
-    , name = name
     , path = path
     , runTrigger = Nothing
     , pendingCard = Nothing

--- a/src/SlamData/Workspace/Deck/Model.purs
+++ b/src/SlamData/Workspace/Deck/Model.purs
@@ -31,22 +31,19 @@ import SlamData.Workspace.Deck.DeckId (DeckId, deckIdToString)
 import Utils.Path (DirPath, FilePath)
 
 type Deck =
-  { name ∷ Maybe String
-  , parent ∷ Maybe (Tuple DeckId CardId)
+  { parent ∷ Maybe (Tuple DeckId CardId)
   , cards ∷ Array Card.Model
   }
 
 emptyDeck :: Deck
 emptyDeck =
-  { name: Nothing
-  , parent: Nothing
+  { parent: Nothing
   , cards: [ ]
   }
 
 encode ∷ Deck → Json
 encode r
    = "version" := 3
-  ~> "name" := r.name
   ~> "parent" := r.parent
   ~> "cards" := map Card.encode r.cards
   ~> jsonEmptyObject
@@ -56,11 +53,9 @@ decode = decodeJson >=> \obj → do
   case obj .? "version" of
     Right n | n ≠ 3 → throwError "Expected deck format v3"
     l → l
-  { name: _
-  , parent: _
+  { parent: _
   , cards: _
-  } <$> obj .? "name"
-    <*> obj .? "parent"
+  } <$> obj .? "parent"
     <*> (traverse Card.decode =<< obj .? "cards")
 
 deckIndex ∷ DirPath → DeckId → FilePath

--- a/src/SlamData/Workspace/Deck/Slider.purs
+++ b/src/SlamData/Workspace/Deck/Slider.purs
@@ -236,11 +236,10 @@ renderCard comp st card index =
     , cardId: card.cardId
     , deckId: st.id
     , level: st.level
+    , accessType: st.accessType
     }
 
   cardComponent =
     { component: Factory.cardComponent card cardOpts
-    , initialState:
-        H.parentState
-          CardC.initialCardState { accessType = st.accessType }
+    , initialState: H.parentState CardC.initialCardState
     }

--- a/test/src/Test/SlamData/Property/Workspace/Deck/Model.purs
+++ b/test/src/Test/SlamData/Property/Workspace/Deck/Model.purs
@@ -39,9 +39,8 @@ runArbDeck (ArbDeck m) = m
 instance arbitraryArbWorkspace ∷ Arbitrary ArbDeck where
   arbitrary = do
     cards ← map runArbCard <$> arbitrary
-    name ← arbitrary
     parent ← map (bimap runArbDeckId runArbCardId) <$> arbitrary
-    pure $ ArbDeck { name, cards, parent }
+    pure $ ArbDeck { cards, parent }
 
 check ∷ QC Unit
 check = quickCheck $ runArbDeck ⋙ \model →


### PR DESCRIPTION
- Make `accessType` a card option rather than a state-mutable thing
- Remove `name` from `Deck` (unused)
- Removed some unused queries from `Deck` and `Workspace`