### PR TITLE
Fresher element references in Feature

### DIFF
--- a/test/src/Test/SlamData/Feature/Interactions.purs
+++ b/test/src/Test/SlamData/Feature/Interactions.purs
@@ -313,8 +313,7 @@ provideApiVariableBindingsForVariablesCard name ty val =
   where
   provideValueForVariablesCard ∷ String → SlamFeature Unit
   provideValueForVariablesCard name = do
-    Feature.provideFieldValueUntilExpectedValue
-      name
+    Feature.provideFieldValue
       (XPath.first $ XPath.anywhere $ XPaths.variablesCardVariableName)
       name
     Feature.pressEnter
@@ -327,8 +326,7 @@ provideApiVariableBindingsForVariablesCard name ty val =
 
   provideDefaultValueForVariablesCard ∷ String → String → SlamFeature Unit
   provideDefaultValueForVariablesCard name val = do
-    Feature.provideFieldValueUntilExpectedValue
-      val
+    Feature.provideFieldValue
       (XPath.first $ XPath.anywhere $ XPaths.variablesCardDefaultValueFor name)
       val
     Feature.pressEnter


### PR DESCRIPTION
When selenium is asked to perform an interaction with a stale element reference we currently reattempt that interaction with the stale element reference until timeout.

This PR makes getting a fresh element reference and trying again more common instead.