### PR TITLE
Publish styles

### DIFF
--- a/less/filesystem.less
+++ b/less/filesystem.less
@@ -2,3 +2,6 @@
   margin-left: 0.25rem;
   width: 1rem;
 }
+
+@import "filesystem/search";
+@import "filesystem/toolbar";

--- a/less/filesystem/search.less
+++ b/less/filesystem/search.less
@@ -1,0 +1,80 @@
+img.search-clear {
+    width: 16px;
+    height: 16px;
+    position: absolute;
+    right: 44px;
+    top: 19px;
+    z-index: 100;
+    color: #0f0f0f;
+    cursor: pointer;
+    text-decoration: none;
+    &:hover {
+        text-decoration: none;
+        color: #000;
+    }
+}
+
+.search .search-input {
+    width: 100%;
+    padding-top: 10px;
+    border-radius: 0;
+    input, button {
+        border-radius: 0;
+        z-input: 1;
+        background-color: transparent;
+    }
+
+    .search-path {
+        .search-affix, .search-affix-empty {
+            color: #000;
+        }
+        .search-path-body {
+            color: transparent;
+        }
+        .search-affix-empty {
+            margin-left: 0;
+        }
+        .search-affix {
+            margin-left: 6px;
+        }
+        &-active {
+            .search-affix, .search-affix-empty {
+                color: #999;
+            }
+            .search-path-body {
+                color: transparent;
+            }
+            .search-affix-empty {
+                margin-left: 0;
+            }
+            .search-affix {
+                margin-left: 6px;
+            }
+        }
+        &, &-active {
+            top: 11px;
+            left: 0;
+            z-index: 0;
+            width: 100%;
+            background-color: white;
+            padding: 6px 13px;
+            position: absolute;
+        }
+    }
+
+
+    &.input-group {
+        span.input-group-btn {
+            width: 34px;
+        }
+    }
+
+    .btn {
+        width: 40px;
+        height: 34px;
+        padding: 0;
+        i.glyphicon {
+            top: 2px;
+        }
+    }
+}

--- a/less/filesystem/toolbar.less
+++ b/less/filesystem/toolbar.less
@@ -1,0 +1,35 @@
+.toolbar-sort {
+    padding-top: 14px;
+    padding-bottom: 10px;
+    cursor: pointer;
+
+    i {
+      margin-left: 10px;
+    }
+}
+.toolbar-menu {
+    input[type=file] {
+        width: 0.1px;
+        height: 0.1px;
+        opacity: 0;
+        overflow: hidden;
+        position: absolute;
+        z-index: -1;
+    }
+    padding-right: 0;
+    ul.list-inline {
+        margin-top: 8px;
+        margin-bottom: 0;
+    }
+    i {
+        padding-left: 10px;
+        font-size: 16px;
+        line-height: 40px;
+        position: relative;
+        overflow: hidden;
+        color: #337ab7;
+        &:hover {
+            color: #23527c
+        }
+    }
+}

--- a/less/main.less
+++ b/less/main.less
@@ -32,7 +32,7 @@ body {
     padding: 0;
     font-family: Ubuntu, Arial, Helvetica, sans-serif;
     height: 100%;
-    div.filesystem, div.dashboard {
+    div.filesystem, div.workspace {
         height: 100%;
         width: 100%;
     }
@@ -144,87 +144,6 @@ select.form-control, input.form-control {
     }
 }
 
-img.search-clear {
-    width: 16px;
-    height: 16px;
-    position: absolute;
-    right: 44px;
-    top: 19px;
-    z-index: 100;
-    color: #0f0f0f;
-    cursor: pointer;
-    text-decoration: none;
-    &:hover {
-        text-decoration: none;
-        color: #000;
-    }
-}
-
-.search .search-input {
-    width: 100%;
-    padding-top: 10px;
-    border-radius: 0;
-    input, button {
-        border-radius: 0;
-        z-input: 1;
-        background-color: transparent;
-    }
-
-    .search-path {
-        .search-affix, .search-affix-empty {
-            color: #000;
-        }
-        .search-path-body {
-            color: transparent;
-        }
-        .search-affix-empty {
-            margin-left: 0;
-        }
-        .search-affix {
-            margin-left: 6px;
-        }
-        &-active {
-            .search-affix, .search-affix-empty {
-                color: #999;
-            }
-            .search-path-body {
-                color: transparent;
-            }
-            .search-affix-empty {
-                margin-left: 0;
-            }
-            .search-affix {
-                margin-left: 6px;
-            }
-        }
-        &, &-active {
-            top: 11px;
-            left: 0;
-            z-index: 0;
-            width: 100%;
-            background-color: white;
-            padding: 6px 13px;
-            position: absolute;
-        }
-    }
-
-
-    &.input-group {
-        span.input-group-btn {
-            width: 34px;
-        }
-    }
-
-    .btn {
-        width: 40px;
-        height: 34px;
-        padding: 0;
-        i.glyphicon {
-            top: 2px;
-        }
-    }
-}
-
 .fade {
     z-index: -100500;
     &.in {
@@ -238,38 +157,6 @@ ol.breadcrumb {
     margin-top: 12px;
     >li+li:before {
         padding-right: 1px;
-    }
-}
-
-.toolbar-sort {
-    padding-top: 14px;
-    padding-bottom: 10px;
-    cursor: pointer;
-}
-.toolbar-menu {
-    input[type=file] {
-        width: 0.1px;
-        height: 0.1px;
-        opacity: 0;
-        overflow: hidden;
-        position: absolute;
-        z-index: -1;
-    }
-    padding-right: 0;
-    ul.list-inline {
-        margin-top: 8px;
-        margin-bottom: 0;
-    }
-    i {
-        padding-left: 10px;
-        font-size: 16px;
-        line-height: 40px;
-        position: relative;
-        overflow: hidden;
-        color: #337ab7;
-        &:hover {
-            color: #23527c
-        }
     }
 }
 
@@ -364,10 +251,6 @@ ol.breadcrumb {
         margin-left: 4px;
         width: 5em;
     }
-}
-
-.search-card-button {
-    height: 34px;
 }
 
 .echarts-container {

--- a/less/main.less
+++ b/less/main.less
@@ -36,6 +36,7 @@ body {
         height: 100%;
         width: 100%;
     }
+    background: transparent;
 }
 
 ::-webkit-input-placeholder {
@@ -472,4 +473,5 @@ button {
 @import "dialog/download";
 @import "form-builder";
 @import "deck";
+@import "workspace";
 @import "form";

--- a/less/workspace.less
+++ b/less/workspace.less
@@ -32,11 +32,27 @@
         }
       }
 
+      .sd-deck-frame {
+        top: 0.5rem;
+        bottom: 0.5rem;
+        left: 0.5rem;
+        right: 0.5rem;
+        width: auto;
+        height: auto;
+        // this tiny shadow is to give the top/left edge of the deck some
+        // definition over white backgrounds - the sd-deck-shadow is also used
+        // to provide a larger softer drop
+        box-shadow: 0px 0px 2px 0px rgba(0, 0, 0, 0.1);
+      }
+
       .sd-deck-shadow {
-        box-sizing: content-box;
-        border: 1px solid #ddd;
-        left: -1px;
-        top: -1px;
+        top: 0.5rem;
+        bottom: 0.5rem;
+        left: 0.5rem;
+        right: 0.5rem;
+        width: auto;
+        height: auto;
+        box-shadow: 2px 2px 8px 0px rgba(0, 0, 0, 0.15);
       }
 
       > .sd-card-slider {

--- a/less/workspace.less
+++ b/less/workspace.less
@@ -1,0 +1,54 @@
+.sd-workspace.sd-published {
+
+  .sd-card-header {
+    display: none;
+  }
+
+  .sd-board-inset-shadow, .sd-deck-shadow, .sd-deck-container.sd-focused {
+    box-shadow: none;
+  }
+
+  .sd-board-grid {
+    background: none;
+  }
+
+  > div > .sd-deck-container {
+
+    > .sd-deck-frame {
+     display: none;
+    }
+
+    > .sd-deck {
+      top: 0;
+      bottom: 0;
+
+      .sd-deck {
+        top: ~"calc(1.5rem - 1px)";
+        bottom: ~"calc(1.5rem - 1px)";
+
+        .sd-card-slider {
+          left: ~"calc(1.5rem - 1px)";
+          right: ~"calc(1.5rem - 1px)";
+        }
+      }
+
+      .sd-deck-shadow {
+        box-sizing: content-box;
+        border: 1px solid #ddd;
+        left: -1px;
+        top: -1px;
+      }
+
+      > .sd-card-slider {
+        left: 0;
+        top: 0;
+        right: 0;
+        bottom: 0;
+
+        > .sd-card {
+          background: none;
+        }
+      }
+    }
+  }
+}

--- a/src/SlamData/FileSystem/Component.purs
+++ b/src/SlamData/FileSystem/Component.purs
@@ -50,6 +50,7 @@ import Quasar.Data (QData(..))
 import SlamData.Config as Config
 import SlamData.Effects (Slam)
 import SlamData.FileSystem.Breadcrumbs.Component as Breadcrumbs
+import SlamData.FileSystem.Component.CSS as CSS
 import SlamData.FileSystem.Component.Install (ChildQuery, ChildSlot, ChildState, QueryP, StateP, cpBreadcrumbs, cpDialog, cpListing, cpSearch, cpHeader, toDialog, toFs, toListing, toSearch)
 import SlamData.FileSystem.Component.Query (Query(..))
 import SlamData.FileSystem.Component.Render (sorting, toolbar)
@@ -75,7 +76,6 @@ import SlamData.Quasar.Auth (authHeaders) as API
 import SlamData.Quasar.Data (makeFile, save) as API
 import SlamData.Quasar.FS (children, delete, getNewName) as API
 import SlamData.Quasar.Mount (mountInfo, viewInfo) as API
-import SlamData.Render.CSS as Rc
 import SlamData.Render.Common (content, row)
 import SlamData.SignIn.Component as SignIn
 import SlamData.Workspace.Action (Action(..), AccessType(..))
@@ -93,7 +93,7 @@ comp = H.parentComponent { render, eval, peek: Just (peek ∘ H.runChildF) }
 render ∷ State → HTML
 render state@{ version, sort, salt, path } =
   HH.div
-    [ HP.classes [ Rc.filesystem ]
+    [ HP.classes [ CSS.filesystem ]
     , HE.onClick (HE.input_ DismissSignInSubmenu)
     ]
     [ HH.slot' cpHeader unit \_ →

--- a/src/SlamData/FileSystem/Component/CSS.purs
+++ b/src/SlamData/FileSystem/Component/CSS.purs
@@ -1,0 +1,31 @@
+{-
+Copyright 2016 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
+module SlamData.FileSystem.Component.CSS where
+
+import Halogen.HTML.Core (className, ClassName)
+
+filesystem ∷ ClassName
+filesystem = className "filesystem"
+
+toolbarSort ∷ ClassName
+toolbarSort = className "toolbar-sort"
+
+toolbarMenu ∷ ClassName
+toolbarMenu = className "toolbar-menu"
+
+hiddenFileInput ∷ ClassName
+hiddenFileInput = className "hidden-file-input"

--- a/src/SlamData/FileSystem/Component/Render.purs
+++ b/src/SlamData/FileSystem/Component/Render.purs
@@ -21,7 +21,6 @@ import SlamData.Prelude
 import Data.Lens ((^.))
 
 import Halogen.HTML.Core (HTML, ClassName)
-import Halogen.HTML.CSS.Indexed as CSS
 import Halogen.HTML.Events.Handler as EH
 import Halogen.HTML.Events.Indexed as E
 import Halogen.HTML.Indexed as H
@@ -30,64 +29,62 @@ import Halogen.HTML.Properties.Indexed.ARIA as ARIA
 import Halogen.Query (action)
 import Halogen.Themes.Bootstrap3 as B
 
-import CSS.Geometry (marginLeft)
-import CSS.Size (px)
-
+import SlamData.FileSystem.Component.CSS as CSS
 import SlamData.FileSystem.Component.Query (Query(..))
 import SlamData.FileSystem.Component.State (State, _showHiddenFiles, _isMount, _sort)
 import SlamData.FileSystem.Listing.Sort (Sort(..))
-import SlamData.Render.CSS as Rc
 
-sorting :: forall a. State -> HTML a (Query Unit)
+sorting ∷ ∀ a. State → HTML a (Query Unit)
 sorting state =
-  H.div [ P.classes [ B.colXs4, Rc.toolbarSort ] ]
-  [ H.a [ E.onClick \_ -> EH.preventDefault $> Just (action Resort) ]
-    [ H.text "Name"
-    , H.i
-        [ chevron (state ^. _sort)
-        , CSS.style (marginLeft $ px 10.0)
-        , ARIA.label $ label (state ^. _sort)
-        , P.title $ label (state ^. _sort)
-        ] [ ]
-    ]
-  ]
+  H.div
+      [ P.classes [ B.colXs4, CSS.toolbarSort ] ]
+      [ H.a
+          [ E.onClick \_ → EH.preventDefault $> Just (action Resort) ]
+          [ H.text "Name"
+          , H.i
+              [ chevron (state ^. _sort)
+              , ARIA.label $ label (state ^. _sort)
+              , P.title $ label (state ^. _sort)
+              ]
+              []
+          ]
+      ]
   where
   chevron Asc = P.classes [ B.glyphicon, B.glyphiconChevronUp ]
   chevron Desc = P.classes [ B.glyphicon, B.glyphiconChevronDown ]
   label Asc = "Sort files by name descending"
   label Desc = "Sort files by name ascending"
 
-toolbar :: forall p. State -> HTML p (Query Unit)
+toolbar ∷ ∀ p. State → HTML p (Query Unit)
 toolbar state =
-  H.div [ P.classes [ B.colXs5, Rc.toolbarMenu ] ]
-  [ H.ul [ P.classes [ B.listInline, B.pullRight ] ]
-    $ configure <> [ showHide, download, mount, folder, file, workspace ]
-  ]
+  H.div
+    [ P.classes [ B.colXs5, CSS.toolbarMenu ] ]
+    [ H.ul
+        [ P.classes [ B.listInline, B.pullRight ] ]
+        $ configure <> [ showHide, download, mount, folder, file, workspace ]
+    ]
   where
-  configure :: Array (HTML p (Query Unit))
+  configure ∷ Array (HTML p (Query Unit))
   configure = do
     guard $ state ^. _isMount
-    pure $ toolItem
-      Configure
-      "Configure mount"
-      B.glyphiconWrench
+    pure $ toolItem Configure "Configure mount" B.glyphiconWrench
 
-  showHide :: HTML p (Query Unit)
+  showHide ∷ HTML p (Query Unit)
   showHide =
     if state ^. _showHiddenFiles
     then toolItem HideHiddenFiles "Hide hidden files" B.glyphiconEyeClose
     else toolItem ShowHiddenFiles "Show hidden files" B.glyphiconEyeOpen
 
-  download :: HTML p (Query Unit)
+  download ∷ HTML p (Query Unit)
   download = toolItem Download "Download" B.glyphiconCloudDownload
 
-  mount :: HTML p (Query Unit)
+  mount ∷ HTML p (Query Unit)
   mount = toolItem MakeMount "Mount database" B.glyphiconHdd
 
-  folder :: HTML p (Query Unit)
+  folder ∷ HTML p (Query Unit)
   folder = toolItem MakeFolder "Create folder" B.glyphiconFolderClose
 
-  file :: HTML p (Query Unit)
+  file ∷ HTML p (Query Unit)
   file =
     H.li_
       [ H.input
@@ -96,29 +93,31 @@ toolbar state =
           , P.id_ "upload"
           ]
       , H.label
-            [ P.for "upload"
-            , P.title "Upload file"
-            , ARIA.label "Upload file"
-            ]
-            [ H.i
-                [ P.classes [ B.glyphicon, B.glyphiconCloudUpload, Rc.hiddenFileInput ] ]
-                []
-            ]
+          [ P.for "upload"
+          , P.title "Upload file"
+          , ARIA.label "Upload file"
+          ]
+          [ H.i
+              [ P.classes [ B.glyphicon, B.glyphiconCloudUpload, CSS.hiddenFileInput ] ]
+              []
+          ]
       ]
 
-  workspace :: HTML p (Query Unit)
+  workspace ∷ HTML p (Query Unit)
   workspace = toolItem MakeWorkspace "Create workspace" B.glyphiconBook
 
-toolItem :: forall p f. (Unit -> f Unit)
-            -> String -> ClassName -> HTML p (f Unit)
+toolItem ∷ ∀ p f. (Unit → f Unit) → String → ClassName → HTML p (f Unit)
 toolItem func title icon =
-  H.li_ [ H.button [ ARIA.label title
-                   , P.title title
-                   , E.onClick (E.input_ func)
-                   ]
-          [ H.i [ P.title title
-                , P.classes [ B.glyphicon, icon ]
-                ]
-            [ ]
-          ]
+  H.li_
+    [ H.button
+        [ ARIA.label title
+        , P.title title
+        , E.onClick (E.input_ func)
         ]
+        [ H.i
+            [ P.title title
+            , P.classes [ B.glyphicon, icon ]
+            ]
+            []
+        ]
+    ]

--- a/src/SlamData/FileSystem/Dialog/Download/Component/Render.purs
+++ b/src/SlamData/FileSystem/Dialog/Download/Component/Render.purs
@@ -37,6 +37,7 @@ import SlamData.Download.Model as D
 import SlamData.Download.Render as Rd
 import SlamData.FileSystem.Dialog.Download.Component.Query (Query(..))
 import SlamData.FileSystem.Dialog.Download.Component.State (State)
+import SlamData.FileSystem.Listing.Item.Component.CSS as ItemCSS
 import SlamData.FileSystem.Resource (Resource, isFile, resourcePath, isHidden)
 import SlamData.Quasar (reqHeadersToJSON, encodeURI)
 import SlamData.Render.Common (fadeWhen)
@@ -100,7 +101,7 @@ resItem res =
   HH.button
     [ HP.classes
         $ [ B.listGroupItem ]
-        ⊕ if isHidden res then [ Rc.itemHidden ] else []
+        ⊕ if isHidden res then [ ItemCSS.itemHidden ] else []
     , HE.onClick (HE.input_ (SourceClicked res))
     ]
     [ HH.text (resourcePath res) ]

--- a/src/SlamData/FileSystem/Dialog/Rename/Component.purs
+++ b/src/SlamData/FileSystem/Dialog/Rename/Component.purs
@@ -39,6 +39,7 @@ import Halogen.Themes.Bootstrap3 as B
 import SlamData.Config as Config
 import SlamData.Dialog.Render (modalDialog, modalHeader, modalBody, modalFooter)
 import SlamData.Effects (Slam)
+import SlamData.FileSystem.Listing.Item.Component.CSS as ItemCSS
 import SlamData.FileSystem.Resource as R
 import SlamData.Quasar.FS as API
 import SlamData.Render.Common (fadeWhen, formGroup)
@@ -224,7 +225,7 @@ render dialog =
   renameItem res =
     HH.button [ HP.classes ([ B.listGroupItem ]
                           <> (if R.isHidden res
-                              then [ Rc.itemHidden ]
+                              then [ ItemCSS.itemHidden ]
                               else [ ]))
              , HE.onClick (HE.input_ (DirClicked res))
              ]

--- a/src/SlamData/FileSystem/Listing/Item/Component.purs
+++ b/src/SlamData/FileSystem/Listing/Item/Component.purs
@@ -21,7 +21,7 @@ import SlamData.Prelude
 import Data.Lens (LensP, lens, (%~), (.~))
 
 import Halogen as H
-import Halogen.HTML.CSS.Indexed as CSS
+import Halogen.HTML.CSS.Indexed as HCSS
 import Halogen.HTML.Events.Handler as HEH
 import Halogen.HTML.Events.Indexed as HE
 import Halogen.HTML.Indexed as HH
@@ -34,8 +34,8 @@ import CSS.Size (px)
 
 import SlamData.Effects (Slam)
 import SlamData.FileSystem.Listing.Item (Item(..), itemResource)
+import SlamData.FileSystem.Listing.Item.Component.CSS as CSS
 import SlamData.FileSystem.Resource (Resource(..), Mount(..), resourceName, resourcePath, isMount, isFile, isWorkspace, isViewMount, hiddenTopLevel, root)
-import SlamData.Render.CSS as Rc
 
 type State =
   { item ∷ Item
@@ -86,11 +86,11 @@ render state = case state.item of
   Item _ → itemView state false false
   PhantomItem _ →
     HH.div
-      [ HP.classes [ B.listGroupItem, Rc.phantom ] ]
+      [ HP.classes [ B.listGroupItem, CSS.phantom ] ]
       [ HH.div
           [ HP.class_ B.row ]
           [ HH.div
-              [ HP.classes [ B.colXs8, Rc.itemContent ] ]
+              [ HP.classes [ B.colXs8, CSS.itemContent ] ]
               [ HH.span_
                   [ HH.img [ HP.src "img/spin.gif" ]
                   , HH.text $ itemName state
@@ -158,7 +158,7 @@ itemView state@{ item } selected presentActions | otherwise =
     [ HH.div
         [ HP.class_ B.row ]
         [ HH.div
-            [ HP.classes [ B.colXs8, Rc.itemContent ] ]
+            [ HP.classes [ B.colXs8, CSS.itemContent ] ]
             [ HH.a
                 [ HE.onClick \_ →
                     HEH.preventDefault $>
@@ -169,7 +169,7 @@ itemView state@{ item } selected presentActions | otherwise =
                 ]
             ]
         , HH.div
-            [ HP.classes $ [ B.colXs4, Rc.itemToolbar ] ⊕ (guard selected $> Rc.selected) ]
+            [ HP.classes $ [ B.colXs4, CSS.itemToolbar ] ⊕ (guard selected $> CSS.selected) ]
             [ itemActions presentActions item ]
         ]
     ]
@@ -178,7 +178,7 @@ itemView state@{ item } selected presentActions | otherwise =
   itemClasses =
     [ B.listGroupItem ]
     ⊕ (guard selected $> B.listGroupItemInfo)
-    ⊕ (if itemIsHidden item && presentHiddenItem state then [ Rc.itemHidden ] else [ ])
+    ⊕ (if itemIsHidden item && presentHiddenItem state then [ CSS.itemHidden ] else [ ])
 
   label ∷ String
   label | selected  = "Deselect " ++ itemName state
@@ -187,7 +187,7 @@ itemView state@{ item } selected presentActions | otherwise =
 iconClasses ∷ forall r i. Item → HP.IProp (class ∷ HP.I | r) i
 iconClasses item = HP.classes
   [ B.glyphicon
-  , Rc.itemIcon
+  , CSS.itemIcon
   , iconClass (itemResource item)
   ]
   where
@@ -203,7 +203,7 @@ itemActions presentActions item | not presentActions = HH.text ""
 itemActions presentActions item | otherwise =
   HH.ul
     [ HP.classes [ B.listInline, B.pullRight ]
-    , CSS.style $ marginBottom (px zero)
+    , HCSS.style $ marginBottom (px zero)
     ]
     (conf ⊕ common ⊕ share)
   where
@@ -233,7 +233,7 @@ itemActions presentActions item | otherwise =
           [ HE.onClick $ HE.input_ (act (itemResource item))
           , HP.title label
           , ARIA.label label
-          , HP.class_ Rc.fileAction
+          , HP.class_ CSS.fileAction
           ]
           [ HH.i [ HP.classes [ B.glyphicon, cls ] ] [] ]
       ]

--- a/src/SlamData/FileSystem/Listing/Item/Component/CSS.purs
+++ b/src/SlamData/FileSystem/Listing/Item/Component/CSS.purs
@@ -1,0 +1,40 @@
+{-
+Copyright 2016 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
+module SlamData.FileSystem.Listing.Item.Component.CSS where
+
+import Halogen.HTML.Core (className, ClassName)
+
+selected ∷ ClassName
+selected = className "selected"
+
+phantom ∷ ClassName
+phantom = className "phantom"
+
+itemIcon ∷ ClassName
+itemIcon = className "item-icon"
+
+itemToolbar ∷ ClassName
+itemToolbar = className "item-toolbar"
+
+itemContent ∷ ClassName
+itemContent = className "item-content"
+
+itemHidden ∷ ClassName
+itemHidden = className "item-hidden"
+
+fileAction ∷ ClassName
+fileAction = className "file-action"

--- a/src/SlamData/FileSystem/Search/Component.purs
+++ b/src/SlamData/FileSystem/Search/Component.purs
@@ -32,8 +32,8 @@ import Halogen.Component.Utils as HU
 
 import SlamData.Config as Config
 import SlamData.Effects (Slam)
+import SlamData.FileSystem.Search.Component.CSS as CSS
 import SlamData.Render.Common (glyph)
-import SlamData.Render.CSS as Rc
 
 import Text.SlamSearch (mkQuery)
 
@@ -102,7 +102,7 @@ comp = H.component { render, eval }
 render ∷ State → HTML
 render state =
   HH.div
-    [ HP.classes [ Rc.search ] ]
+    [ HP.classes [ CSS.search ] ]
     [ HH.form
         [ HE.onSubmit (HE.input_ Submit)]
         [ HH.div
@@ -119,22 +119,22 @@ render state =
             , HH.span
                 [ HP.class_
                     if state.focused
-                      then Rc.searchPathActive
-                      else Rc.searchPath
+                      then CSS.searchPathActive
+                      else CSS.searchPath
                 ]
                 [ HH.span
-                    [ HP.class_ Rc.searchPathBody ]
+                    [ HP.class_ CSS.searchPathBody ]
                     [ HH.text state.value ]
                 , HH.span
                     [ HP.class_
                         if state.value ≡ ""
-                        then Rc.searchAffixEmpty
-                        else Rc.searchAffix
+                        then CSS.searchAffixEmpty
+                        else CSS.searchAffix
                     ]
                     [ HH.text $ "path:" ⊕ printPath (state.path) ]
                 ]
             , HH.img
-                [ HP.class_ Rc.searchClear
+                [ HP.class_ CSS.searchClear
                 , HP.src searchIcon
                 , HE.onClick (HE.input_ Clear)
                 ]
@@ -152,7 +152,7 @@ render state =
   where
   searchClasses ∷ Array HH.ClassName
   searchClasses =
-    [ B.inputGroup, Rc.searchInput] ⊕ do
+    [ B.inputGroup, CSS.searchInput] ⊕ do
       guard (not $ state.valid)
       pure B.hasError
 

--- a/src/SlamData/FileSystem/Search/Component/CSS.purs
+++ b/src/SlamData/FileSystem/Search/Component/CSS.purs
@@ -1,0 +1,43 @@
+{-
+Copyright 2016 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
+module SlamData.FileSystem.Search.Component.CSS where
+
+import Halogen.HTML.Core (className, ClassName)
+
+search ∷ ClassName
+search = className "search"
+
+searchInput ∷ ClassName
+searchInput = className "search-input"
+
+searchClear ∷ ClassName
+searchClear = className "search-clear"
+
+searchPath ∷ ClassName
+searchPath = className "search-path"
+
+searchPathActive ∷ ClassName
+searchPathActive = className "search-path-active"
+
+searchAffix ∷ ClassName
+searchAffix = className "search-affix"
+
+searchPathBody ∷ ClassName
+searchPathBody = className "search-path-body"
+
+searchAffixEmpty ∷ ClassName
+searchAffixEmpty = className "search-affix-empty"

--- a/src/SlamData/Render/CSS.purs
+++ b/src/SlamData/Render/CSS.purs
@@ -18,41 +18,8 @@ module SlamData.Render.CSS where
 
 import Halogen.HTML.Core (className, ClassName)
 
-filesystem ∷ ClassName
-filesystem = className "filesystem"
-
-dashboard ∷ ClassName
-dashboard = className "dashboard"
-
 version ∷ ClassName
 version = className "version"
-
-selected ∷ ClassName
-selected = className "selected"
-
-phantom ∷ ClassName
-phantom = className "phantom"
-
-searchInput ∷ ClassName
-searchInput = className "search-input"
-
-searchClear ∷ ClassName
-searchClear = className "search-clear"
-
-searchPath ∷ ClassName
-searchPath = className "search-path"
-
-searchPathActive ∷ ClassName
-searchPathActive = className "search-path-active"
-
-searchAffix ∷ ClassName
-searchAffix = className "search-affix"
-
-searchPathBody ∷ ClassName
-searchPathBody = className "search-path-body"
-
-searchAffixEmpty ∷ ClassName
-searchAffixEmpty = className "search-affix-empty"
 
 results ∷ ClassName
 results = className "results"
@@ -60,14 +27,8 @@ results = className "results"
 header ∷ ClassName
 header = className "header"
 
-headerMenu ∷ ClassName
-headerMenu = className "header-menu"
-
 logo ∷ ClassName
 logo = className "logo"
-
-navCont ∷ ClassName
-navCont = className "nav-cont"
 
 navIcon ∷ ClassName
 navIcon = className "nav-icon"
@@ -75,29 +36,8 @@ navIcon = className "nav-icon"
 navLogo ∷ ClassName
 navLogo = className "nav-logo"
 
-search ∷ ClassName
-search = className "search"
-
 content ∷ ClassName
 content = className "content"
-
-toolbarSort ∷ ClassName
-toolbarSort = className "toolbar-sort"
-
-toolbarMenu ∷ ClassName
-toolbarMenu = className "toolbar-menu"
-
-itemIcon ∷ ClassName
-itemIcon = className "item-icon"
-
-itemToolbar ∷ ClassName
-itemToolbar = className "item-toolbar"
-
-itemContent ∷ ClassName
-itemContent = className "item-content"
-
-itemHidden ∷ ClassName
-itemHidden = className "item-hidden"
 
 invisible ∷ ClassName
 invisible = className "sd-invisible"
@@ -108,9 +48,6 @@ fileListField = className "file-list-field"
 fileListGroup ∷ ClassName
 fileListGroup = className "file-list-group"
 
-workspaceNav ∷ ClassName
-workspaceNav = className "workspace-nav"
-
 dialogDownload ∷ ClassName
 dialogDownload = className "dialog-download"
 
@@ -119,9 +56,6 @@ dialogMount = className "dialog-mount"
 
 renameDialogForm ∷ ClassName
 renameDialogForm = className "rename-dialog-form"
-
-mountSection ∷ ClassName
-mountSection = className "mount-section"
 
 mountMongoDB ∷ ClassName
 mountMongoDB = className "mount-mongodb"
@@ -151,89 +85,23 @@ mountProgressSpinner ∷ Boolean → ClassName
 mountProgressSpinner true = className "mount-progress-spinner"
 mountProgressSpinner false = className "mount-progress-spinner-hidden"
 
-workspaceViewHack ∷ ClassName
-workspaceViewHack = className "workspace-view-hack"
-
 cardInput ∷ ClassName
 cardInput = className "card-input"
-
-cardOutput ∷ ClassName
-cardOutput = className "card-output"
-
-cardOutputLabel ∷ ClassName
-cardOutputLabel = className "card-output-label"
-
-cardOutputResult ∷ ClassName
-cardOutputResult = className "card-output-result"
-
-cardNextActions ∷ ClassName
-cardNextActions = className "card-next-actions"
-
-newCardMenu ∷ ClassName
-newCardMenu = className "new-card-menu"
 
 aceContainer ∷ ClassName
 aceContainer = className "ace-container"
 
-playButton ∷ ClassName
-playButton = className "play-button"
-
-stopButton ∷ ClassName
-stopButton = className "stop-button"
-
-statusText ∷ ClassName
-statusText = className "status-text"
-
 cardFailures ∷ ClassName
 cardFailures = className "card-failures"
-
-cardBlockedMessage ∷ ClassName
-cardBlockedMessage = className "card-blocked-message"
-
-cardEvalLine ∷ ClassName
-cardEvalLine = className "card-eval-line"
-
-pageInput ∷ ClassName
-pageInput = className "page-input"
 
 pageSize ∷ ClassName
 pageSize = className "page-size"
 
-searchCardButton ∷ ClassName
-searchCardButton = className "search-card-button"
-
-nextCardList ∷ ClassName
-nextCardList = className "next-card-list"
-
-echartsContainer ∷ ClassName
-echartsContainer = className "echarts-container"
-
-chartConfigureForm ∷ ClassName
-chartConfigureForm = className "chart-configure-form"
-
-vizCardEditor ∷ ClassName
-vizCardEditor = className "card-editor"
-
-vizChartTypeSelector ∷ ClassName
-vizChartTypeSelector = className "chart-type-selector"
-
-vizChartConfiguration ∷ ClassName
-vizChartConfiguration = className "chart-configuration"
-
 collapsed ∷ ClassName
 collapsed = className "collapsed"
 
-scrollbox ∷ ClassName
-scrollbox = className "scrollbox"
-
 loadingMessage ∷ ClassName
 loadingMessage = className "loading-message"
-
-withAggregation ∷ ClassName
-withAggregation = className "with-aggregation"
-
-aggregation ∷ ClassName
-aggregation = className "aggregation"
 
 embedBox ∷ ClassName
 embedBox = className "embed-box"
@@ -262,42 +130,8 @@ refreshButton = className "refresh-button"
 shareButton ∷ ClassName
 shareButton = className "share-button"
 
-hiddenFileInput ∷ ClassName
-hiddenFileInput = className "hidden-file-input"
-
-chartConfigureHeight ∷ ClassName
-chartConfigureHeight = className "chart-configure-height"
-
-chartConfigureWidth ∷ ClassName
-chartConfigureWidth = className "chart-configure-width"
-
-
-chartCategory ∷ ClassName
-chartCategory = className "chart-category"
-
-chartMeasureOne ∷ ClassName
-chartMeasureOne = className "chart-measure-one"
-
-chartMeasureTwo ∷ ClassName
-chartMeasureTwo = className "chart-measure-two"
-
-chartDimension ∷ ClassName
-chartDimension = className "chart-dimension"
-
-chartSeriesOne ∷ ClassName
-chartSeriesOne = className "chart-series-one"
-
-chartSeriesTwo ∷ ClassName
-chartSeriesTwo = className "chart-series-two"
-
-pieChartIcon ∷ ClassName
-pieChartIcon = className "pie-chart-icon"
-
-barChartIcon ∷ ClassName
-barChartIcon = className "bar-chart-icon"
-
-lineChartIcon ∷ ClassName
-lineChartIcon = className "line-chart-icon"
+aggregation ∷ ClassName
+aggregation = className "aggregation"
 
 deleteDeckIcon ∷ ClassName
 deleteDeckIcon = className "delete-deck-icon"
@@ -305,20 +139,11 @@ deleteDeckIcon = className "delete-deck-icon"
 actionIcon ∷ ClassName
 actionIcon = className "action-icon"
 
-chartEditor ∷ ClassName
-chartEditor = className "chart-editor"
-
 chartOutput ∷ ClassName
 chartOutput = className "chart-output"
 
 glyphiconInactive ∷ ClassName
 glyphiconInactive = className "glyphicon-inactive"
-
-axisLabelParam ∷ ClassName
-axisLabelParam = className "axis-label-param"
-
-chartSizeParam ∷ ClassName
-chartSizeParam = className "chart-size-param"
 
 downloadCardEditor ∷ ClassName
 downloadCardEditor = className "download-card-editor"
@@ -328,18 +153,6 @@ downloadTypeSelector = className "download-type-selector"
 
 downloadConfiguration ∷ ClassName
 downloadConfiguration = className "download-configuration"
-
-sqlMountVarPair ∷ ClassName
-sqlMountVarPair = className "sql-mount-var-pair"
-
-sqlMountForm ∷ ClassName
-sqlMountForm = className "sql-mount-form"
-
-sqlMountAddVarPairButton ∷ ClassName
-sqlMountAddVarPairButton = className "sql-mount-add-var-pair-button"
-
-fileAction ∷ ClassName
-fileAction = className "file-action"
 
 permissionsCheckboxes ∷ ClassName
 permissionsCheckboxes = className "permissions-checkboxes"
@@ -352,7 +165,6 @@ cancelInputRunIcon = className "cancel-input-run-icon"
 
 userShareForm ∷ ClassName
 userShareForm = className "user-share-form"
-
 
 nextActionCard ∷ ClassName
 nextActionCard = className "next-action-card"

--- a/src/SlamData/Workspace/Card/ChartOptions/Component.purs
+++ b/src/SlamData/Workspace/Card/ChartOptions/Component.purs
@@ -34,7 +34,7 @@ import CSS.Size (px)
 
 import Halogen as H
 import Halogen.CustomProps as Cp
-import Halogen.HTML.CSS.Indexed as CSS
+import Halogen.HTML.CSS.Indexed as HCSS
 import Halogen.HTML.Events.Indexed as HE
 import Halogen.HTML.Indexed as HH
 import Halogen.HTML.Properties.Indexed as HP
@@ -45,21 +45,21 @@ import SlamData.Effects (Slam)
 import SlamData.Form.Select (Select, autoSelect, newSelect, (⊝), ifSelected, trySelect', _value)
 import SlamData.Quasar.Query as Quasar
 import SlamData.Render.Common (row)
-import SlamData.Render.CSS as Rc
 import SlamData.Workspace.Card.CardType (CardType(ChartOptions))
 import SlamData.Workspace.Card.Chart.Aggregation (aggregationSelect)
 import SlamData.Workspace.Card.Chart.Axis (analyzeJArray, Axis)
 import SlamData.Workspace.Card.Chart.Axis as Ax
 import SlamData.Workspace.Card.Chart.ChartConfiguration (ChartConfiguration, depends, dependsOnArr)
 import SlamData.Workspace.Card.Chart.ChartType (ChartType(..), isPie)
-import SlamData.Workspace.Card.Common.Render (renderLowLOD)
-import SlamData.Workspace.Card.Component as CC
-import SlamData.Workspace.Card.Model as Card
-import SlamData.Workspace.Card.Port as P
+import SlamData.Workspace.Card.ChartOptions.Component.CSS as CSS
 import SlamData.Workspace.Card.ChartOptions.Component.Query (QueryC, Query(..))
 import SlamData.Workspace.Card.ChartOptions.Component.State as VCS
 import SlamData.Workspace.Card.ChartOptions.Form.Component (formComponent)
 import SlamData.Workspace.Card.ChartOptions.Form.Component as Form
+import SlamData.Workspace.Card.Common.Render (renderLowLOD)
+import SlamData.Workspace.Card.Component as CC
+import SlamData.Workspace.Card.Model as Card
+import SlamData.Workspace.Card.Port as P
 import SlamData.Workspace.LevelOfDetails (LevelOfDetails(..))
 
 type HTML = H.ParentHTML Form.StateP QueryC Form.QueryP Slam ChartType
@@ -124,7 +124,7 @@ renderHighLOD ∷ VCS.State → HTML
 renderHighLOD state =
     HH.div
       [ HP.classes
-          $ [ Rc.cardInput, HH.className "card-input-maximum-lod" ]
+          $ [ CSS.cardInput, HH.className "card-input-maximum-lod" ]
           ⊕ (guard (state.levelOfDetails ≠ High) $> B.hidden)
       ]
       [ renderEmpty $ not Set.isEmpty state.availableChartTypes
@@ -137,7 +137,7 @@ renderEmpty hidden =
     [ HP.classes
         $ [ B.alert, B.alertDanger ]
         ⊕ (guard hidden $> B.hide)
-    , CSS.style $ marginBottom $ px 12.0
+    , HCSS.style $ marginBottom $ px 12.0
     ]
     [ HH.text "There is no available chart for this dataset" ]
 
@@ -145,7 +145,7 @@ renderForm ∷ VCS.State → HTML
 renderForm state =
   HH.div
     [ HP.classes
-        $ [ Rc.vizCardEditor ]
+        $ [ CSS.vizCardEditor ]
         ⊕ (guard hidden $> B.hide)
     ]
     [ renderChartTypeSelector state
@@ -158,7 +158,7 @@ renderForm state =
 renderChartTypeSelector ∷ VCS.State → HTML
 renderChartTypeSelector state =
   HH.div
-    [ HP.classes [ Rc.vizChartTypeSelector ] ]
+    [ HP.classes [ CSS.vizChartTypeSelector ] ]
     $ foldl (foldFn state.chartType) empty state.availableChartTypes
   where
   foldFn ∷ ChartType → Array HTML → ChartType → Array HTML
@@ -178,15 +178,15 @@ renderChartTypeSelector state =
   src Bar = "img/bar.svg"
 
   cls ∷ ChartType → HH.ClassName
-  cls Pie = Rc.pieChartIcon
-  cls Line = Rc.lineChartIcon
-  cls Bar = Rc.barChartIcon
+  cls Pie = CSS.pieChartIcon
+  cls Line = CSS.lineChartIcon
+  cls Bar = CSS.barChartIcon
 
 
 renderChartConfiguration ∷ VCS.State → HTML
 renderChartConfiguration state =
   HH.div
-    [ HP.classes [ Rc.vizChartConfiguration ] ]
+    [ HP.classes [ CSS.vizChartConfiguration ] ]
     [ renderTab Pie
     , renderTab Line
     , renderTab Bar
@@ -209,9 +209,9 @@ renderChartConfiguration state =
 renderDimensions ∷ VCS.State → HTML
 renderDimensions state =
   row
-  [ chartInput Rc.axisLabelParam "Axis label angle"
+  [ chartInput CSS.axisLabelParam "Axis label angle"
       (_.axisLabelAngle ⋙ show) RotateAxisLabel (isPie state.chartType)
-  , chartInput Rc.axisLabelParam "Axis font size"
+  , chartInput CSS.axisLabelParam "Axis font size"
       (_.axisLabelFontSize ⋙ show) SetAxisFontSize (isPie state.chartType)
   ]
   where

--- a/src/SlamData/Workspace/Card/ChartOptions/Component/CSS.purs
+++ b/src/SlamData/Workspace/Card/ChartOptions/Component/CSS.purs
@@ -1,0 +1,43 @@
+{-
+Copyright 2016 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
+module SlamData.Workspace.Card.ChartOptions.Component.CSS where
+
+import Halogen.HTML.Core (className, ClassName)
+
+cardInput ∷ ClassName
+cardInput = className "card-input"
+
+vizCardEditor ∷ ClassName
+vizCardEditor = className "card-editor"
+
+vizChartTypeSelector ∷ ClassName
+vizChartTypeSelector = className "chart-type-selector"
+
+vizChartConfiguration ∷ ClassName
+vizChartConfiguration = className "chart-configuration"
+
+pieChartIcon ∷ ClassName
+pieChartIcon = className "pie-chart-icon"
+
+barChartIcon ∷ ClassName
+barChartIcon = className "bar-chart-icon"
+
+lineChartIcon ∷ ClassName
+lineChartIcon = className "line-chart-icon"
+
+axisLabelParam ∷ ClassName
+axisLabelParam = className "axis-label-param"

--- a/src/SlamData/Workspace/Card/ChartOptions/Form/Component.purs
+++ b/src/SlamData/Workspace/Card/ChartOptions/Form/Component.purs
@@ -53,7 +53,7 @@ import SlamData.Form.Select.Component as S
 import SlamData.Form.SelectPair.Component as P
 import SlamData.Workspace.Card.Chart.Aggregation (Aggregation(..), allAggregations)
 import SlamData.Workspace.Card.Chart.ChartConfiguration (JSelect, ChartConfiguration)
-import SlamData.Render.CSS as Rc
+import SlamData.Workspace.Card.ChartOptions.Form.Component.CSS as CSS
 
 data Query a
   = SetConfiguration ChartConfiguration a
@@ -120,7 +120,7 @@ render
   → FormHTML
 render conf =
   HH.div
-    [ HP.classes [ Rc.chartEditor ] ]
+    [ HP.classes [ CSS.chartEditor ] ]
     $ fold
       [ if null conf.dimensions
           then foldMap (renderCategory 0) (conf.series !! 0)
@@ -144,7 +144,7 @@ render conf =
   renderDimension ix sel =
     [ HH.form
         [ CP.nonSubmit
-        , HP.classes [ Rc.chartConfigureForm, Rc.chartDimension ]
+        , HP.classes [ CSS.chartConfigureForm, CSS.chartDimension ]
         ]
         [ dimensionLabel
         , HH.slot' cpDimension ix \_ →
@@ -159,9 +159,9 @@ render conf =
     [ HH.form
         [ CP.nonSubmit
         , HP.classes
-            [ Rc.chartConfigureForm
-            , Rc.chartMeasureOne
-            , Rc.withAggregation
+            [ CSS.chartConfigureForm
+            , CSS.chartMeasureOne
+            , CSS.withAggregation
             ]
         ]
         [ measureLabel
@@ -177,8 +177,8 @@ render conf =
     [ HH.form
         [ CP.nonSubmit
         , HP.classes
-            [ Rc.chartConfigureForm
-            , Rc.chartSeriesOne
+            [ CSS.chartConfigureForm
+            , CSS.chartSeriesOne
             ]
         ]
       [ seriesLabel
@@ -194,8 +194,8 @@ render conf =
     [ HH.form
         [ CP.nonSubmit
         , HP.classes
-            [ Rc.chartConfigureForm
-            , Rc.chartCategory
+            [ CSS.chartConfigureForm
+            , CSS.chartCategory
             ]
         ]
         [ categoryLabel
@@ -213,13 +213,13 @@ render conf =
            , defaultWhen: (_ > 1)
            , mainState: sel
            , ariaLabel: renderLabel i "Measure"
-           , classes: [Rc.aggregation, B.btnPrimary]
+           , classes: [CSS.aggregation, B.btnPrimary]
            }
       else { disableWhen: (_ < 1)
            , defaultWhen: (const true)
            , mainState: sel
            , ariaLabel: renderLabel i "Measure"
-           , classes: [Rc.aggregation, B.btnPrimary]
+           , classes: [CSS.aggregation, B.btnPrimary]
            }
 
 

--- a/src/SlamData/Workspace/Card/ChartOptions/Form/Component/CSS.purs
+++ b/src/SlamData/Workspace/Card/ChartOptions/Form/Component/CSS.purs
@@ -1,0 +1,43 @@
+{-
+Copyright 2016 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
+module SlamData.Workspace.Card.ChartOptions.Form.Component.CSS where
+
+import Halogen.HTML.Core (className, ClassName)
+
+chartConfigureForm ∷ ClassName
+chartConfigureForm = className "chart-configure-form"
+
+withAggregation ∷ ClassName
+withAggregation = className "with-aggregation"
+
+aggregation ∷ ClassName
+aggregation = className "aggregation"
+
+chartCategory ∷ ClassName
+chartCategory = className "chart-category"
+
+chartMeasureOne ∷ ClassName
+chartMeasureOne = className "chart-measure-one"
+
+chartDimension ∷ ClassName
+chartDimension = className "chart-dimension"
+
+chartSeriesOne ∷ ClassName
+chartSeriesOne = className "chart-series-one"
+
+chartEditor ∷ ClassName
+chartEditor = className "chart-editor"

--- a/src/SlamData/Workspace/Card/Draftboard/Component.purs
+++ b/src/SlamData/Workspace/Card/Draftboard/Component.purs
@@ -132,8 +132,14 @@ render opts state =
   bgSize = do
     let size = foldr maxSize { width: 0.0, height: 0.0 } state.decks
         size' = maybe size (flip maxSize size ∘ snd) state.moving
-    CSS.width $ CSS.px $ gridToPx $ size'.width + 1.0
-    CSS.height $ CSS.px $ gridToPx $ size'.height + 1.0
+    CSS.width $ CSS.px $ gridToPx $ size'.width + pad
+    CSS.height $ CSS.px $ gridToPx $ size'.height + pad
+
+  -- Leave an extra 1-grid-square gap at the edge to allow insertion of new
+  -- decks when editing
+  pad = case opts.deck.accessType of
+    AT.Editable → 1.0
+    _ -> 0.0
 
 evalCard ∷ Natural CC.CardEvalQuery DraftboardDSL
 evalCard = case _ of

--- a/src/SlamData/Workspace/Card/Open/Component.purs
+++ b/src/SlamData/Workspace/Card/Open/Component.purs
@@ -35,6 +35,7 @@ import Halogen.HTML.Properties.Indexed.ARIA as ARIA
 import Halogen.Themes.Bootstrap3 as B
 
 import SlamData.Effects (Slam)
+import SlamData.FileSystem.Listing.Item.Component.CSS as ItemCSS
 import SlamData.FileSystem.Resource as R
 import SlamData.Quasar.FS as Quasar
 import SlamData.Render.Common (glyph)
@@ -121,7 +122,7 @@ renderHighLOD state =
     HH.li
       [ HP.classes
           $ ((guard (Just (R.getPath r) ≡ (Right <$> state.selected))) $> B.active)
-          ⊕ ((guard (R.hiddenTopLevel r)) $> RC.itemHidden)
+          ⊕ ((guard (R.hiddenTopLevel r)) $> ItemCSS.itemHidden)
       , HE.onClick (HE.input_ (right ∘ ResourceSelected r))
       , ARIA.label labelTitle
 

--- a/src/SlamData/Workspace/Component.purs
+++ b/src/SlamData/Workspace/Component.purs
@@ -90,7 +90,9 @@ comp wiring =
 render ∷ Wiring → State → WorkspaceHTML
 render wiring state =
   HH.div
-    [ HP.class_ (HH.className "sd-workspace")
+    [ HP.classes
+        $ (guard (AT.isReadOnly (state ^. _accessType)) $> HH.className "sd-published")
+        ⊕ [ HH.className "sd-workspace" ]
     , HE.onClick (HE.input_ DismissAll)
     ]
     $ header ⊕ deck

--- a/src/SlamData/Workspace/FileInput/Component.purs
+++ b/src/SlamData/Workspace/FileInput/Component.purs
@@ -48,6 +48,7 @@ import Network.HTTP.Affjax (AJAX)
 
 import Quasar.Types (FilePath)
 
+import SlamData.FileSystem.Listing.Item.Component.CSS as ItemCSS
 import SlamData.FileSystem.Resource as R
 import SlamData.Quasar.FS as API
 import SlamData.Render.CSS as CSS
@@ -180,7 +181,7 @@ renderItem r =
   HH.button
     [ HP.classes $
         [ B.listGroupItem
-        ] <> if R.isHidden r then [ CSS.itemHidden ] else [ ]
+        ] <> if R.isHidden r then [ ItemCSS.itemHidden ] else [ ]
     , HE.onClick $ HE.input_ (SelectFile r)
     ]
     [ HH.text $ R.resourcePath r


### PR DESCRIPTION
There's a bunch of CSS refactoring and deleting of unused styles in here, so sorry about that, I got slightly carried away.

Here's what a published deck looks like now:

![published](https://cloud.githubusercontent.com/assets/693642/16738474/b8eeb388-478d-11e6-94cd-8e5eb14ce333.png)

It's a little spartan looking, but the reason for that is the background has to be set to `transparent` for this rather neat thing for the embedding case:

![embedded](https://cloud.githubusercontent.com/assets/693642/16738493/ce19a8bc-478d-11e6-956c-a13929559489.png)

So since we have a transparent background, when embedded, the iframe is "invisible".

Regarding styling, I figured going completely flat was less opinionated that having drop shadows. There is still a grey keyline around things, but that's sort of required so that nested draftboards don't merge into an edgeless confusion.

