### PR TITLE
SD-1853: Update pending card style

### DIFF
--- a/less/deck.less
+++ b/less/deck.less
@@ -245,3 +245,4 @@ button.sd-zoom-deck {
 @import "deck/card-minimum-lod";
 @import "deck/share.less";
 @import "deck/unshare.less";
+@import "deck/pending.less";

--- a/less/deck/card-minimum-lod.less
+++ b/less/deck/card-minimum-lod.less
@@ -17,10 +17,12 @@
             position: relative;
             left: 50%;
             margin-left: -21px;
+            margin-bottom: 0.5rem;
         }
         i.glyphicon {
             display: block;
             font-size: 26pt;
+            margin-bottom: 0.5rem;
         }
     }
 }

--- a/less/deck/pending.less
+++ b/less/deck/pending.less
@@ -1,0 +1,17 @@
+.sd-card-pending > div {
+
+  position: absolute;
+  height: auto;
+  text-align: center;
+  top: 50%;
+  width: 100%;
+  margin-top: -32px;
+
+  i {
+    display: block;
+    width: 32px;
+    height: 32px;
+    background: url(../img/spin.gif);
+    margin: 0 auto 0.5rem;
+  }
+}

--- a/src/SlamData/Workspace/Card/Pending/Component.purs
+++ b/src/SlamData/Workspace/Card/Pending/Component.purs
@@ -17,8 +17,8 @@ limitations under the License.
 module SlamData.Workspace.Card.Pending.Component where
 
 import SlamData.Prelude
-import SlamData.Effects (Slam)
 
+import SlamData.Effects (Slam)
 import SlamData.Workspace.Card.CardType as CT
 import SlamData.Workspace.Card.Component as CC
 import SlamData.Workspace.Card.Model as Card
@@ -26,9 +26,7 @@ import SlamData.Workspace.Card.Pending.Component.Query as PCQ
 import SlamData.Workspace.Card.Pending.Component.State as PCS
 
 import Halogen as H
-import Halogen.Themes.Bootstrap3 as B
 import Halogen.HTML.Indexed as HH
-import Halogen.HTML.Properties.Indexed as HP
 
 type DSL = H.ComponentDSL PCS.State PCQ.QueryP Slam
 type HTML = H.ComponentHTML PCQ.QueryP
@@ -43,32 +41,29 @@ comp =
     , _Query: CC.makeQueryPrism CC._PendingQuery
     }
 
-render
-  ∷ PCS.State
-  → HTML
+render ∷ PCS.State → HTML
 render st =
-  HH.div [ HP.classes [ B.alert, B.alertInfo ] ]
-    [ HH.img [ HP.src "img/blue-spin.svg" ]
-    , HH.text st.message
+  HH.div_
+    [ HH.i_ []
+    , HH.span_ [ HH.text st.message ]
     ]
 
 eval ∷ PCQ.QueryP ~> DSL
 eval = coproduct cardEval PCQ.initiality
 
 cardEval ∷ CC.CardEvalQuery ~> DSL
-cardEval q =
-  case q of
-    CC.EvalCard _ _ next → do
-      pure next
-    CC.Activate next →
-      pure next
-    CC.Save k →
-      pure $ k Card.PendingCard
-    CC.Load _ next →
-      pure next
-    CC.SetDimensions _ next →
-      pure next
-    CC.ModelUpdated _ next →
-      pure next
-    CC.ZoomIn next →
-      pure next
+cardEval = case _ of
+  CC.EvalCard _ _ next → do
+    pure next
+  CC.Activate next →
+    pure next
+  CC.Save k →
+    pure $ k Card.PendingCard
+  CC.Load _ next →
+    pure next
+  CC.SetDimensions _ next →
+    pure next
+  CC.ModelUpdated _ next →
+    pure next
+  CC.ZoomIn next →
+    pure next


### PR DESCRIPTION
It now looks like this (but animated):

![pneding](https://cloud.githubusercontent.com/assets/693642/16746147/e8186d16-47b0-11e6-97bd-1761d94e4344.png)

It doesn't fade out on completion as it is an actual card, so we can't overlay it to get the fade to work correctly right now.