### PR TITLE
Fix inset shadow issue in FF

### DIFF
--- a/less/deck/draftboard-card.less
+++ b/less/deck/draftboard-card.less
@@ -19,6 +19,8 @@
 
   .sd-board-inset-shadow {
     position: fixed;
+    top: 0;
+    left: 0;
     width: 100%;
     height: 100%;
     z-index: 30;


### PR DESCRIPTION
Without these properties some strange things happen with the inset shadow size/position in firefox if the window is resized after scrolling a board card.

Bug spotted by @natefaubion.