### PR TITLE
SD1717: Update resize gripper

### DIFF
--- a/less/deck.less
+++ b/less/deck.less
@@ -152,32 +152,12 @@
 .sd-resize-deck {
   height: @grid-size;
   width: @grid-size;
-  background-color: transparent;
+  background: url(../img/gripper-resize.svg) no-repeat center;
   position: absolute;
   bottom: 0;
   right: 0;
   border: none;
   margin: 0;
-
-  &:before {
-    content: "";
-    position: absolute;
-    top: 50%;
-    left: 0;
-    right: 0;
-    border-top: 1px solid #ccc;
-    transform: rotate(-45deg);
-  }
-
-  &:after {
-    content: "";
-    position: absolute;
-    top: (@grid-size / 3 * 2);
-    left: 40%;
-    width: 50%;
-    border-top: 1px solid #ccc;
-    transform: rotate(-45deg);
-  }
 }
 
 button.sd-zoom-deck {

--- a/public/img/gripper-resize.svg
+++ b/public/img/gripper-resize.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<svg width="24" height="24" version="1.1" xmlns="http://www.w3.org/2000/svg">
+  <rect x="7" y="15" width="2" height="2" stroke="none" fill="#ccc"/>
+  <rect x="11" y="15" width="2" height="2" stroke="none" fill="#ccc"/>
+  <rect x="11" y="11" width="2" height="2" stroke="none" fill="#ccc"/>
+  <rect x="15" y="11" width="2" height="2" stroke="none" fill="#ccc"/>
+  <rect x="15" y="7" width="2" height="2" stroke="none" fill="#ccc"/>
+</svg>


### PR DESCRIPTION
Forgot to update this with the others. This is the two-dot-diagonal version:

![resize-gripper](https://cloud.githubusercontent.com/assets/693642/16537187/a54ddcb4-3ff4-11e6-8fb7-620ae61f47f6.png)

It might not be perfect, but I think of all the things we tried it was the least bad, and we can always refine from here, at least it matches the rest now.