### PR TITLE
SD-1855: Detect embedding, only use transparent background when embedded

### DIFF
--- a/less/main.less
+++ b/less/main.less
@@ -36,7 +36,15 @@ body {
         height: 100%;
         width: 100%;
     }
-    background: transparent;
+    background: #fff;
+}
+
+body.sd-workspace-page {
+  background: #eee;
+}
+
+body.sd-workspace-page.sd-embedded {
+  background: transparent;
 }
 
 ::-webkit-input-placeholder {

--- a/public/workspace.html
+++ b/public/workspace.html
@@ -12,6 +12,6 @@
     <link rel="stylesheet" href="css/main.css">
     <link rel="icon" type="image/png" href="img/favicon.png">
   </head>
-  <body class="workspace-page">
+  <body class="sd-workspace-page">
   </body>
 </html>

--- a/src/Control/UI/Browser.js
+++ b/src/Control/UI/Browser.js
@@ -28,3 +28,11 @@ exports.setTitle = function(t) {
         document.title = t;
     };
 };
+
+exports.detectEmbedding = function() {
+    try {
+        return window.self !== window.top;
+    } catch (e) {
+        return true;
+    }
+};

--- a/src/Control/UI/Browser.purs
+++ b/src/Control/UI/Browser.purs
@@ -27,6 +27,7 @@ module Control.UI.Browser
   , hostAndProtocol
   , getHref
   , setHref
+  , detectEmbedding
   ) where
 
 import Prelude
@@ -79,3 +80,6 @@ foreign import select :: forall e. HTMLElement -> Eff (dom :: DOM | e) Unit
 foreign import newTab :: forall e. String -> Eff (dom :: DOM | e) Unit
 foreign import clearValue :: forall e. HTMLElement -> Eff (dom :: DOM | e) Unit
 foreign import setTitle :: forall e. String -> Eff (dom :: DOM | e) Unit
+
+-- | Checks whether the current page is embedded in another page via iframe.
+foreign import detectEmbedding :: forall e. Eff (dom :: DOM | e) Boolean


### PR DESCRIPTION
This gives us a tinted background when viewing a published notebook:

![published2](https://cloud.githubusercontent.com/assets/693642/16748623/1a8a5834-47bd-11e6-83f9-24065ba7822e.png)

While maintaining the transparent background when embedded. I figured detecting rather than using a different route or something would be better, as that way if someone ignores our embed code and just dumps a publish URL in an iframe it will still work out.