### PR TITLE
SD-1790: Ensure wrapping build correct hierarchy

### DIFF
--- a/src/SlamData/Workspace/Card/Common.purs
+++ b/src/SlamData/Workspace/Card/Common.purs
@@ -19,9 +19,11 @@ module SlamData.Workspace.Card.Common where
 import SlamData.Workspace.Card.CardId (CardId)
 import SlamData.Workspace.Deck.Common (DeckOptions)
 import SlamData.Workspace.Deck.Component.Cycle (DeckComponent)
+import SlamData.Workspace.Deck.DeckId (DeckId)
 
 type CardOptions =
   { deck ∷ DeckOptions
   , deckComponent ∷ DeckComponent
-  , id ∷ CardId
+  , cardId ∷ CardId
+  , deckId ∷ DeckId
   }

--- a/src/SlamData/Workspace/Card/Draftboard/Component.purs
+++ b/src/SlamData/Workspace/Card/Draftboard/Component.purs
@@ -396,10 +396,8 @@ addDeck opts deck coords = do
     addDeckAt opts deck
 
 addDeckAt ∷ CardOptions → DM.Deck → DeckPosition → DraftboardDSL Unit
-addDeckAt { deck: opts, id: cardId } deck deckPos = do
-  let
-    parentId = opts.id
-    deck' = deck { parent = Just (parentId × cardId) }
+addDeckAt { deck: opts, deckId: parentId, cardId } deck deckPos = do
+  let deck' = deck { parent = Just (parentId × cardId) }
   H.modify $ _inserting .~ true
   deckId ← saveDeck opts.path deck'
   case deckId of
@@ -434,14 +432,12 @@ deleteDeck { deck } deckId = do
       H.modify \s → s { decks = Map.delete deckId s.decks }
 
 wrapDeck ∷ CardOptions → DeckId → DraftboardDSL Unit
-wrapDeck { id: cardId, deck } oldId = do
+wrapDeck { cardId, deckId: parentId, deck } oldId = do
   H.gets (Map.lookup oldId ∘ _.decks) >>= traverse_ \deckPos → do
     let
-      parentId = deck.id
       deckPos' = deckPos { x = 1.0, y = 1.0 }
       newDeck = (wrappedDeck deckPos' oldId) { parent = Just (parentId × cardId) }
-    deckId ← saveDeck deck.path newDeck
-    case deckId of
+    saveDeck deck.path newDeck >>= case _ of
       Left err → do
         -- TODO: do something to notify the user saving failed
         pure unit
@@ -466,13 +462,13 @@ unwrapDeck
   → DeckId
   → Map.Map DeckId (DeckPosition × DM.Deck)
   → DraftboardDSL Unit
-unwrapDeck opts oldId decks = void $ runMaybeT do
+unwrapDeck { deckId, cardId, deck } oldId decks = void $ runMaybeT do
   -- sort the decks here so they are ordered by position, this ensures that if
   -- decks need to be accomodated when broken out, the decks in the top left
   -- corner will maintain their position and the others will be accomodated.
   let deckList = List.sortBy (compare `on` toCoords) $ Map.toList decks
-  let coord = opts.deck.id × opts.id
-  let level' = DL.succ opts.deck.level
+  let coord = deckId × cardId
+  let level' = DL.succ deck.level
   offset ← MaybeT $ H.gets (Map.lookup oldId ∘ _.decks)
   lift do
     H.modify \s →
@@ -522,7 +518,7 @@ mirrorDeck opts oldId = do
         reallyAccomodateDeck (Map.toList st.decks) deckPos
 
 groupDecks ∷ CardOptions → DeckId → DeckId → DraftboardDSL Unit
-groupDecks { id: cardId, deck } deckFrom deckTo = do
+groupDecks { cardId, deckId, deck } deckFrom deckTo = do
   st ← H.get
   for_ (Map.lookup deckFrom st.decks) \rectFrom →
   for_ (Map.lookup deckTo st.decks) \rectTo → do
@@ -530,7 +526,7 @@ groupDecks { id: cardId, deck } deckFrom deckTo = do
       rectTo' = rectTo { x = 1.0, y = 1.0 }
       rectFrom' = rectFrom { x = 1.0, y = rectTo.height + 2.0 }
       newDeck = DM.emptyDeck
-        { parent = Just (deck.id × cardId)
+        { parent = Just (deckId × cardId)
         , cards = pure
           { cardId: CID.CardId 0
           , model: Card.Draftboard
@@ -541,8 +537,7 @@ groupDecks { id: cardId, deck } deckFrom deckTo = do
             }
           }
         }
-    deckId ← saveDeck deck.path newDeck
-    case deckId of
+    saveDeck deck.path newDeck >>= case _ of
       Left err → do
         -- TODO: do something to notify the user saving failed
         pure unit

--- a/src/SlamData/Workspace/Component.purs
+++ b/src/SlamData/Workspace/Component.purs
@@ -54,7 +54,7 @@ import SlamData.Workspace.Card.CardId as CID
 import SlamData.Workspace.Card.Draftboard.Common as DBC
 import SlamData.Workspace.Component.ChildSlot (ChildQuery, ChildSlot, ChildState, cpDeck, cpHeader)
 import SlamData.Workspace.Component.Query (QueryP, Query(..), fromWorkspace, fromDeck, toWorkspace, toDeck)
-import SlamData.Workspace.Component.State (State, _accessType, _loaded, _path, _version, _stateMode, _globalVarMap, _deckId, initialState)
+import SlamData.Workspace.Component.State (State, _accessType, _initialDeckId, _loaded, _path, _version, _stateMode, _globalVarMap, initialState)
 import SlamData.Workspace.Deck.Common (wrappedDeck, defaultPosition)
 import SlamData.Workspace.Deck.Component as Deck
 import SlamData.Workspace.Deck.Component.Nested as DN
@@ -100,7 +100,7 @@ render wiring state =
 
   deck ∷ Array WorkspaceHTML
   deck =
-    pure case state.stateMode, state.path, state.deckId of
+    pure case state.stateMode, state.path, state.initialDeckId of
       Loading, _, _ →
         HH.div [ HP.classes [ workspaceClass ] ]
           []
@@ -157,7 +157,7 @@ render wiring state =
 eval ∷ Wiring → Natural Query WorkspaceDSL
 eval _ (Init next) = do
   deckId ← H.fromEff freshDeckId
-  H.modify (_deckId ?~ deckId)
+  H.modify (_initialDeckId ?~ deckId)
   pure next
 eval _ (SetGlobalVarMap varMap next) = do
   H.modify (_globalVarMap .~ varMap)
@@ -167,12 +167,10 @@ eval _ (DismissAll next) = do
   querySignIn $ H.action SignIn.DismissSubmenu
   pure next
 eval _ (Reset path next) = do
-  deckId ← H.fromEff freshDeckId
   H.modify _
     { path = Just path
     , stateMode = Ready
     , accessType = AT.Editable
-    , deckId = Just deckId
     }
   queryDeck $ H.action $ Deck.Reset path
   queryDeck $ H.action $ Deck.Focus
@@ -192,14 +190,13 @@ eval _ (Load path deckId accessType next) = do
     H.modify _
       { stateMode = Loading
       , path = Just path
-      , deckId = deckId
       }
     queryDeck $ H.action $ Deck.Reset path
     maybe loadRoot loadDeck deckId
     void $ queryDeck $ H.action $ Deck.Focus
 
   loadDeck deckId = void do
-    H.modify _ { stateMode = Ready, deckId = Just deckId }
+    H.modify _ { stateMode = Ready }
     queryDeck $ H.action $ Deck.Load path deckId DL.root
 
   loadRoot =
@@ -216,13 +213,12 @@ peek = ((const $ pure unit) ⨁ peekDeck) ⨁ (const $ pure unit)
   peekDeck (Deck.DoAction (Deck.Unwrap decks) _) = void $ runMaybeT do
     state ← lift H.get
     path ← MaybeT $ pure state.path
-    oldId ← MaybeT $ pure state.deckId
+    oldId ← MaybeT $ queryDeck $ H.request Deck.GetId
     parent ← lift $ join <$> queryDeck (H.request Deck.GetParent)
     newId × (_ × deck) ← MaybeT $ pure $ List.head $ Map.toList decks
     let deck' = deck { parent = parent }
 
     lift do
-      H.modify (_deckId ?~ newId)
       queryDeck $ H.action $ Deck.SetModel newId deck' DL.root
       queryDeck $ H.action $ Deck.Save Nothing
 
@@ -248,7 +244,7 @@ peek = ((const $ pure unit) ⨁ peekDeck) ⨁ (const $ pure unit)
     oldId ← MaybeT $ queryDeck (H.request Deck.GetId)
     newId ← lift $ H.fromEff freshDeckId
 
-    let transitionDeck newDeck =
+    let transitionDeck newDeck = do
           traverse_ (queryDeck ∘ H.action)
             [ Deck.SetParent (Tuple newId (CID.CardId 0))
             , Deck.Save Nothing

--- a/src/SlamData/Workspace/Component.purs
+++ b/src/SlamData/Workspace/Component.purs
@@ -123,7 +123,6 @@ render wiring state =
 
   deckOpts path deckId =
     { path
-    , id: deckId
     , level: DL.root
     , accessType: state.accessType
     , wiring

--- a/src/SlamData/Workspace/Component/State.purs
+++ b/src/SlamData/Workspace/Component/State.purs
@@ -22,7 +22,7 @@ module SlamData.Workspace.Component.State
   , _loaded
   , _version
   , _path
-  , _deckId
+  , _initialDeckId
   , _stateMode
   ) where
 
@@ -44,7 +44,7 @@ type State =
   , loaded ∷ Boolean
   , version ∷ Maybe String
   , path ∷ Maybe DirPath
-  , deckId ∷ Maybe DeckId
+  , initialDeckId ∷ Maybe DeckId
   , stateMode ∷ StateMode
   }
 
@@ -55,7 +55,7 @@ initialState version =
   , loaded: false
   , version
   , path: Nothing
-  , deckId: Nothing
+  , initialDeckId: Nothing
   , stateMode: Loading
   }
 
@@ -74,8 +74,10 @@ _version = lens _.version _{version = _}
 _path ∷ ∀ a r. LensP {path ∷ a|r} a
 _path = lens _.path _{path = _}
 
-_deckId ∷ ∀ a r. LensP {deckId ∷ a|r} a
-_deckId = lens _.deckId _{deckId = _}
+-- | This is only used while the workspace and initial deck are created, after
+-- | that the value is irrelevant.
+_initialDeckId ∷ ∀ a r. LensP {initialDeckId ∷ a|r} a
+_initialDeckId = lens _.initialDeckId _{initialDeckId = _}
 
 _stateMode ∷ LensP State StateMode
 _stateMode = lens _.stateMode _{stateMode = _}

--- a/src/SlamData/Workspace/Deck/Common.purs
+++ b/src/SlamData/Workspace/Deck/Common.purs
@@ -43,7 +43,6 @@ type DeckDSL = H.ParentDSL State ChildState Query ChildQuery Slam ChildSlot
 
 type DeckOptions =
   { path ∷ DirPath
-  , id ∷ DeckId
   , level ∷ DeckLevel
   , accessType ∷ AccessType
   , wiring ∷ Wiring

--- a/src/SlamData/Workspace/Deck/Component.purs
+++ b/src/SlamData/Workspace/Deck/Component.purs
@@ -800,7 +800,7 @@ setModel opts model =
     Nothing → do
       st ← DCS.fromModel model <$> H.get
       setDeckState st
-      runCardUpdates opts opts.id L.Nil
+      runCardUpdates opts model.id L.Nil
 
 getModelCards ∷ DeckDSL (Array (DeckId × Card.Model))
 getModelCards = do

--- a/src/SlamData/Workspace/Deck/Slider.purs
+++ b/src/SlamData/Workspace/Deck/Slider.purs
@@ -258,7 +258,8 @@ renderCard opts deckComponent st (deckId × card) index =
   cardOpts =
     { deck: opts
     , deckComponent
-    , id: card.cardId
+    , cardId: card.cardId
+    , deckId: deckId
     }
 
   cardComponent =


### PR DESCRIPTION
This was a little tricky to track down. It's not wrapping a nested deck specifically that causes the issue, it's when the root deck is wrapped, and then a child of that deck is wrapped - the cause was due to a stale `deckId` reference that was taken from the `DeckOptions`. It's not safe to put the `deckId` in there, since it changes when wrapping takes place, so now we always use the deck ID from the state instead.

I spent some time chasing down a deadend with the `Workspace`'s `deckId` too, as this is another place it can go wrong, but actually this value is only used during component initialisation, as it's passed through the component slot thunk for the root deck component. I renamed it and added a comment to make it clear that it only has releveance during init so nobody else wastes time figuring out whether the right thing is happening with it at the `Workspace` state level!