### PR TITLE
Prevent shadow layering of adjacent cards

### DIFF
--- a/less/deck.less
+++ b/less/deck.less
@@ -1,13 +1,17 @@
 @import "deck/common";
 @import "deck/indicator";
 
+.sd-workspace > div > .sd-deck-container {
+  top: 0;
+  left: 0;
+}
+
 .sd-deck-container {
   position: absolute;
-  top: 0;
+  top: 1px;
   right: 0;
-  left: 0;
+  left: 1px;
   bottom: 0;
-  box-shadow: 0px 0px 8px rgba(0, 0, 0, 0.25);
 
   transition: 0.2s ease-out box-shadow;
 
@@ -17,11 +21,24 @@
     width: 100%;
     height: 100%;
     background: #fff;
+    z-index: 2;
     > * {
       opacity: 0;
       pointer-events: none;
       transition: 0.2s ease-out opacity;
     }
+  }
+
+  .sd-deck-shadow {
+    .noselect;
+    pointer-events: none;
+    position: absolute;
+    left: 0px;
+    top: 0px;
+    width: 100%;
+    height: 100%;
+    box-shadow: 0px 0px 8px rgba(0, 0, 0, 0.25);
+    z-index: 1;
   }
 
   & > .loading {
@@ -36,13 +53,23 @@
   }
 
   &.sd-focused {
-    z-index: 2;
+    z-index: 10;
     box-shadow: 0px 0px 16px rgba(0, 0, 0, 0.25);
+
     > div.sd-deck-frame {
+      z-index: 12;
       > * {
         opacity: 1;
         pointer-events: auto;
       }
+    }
+
+    > div.sd-deck {
+      z-index: 12;
+    }
+
+    > div.sd-deck-shadow {
+      z-index: 11;
     }
   }
 }
@@ -53,6 +80,7 @@
   bottom: @grid-size;
   width: 100%;
   overflow: hidden;
+  z-index: 2;
 }
 
 .sd-card-slider {

--- a/less/deck/draftboard-card.less
+++ b/less/deck/draftboard-card.less
@@ -28,6 +28,6 @@
 
   .grouping {
     box-shadow: 0 0 4px 4px blue;
-    z-index: 1;
+    z-index: 19;
   }
 }

--- a/src/SlamData/Workspace/Card/Draftboard/Component.purs
+++ b/src/SlamData/Workspace/Card/Draftboard/Component.purs
@@ -112,7 +112,7 @@ render opts state =
             _ → []
       , HC.style $
           case state.moving of
-            Just (deckId' × rect') | deckId == deckId' → zIndex 2 *> cssPos rect'
+            Just (deckId' × rect') | deckId == deckId' → zIndex 20 *> cssPos rect'
             _ → cssPos rect
       ]
       [ HH.slot deckId $ mkDeckComponent deckId ]

--- a/src/SlamData/Workspace/Deck/Component/CSS.purs
+++ b/src/SlamData/Workspace/Deck/Component/CSS.purs
@@ -27,6 +27,9 @@ deck = className "sd-deck"
 deckFrame ∷ ClassName
 deckFrame = className "sd-deck-frame"
 
+deckShadow ∷ ClassName
+deckShadow = className "sd-deck-shadow"
+
 deckName ∷ ClassName
 deckName = className "sd-deck-name"
 

--- a/src/SlamData/Workspace/Deck/Component/Render.purs
+++ b/src/SlamData/Workspace/Deck/Component/Render.purs
@@ -69,6 +69,7 @@ renderDeck opts deckComponent st =
         , renderBackside $ st.displayMode ≡ DCS.Backside
         , renderDialog $ st.displayMode ≡ DCS.Dialog
         ]
+    , HH.div [ HP.class_ CSS.deckShadow ] []
     ]
 
   where


### PR DESCRIPTION
![flatten-shadows](https://cloud.githubusercontent.com/assets/693642/16702998/ddc79ebe-4561-11e6-9d9b-894334be829e.png)

The single pixel lines between the cards are perhaps a bit strong, but they're not something we entirely can choose the colour of - you're seeing a 1px gap between the cards, so that colour is just the grid line with a shadow overlaid on it.

For reference, here's what it looks like with the shadow overlaps:

![shadows](https://cloud.githubusercontent.com/assets/693642/16703028/1f5c4c76-4562-11e6-8ae3-6d3854b12bbe.png)

Grabbing a deck still raises it above its neighbours:

![grabbed](https://cloud.githubusercontent.com/assets/693642/16703048/415cf276-4562-11e6-9428-10aeda83b6a9.png)

(as does the group-merge-highlight).