### PR TITLE
Update the version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "type": "git",
     "url": "https://github.com/slamdata/slamdata"
   },
-  "version": "v2.5.6",
+  "version": "v3.0.0",
   "contributors": [
     "Maxim Zimaliev <zimaliev@yandex.ru>",
     "Gary Burgess <gary@slamdata.com>",


### PR DESCRIPTION
Just wanted to draw your attention to this old version number which is hanging around in `package.json`. It looks like this version ends up getting displayed in the page title, at least on the demo box (see https://github.com/slamdata/slamdata/blob/07f6d23afd188dd299b84fd0143c02856443d4fd/src/SlamData/FileSystem.purs#L76). Weirdly, in cloud, I see a different version in the page title ("2.5.6", without the "v").

There's probably a better way to fix this, so that this version doesn't need to be manually updated.