### PR TITLE
Fix board inset shadow z-indexing

### DIFF
--- a/less/deck/draftboard-card.less
+++ b/less/deck/draftboard-card.less
@@ -21,7 +21,7 @@
     position: fixed;
     width: 100%;
     height: 100%;
-    z-index: 3;
+    z-index: 30;
     box-shadow: inset 0px 0px 8px 0px rgba(0, 0, 0, 0.25);
     pointer-events: none;
   }


### PR DESCRIPTION
Without this, when a deck is focused the inset shadow z-indexing is wrong if the deck overlaps goes under the board edge:

![z-border](https://cloud.githubusercontent.com/assets/693642/16749124/ff23bbdc-47bf-11e6-8ba6-4f35cdef7aff.png)

(before / after)