### PR TITLE
SD-1781: Fix draftboard caching

### DIFF
--- a/src/SlamData/Workspace/Card/Draftboard/Component.purs
+++ b/src/SlamData/Workspace/Card/Draftboard/Component.purs
@@ -188,7 +188,7 @@ evalBoard opts = case _ of
             ∘ (_grouping .~ grouping)
       Drag.Done _ → do
         stopDragging opts
-        CC.raiseUpdatedP' CC.StateOnlyUpdate
+        CC.raiseUpdatedP' CC.EvalModelUpdate
     pure next
   Resizing deckId ev next → do
     case ev of
@@ -202,7 +202,7 @@ evalBoard opts = case _ of
           H.modify $ _moving ?~ Tuple deckId newRect
       Drag.Done _ → do
         stopDragging opts
-        CC.raiseUpdatedP' CC.StateOnlyUpdate
+        CC.raiseUpdatedP' CC.EvalModelUpdate
     pure next
   SetElement el next → do
     H.modify _ { canvas = el }
@@ -217,7 +217,7 @@ evalBoard opts = case _ of
           { x: floor $ coords.x + 1.0
           , y: floor $ coords.y
           }
-        CC.raiseUpdatedP' CC.StateOnlyUpdate
+        CC.raiseUpdatedP' CC.EvalModelUpdate
     pure next
   LoadDeck deckId next → do
     queryDeck deckId
@@ -245,16 +245,16 @@ peek opts (H.ChildF deckId q) = coproduct (const (pure unit)) peekDeck q
     DCQ.ResizeDeck ev _ → startDragging deckId ev Resizing
     DCQ.DoAction DCQ.DeleteDeck _ → do
       deleteDeck opts deckId
-      CC.raiseUpdatedP' CC.StateOnlyUpdate
+      CC.raiseUpdatedP' CC.EvalModelUpdate
     DCQ.DoAction DCQ.Wrap _ → do
       wrapDeck opts deckId
-      CC.raiseUpdatedP' CC.StateOnlyUpdate
+      CC.raiseUpdatedP' CC.EvalModelUpdate
     DCQ.DoAction (DCQ.Unwrap decks) _ → do
       unwrapDeck opts deckId decks
-      CC.raiseUpdatedP' CC.StateOnlyUpdate
+      CC.raiseUpdatedP' CC.EvalModelUpdate
     DCQ.DoAction DCQ.Mirror _ → do
       mirrorDeck opts deckId
-      CC.raiseUpdatedP' CC.StateOnlyUpdate
+      CC.raiseUpdatedP' CC.EvalModelUpdate
     _ → pure unit
 
   startDragging deckId ev tag =


### PR DESCRIPTION
The draftboard raises `StateOnlyUpdate` notifications for any of the actions involved in rearranging the decks on it, as they have no effect in the scheme of things from an evaluation point of view (for now anyway, since there are no prior/next actions for a board - adding/removing boards will affect the eval model later, if there's some kind of composite output).

The problem is, the card cache is only updated when cards are evaluated... so any changes you make to a board never get cached, since a board card never goes through the eval machinery.

I've switched the notifcations over to `EvalModelUpdate` instead, which should have minimal overhead since a board has to be an orphan in a deck currently, but maybe the proper fix is to cache cards immediately when a `StateOnlyUpdate` arises? (I did start working on this, but it turned out to be rather annoying, since we need to get hold of the card type before we can save it, so I thought I'd present my initial fix and see if you think the additional work is necessary).