### PR TITLE
SD-1858: Remove the source dropdown from the download dialog

### DIFF
--- a/src/SlamData/FileSystem/Component.purs
+++ b/src/SlamData/FileSystem/Component.purs
@@ -444,10 +444,6 @@ download res = do
   hs ← H.fromEff API.authHeaders
   showDialog (Dialog.Download res)
   queryDialog Dialog.cpDownload (H.action $ Download.SetAuthHeaders hs)
-  getChildren
-    (const true)
-    (void ∘ queryDialog Dialog.cpDownload ∘ H.action ∘ Download.AddSources)
-    rootDir
   pure unit
 
 getChildren

--- a/src/SlamData/FileSystem/Dialog/Download/Component/Query.purs
+++ b/src/SlamData/FileSystem/Dialog/Download/Component/Query.purs
@@ -17,20 +17,14 @@ limitations under the License.
 module SlamData.FileSystem.Dialog.Download.Component.Query where
 
 import SlamData.Download.Model
-import SlamData.FileSystem.Resource (Resource)
 import Network.HTTP.RequestHeader (RequestHeader)
 
 data Query a
-  = SourceTyped String a
-  | ToggleList a
-  | SourceClicked Resource a
-  | TargetTyped String a
+  = TargetTyped String a
   | ToggleCompress a
   | SetOutput OutputType a
   | Dismiss a
   | NewTab String a
   | ModifyCSVOpts (CSVOptions -> CSVOptions) a
   | ModifyJSONOpts (JSONOptions -> JSONOptions) a
-  | AddSources (Array Resource) a
-  | SetSources (Array Resource) a
   | SetAuthHeaders (Array RequestHeader) a

--- a/src/SlamData/FileSystem/Dialog/Download/Component/State.purs
+++ b/src/SlamData/FileSystem/Dialog/Download/Component/State.purs
@@ -19,18 +19,15 @@ module SlamData.FileSystem.Dialog.Download.Component.State where
 import SlamData.Prelude
 
 import Data.Array (findIndex)
-import Data.Either.Unsafe as U
 import Data.Lens (LensP, lens, (?~), (.~))
 
 import Network.HTTP.RequestHeader (RequestHeader)
 
 import SlamData.Download.Model (JSONOptions, CSVOptions, initialCSVOptions)
-import SlamData.FileSystem.Resource (Resource, resourceName, root, getPath)
+import SlamData.FileSystem.Resource (Resource, resourceName, getPath)
 
 type State =
-  { source ∷ Either String Resource
-  , sources ∷ (Array Resource)
-  , showSourcesList ∷ Boolean
+  { source ∷ Resource
   , targetName ∷ Either String String
   , compress ∷ Boolean
   , options ∷ Either CSVOptions JSONOptions
@@ -40,9 +37,7 @@ type State =
 
 initialState ∷ Resource → State
 initialState res =
-  { source: Right res
-  , sources: [root, res]
-  , showSourcesList: false
+  { source: res
   , targetName:
       let name = resourceName res
       in Right $ if name ≡ "" then "archive" else name
@@ -52,14 +47,8 @@ initialState res =
   , authHeaders: []
   }
 
-_source ∷ LensP State (Either String Resource)
+_source ∷ LensP State Resource
 _source = lens _.source (_ { source = _ })
-
-_sources ∷ LensP State (Array Resource)
-_sources = lens _.sources (_ { sources = _ })
-
-_showSourcesList ∷ LensP State Boolean
-_showSourcesList = lens _.showSourcesList (_ { showSourcesList = _ })
 
 _targetName ∷ LensP State (Either String String)
 _targetName = lens _.targetName (_ { targetName = _ })
@@ -78,10 +67,6 @@ _authHeaders = lens _.authHeaders (_{authHeaders = _})
 
 validate ∷ State → State
 validate r
-  | isLeft (r.source) =
-    r # _error ?~ "Please enter a valid source path to download"
-  | not $ checkExists (U.fromRight $ r.source) (r.sources) =
-    r # _error ?~ "The source resource does not exists"
   | isLeft (r.targetName) =
     r # _error ?~ "Please enter a valid target filename"
   | otherwise =


### PR DESCRIPTION
The source that was selected in filesystem is now printed instead:

<img width="758" alt="screen shot 2016-07-12 at 02 15 27" src="https://cloud.githubusercontent.com/assets/693642/16752100/9afcf832-47d6-11e6-8941-3e97c90f9e4c.png">

This simplifies the UI, and fixes the issue we had with loading in the entire filesystem into a dropdown.
