### PR TITLE
removed/hidden all grab, resize buttons from deck border in view mode

### DIFF
--- a/less/deck.less
+++ b/less/deck.less
@@ -81,6 +81,12 @@
   padding-left: 3px;
   padding-right: 3px;
   border: none;
+  &.active::after {
+      content: "⬌";
+      top: 50%;
+      margin-top: -50%;
+      color: #444;
+  }
 }
 
 .sd-card-gripper {
@@ -89,13 +95,6 @@
 
 .sd-card-gripper-last {
   float: right;
-}
-
-.sd-card-gripper::after, .sd-card-gripper-last::after {
-  content: "⬌";
-  top: 50%;
-  margin-top: -50%;
-  color: #444;
 }
 
 .sd-flip-deck {

--- a/src/SlamData/Workspace/Card/Draftboard/Component.purs
+++ b/src/SlamData/Workspace/Card/Draftboard/Component.purs
@@ -88,7 +88,7 @@ draftboardComponent opts = Cp.makeCardComponent
   { cardType: Ct.Draftboard
   , component: H.parentComponent
       { render: render opts
-      , eval: coproduct evalCard (evalBoard opts)
+      , eval: evalCard ⨁ (evalBoard opts)
       , peek: Just (peek opts)
       }
   , initialState: H.parentState initialState
@@ -210,7 +210,7 @@ evalBoard opts (AddDeck e next) = do
 evalBoard opts (LoadDeck deckId next) = do
   queryDeck deckId
     $ H.action
-    $ DCQ.Load opts.path deckId (DL.succ opts.level)
+    $ DCQ.Load opts.path deckId (DL.succ opts.level) opts.accessType
   pure next
 
 peek ∷ ∀ a. CardOptions → H.ChildF DeckId (OpaqueQuery DCQ.Query) a → DraftboardDSL Unit
@@ -338,7 +338,7 @@ addDeck opts coords = do
           }
         queryDeck deckId'
           $ H.action
-          $ DCQ.Load opts.path deckId' (DL.succ opts.level)
+          $ DCQ.Load opts.path deckId' (DL.succ opts.level) opts.accessType
 
 saveDeck ∷ DirPath → DM.Deck → DraftboardDSL (Either Exn.Error DeckId)
 saveDeck path model = runExceptT do
@@ -381,7 +381,7 @@ wrapDeck opts oldId = do
           }
         queryDeck newId
           $ H.action
-          $ DCQ.Load opts.path newId (DL.succ opts.level)
+          $ DCQ.Load opts.path newId (DL.succ opts.level) opts.accessType
 
 queryDeck ∷ ∀ a. DeckId → DCQ.Query a → DraftboardDSL (Maybe a)
-queryDeck deckId = H.query deckId <<< opaqueQuery
+queryDeck deckId = H.query deckId ∘ opaqueQuery

--- a/src/SlamData/Workspace/Deck/Component/Query.purs
+++ b/src/SlamData/Workspace/Deck/Component/Query.purs
@@ -27,6 +27,7 @@ import DOM.HTML.Types (HTMLElement)
 import Halogen.Component.Opaque.Unsafe (OpaqueQuery)
 import Halogen.HTML.Events.Types (Event, MouseEvent)
 
+import SlamData.Workspace.AccessType (AccessType)
 import SlamData.Workspace.Card.CardId (CardId)
 import SlamData.Workspace.Card.Port.VarMap as Port
 import SlamData.Workspace.Deck.DeckLevel (DeckLevel)
@@ -42,7 +43,7 @@ data Query a
   | SetParent (Tuple DeckId CardId) a
   | ExploreFile UP.FilePath a
   | Publish a
-  | Load UP.DirPath DeckId DeckLevel a
+  | Load UP.DirPath DeckId DeckLevel AccessType a
   | SetModel DeckId Deck DeckLevel a
   | Save a
   | Reset UP.DirPath a

--- a/src/SlamData/Workspace/Deck/Gripper.purs
+++ b/src/SlamData/Workspace/Deck/Gripper.purs
@@ -22,7 +22,7 @@ module SlamData.Workspace.Deck.Gripper
 
 import Data.Array as Array
 import Halogen as H
-import Halogen.HTML.Core (ClassName)
+import Halogen.HTML.Core (className, ClassName)
 import Halogen.HTML.Elements.Indexed as HH
 import Halogen.HTML.Events.Indexed as HE
 import Halogen.HTML.Properties.Indexed as HP
@@ -73,16 +73,18 @@ gripperClassName :: GripperDef -> ClassName
 gripperClassName (Previous _) = ClassNames.cardGripper
 gripperClassName (Next _) = ClassNames.cardGripperLast
 
-renderGrippers :: Boolean -> Boolean -> Tuple GripperDef GripperDef -> Array DeckHTML
-renderGrippers isActiveCard isGrabbed =
+renderGrippers :: Boolean -> Boolean -> Boolean -> Tuple GripperDef GripperDef -> Array DeckHTML
+renderGrippers isEditable isActiveCard isGrabbed =
   bifoldMap renderSingleton renderSingleton
   where
   render :: GripperDef -> DeckHTML
   render gripperDef =
     HH.button
-      ([ HP.classes [ gripperClassName gripperDef ]
+      ([ HP.classes
+           $ [ gripperClassName gripperDef ]
+           ⊕ (guard isEditable $> className "active")
        , HE.onMouseDown \e ->
-             pure $ Just (H.action (StartSliding e))
+            pure $ guard isEditable $> (H.action $ StartSliding e)
        , ARIA.grabbed $ show $ isGrabbed
        , ARIA.disabled $ show $ (not $ isAvailable gripperDef) || (not $ isActiveCard)
        ]

--- a/src/SlamData/Workspace/Deck/Slider.purs
+++ b/src/SlamData/Workspace/Deck/Slider.purs
@@ -44,6 +44,7 @@ import Halogen.HTML.Properties.Indexed.ARIA as ARIA
 
 import SlamData.Config as Config
 import SlamData.Render.CSS as ClassNames
+import SlamData.Workspace.AccessType as AT
 import SlamData.Workspace.Card.CardId (CardId)
 import SlamData.Workspace.Card.CardId as CardId
 import SlamData.Workspace.Card.Model as Card
@@ -222,6 +223,7 @@ renderCard comp st (deckId × card) index =
     , HP.ref (H.action ∘ DCQ.SetCardElement)
     ])
     $ Gripper.renderGrippers
+        (AT.isEditable st.accessType)
         (cardSelected st (deckId × card.cardId))
         (isJust st.initialSliderX)
         (Gripper.gripperDefsForCard st.displayCards $ Just coord)


### PR DESCRIPTION
https://slamdata.atlassian.net/browse/SD-1700 

Isn't this part of https://slamdata.atlassian.net/browse/SD-1715? I mean we may not focus decks in view mode and that would be cleaner. 

@beckyconning What do you think? 