### PR TITLE
SD-1784: chaining markdown cards

### DIFF
--- a/src/SlamData/Quasar/Query.purs
+++ b/src/SlamData/Quasar/Query.purs
@@ -20,6 +20,7 @@ module SlamData.Quasar.Query
   , compile
   , query
   , queryEJson
+  , queryEJsonVM
   , viewQuery
   , fileQuery
   , all
@@ -97,6 +98,17 @@ queryEJson
 queryEJson path sql =
   runQuasarF $ lmap QF.printQError <$>
     QF.readQueryEJson path sql SM.empty Nothing
+
+queryEJsonVM
+  ∷ ∀ eff m
+  . (Functor m, Affable (QEff eff) m)
+  ⇒ DirPath
+  → SQL
+  → SM.StrMap String
+  → m (Either String (Array EJS.EJson))
+queryEJsonVM path sql vm =
+  runQuasarF $ lmap QF.printQError
+    <$> QF.readQueryEJson path sql vm Nothing
 
 -- | Runs a query creating a view mount for the query.
 -- |

--- a/src/SlamData/Workspace/Card/Eval.purs
+++ b/src/SlamData/Workspace/Card/Eval.purs
@@ -126,13 +126,15 @@ evalCard input =
 evalMarkdownForm
   ∷ ∀ m
   . (Monad m, Affable SlamDataEffects m)
-  ⇒ SD.SlamDownP Port.VarMapValue
+  ⇒ (Port.VarMap × (SD.SlamDownP Port.VarMapValue))
   → MD.Model
   → m Port.VarMap
-evalMarkdownForm doc model = do
+evalMarkdownForm (vm × doc) model = do
   let inputState = SDH.formStateFromDocument doc
   -- TODO: find a way to smash these annotations if possible -js
-  fromEff (MDS.formStateToVarMap inputState model.state ∷ Eff.Eff SlamDataEffects Port.VarMap)
+  thisVarMap ←
+    fromEff (MDS.formStateToVarMap inputState model.state ∷ Eff.Eff SlamDataEffects Port.VarMap)
+  pure $ thisVarMap `SM.union` vm
 
 evalOpen
   ∷ ∀ m

--- a/src/SlamData/Workspace/Card/InsertableCardType.purs
+++ b/src/SlamData/Workspace/Card/InsertableCardType.purs
@@ -63,7 +63,7 @@ inputs =
   , SearchCard × [ Data ]
   , SetupChartCard × [ Data ]
   , SetupDownloadCard × [ Data ]
-  , SetupMarkdownCard × [ None ]
+  , SetupMarkdownCard × [ None, Variables ]
   , SetupVariablesCard × [ None ]
   , ShowChartCard × [ Chart ]
   , ShowDownloadCard × [ Download ]
@@ -83,11 +83,14 @@ outputs =
   , SetupDownloadCard × Download
   , SetupMarkdownCard × Markdown
   , SetupVariablesCard × Variables
+  , SetupVariablesCard × Markdown
   , ShowChartCard × Chart
   , ShowDownloadCard × Download
   , ShowMarkdownCard × Variables
+  , ShowMarkdownCard × Markdown
   , TableCard × Data
   , TroubleshootCard × Variables
+  , TroubleshootCard × Markdown
   ]
 
 contains ∷ ∀ a. (Eq a) ⇒ a → Array a → Boolean

--- a/src/SlamData/Workspace/Card/Variables/Eval.purs
+++ b/src/SlamData/Workspace/Card/Variables/Eval.purs
@@ -31,10 +31,11 @@ eval
   → Map.Map DeckId Port.URLVarMap
   → Model
   → Port.VarMap
-eval deckId urlVarMaps model = foldl alg SM.empty model.items
+eval deckId urlVarMaps model =
+  foldl alg SM.empty model.items
   where
   alg =
-    flip \{ name, fieldType, defaultValue } ->
+    flip \{ name, fieldType, defaultValue } →
       maybe id (SM.insert name) $ defaultValueToVarMapValue fieldType
         =<< (SM.lookup name =<< Map.lookup deckId urlVarMaps)
         <|> defaultValue

--- a/src/SlamData/Workspace/Deck/Component.purs
+++ b/src/SlamData/Workspace/Deck/Component.purs
@@ -257,10 +257,10 @@ eval opts@{ wiring } = case _ of
       H.fromAff $ Bus.write (DeckFocused st.id) wiring.messaging
     pure next
   HandleMessage msg next → do
-    st <- H.get
+    st ← H.get
     case msg of
       DeckFocused focusedDeckId →
-        when (st.id /= focusedDeckId && st.focused) $
+        when (st.id ≠ focusedDeckId && st.focused) $
           H.modify (DCS._focused .~ false)
       URLVarMapsUpdated →
         traverse_ runCard $ DCS.variablesCards st

--- a/test/src/Test/SlamData/Feature/Test/Markdown.purs
+++ b/test/src/Test/SlamData/Feature/Test/Markdown.purs
@@ -221,3 +221,27 @@ test = do
     Expect.cardsInTableColumnInLastCardToBeGT 8 "year" "1950"
     Expect.cardsInTableColumnInLastCardToNotEq 8 "type" "Gold"
     successMsg "Ok, Filtered query results by changing field values"
+
+  mdScenario "Markdown chaining" [] do
+    Interact.insertMdCardInLastDeck
+    Interact.provideMdInLastMdCard $
+      "state = {!``select distinct state from `/test-mount/testDb/zips` order by asc``}"
+      <> "(!``select state from `/test-mount/testDb/zips` limit 1 ``)"
+    Interact.accessNextCardInLastDeck
+    Interact.insertDisplayMarkdownCardInLastDeck
+
+    Interact.accessNextCardInLastDeck
+    Interact.insertMdCardInLastDeck
+    Interact.provideMdInLastMdCard $
+      "city = ___"
+      <> "(!``select city from `/test-mount/testDb/zips` where state = :state[0] order by asc limit 1``)"
+    Interact.accessNextCardInLastDeck
+    Interact.insertDisplayMarkdownCardInLastDeck
+    Expect.fieldInLastMdCard "city" "text" "AGAWAM"
+    Interact.accessPreviousCardInLastDeck
+    Interact.accessPreviousCardInLastDeck
+    Interact.selectFromDropdownInLastDeck "state" "RI"
+    Interact.accessNextCardInLastDeck
+    Interact.accessNextCardInLastDeck
+    Expect.fieldInLastMdCard "city" "text" "ASHAWAY"
+    successMsg "Ok, variables from md card could be used in md card"


### PR DESCRIPTION
fixes https://slamdata.atlassian.net/browse/SD-1784 

How to check 

First 
+ Create "Setup markdown" card
+ Type 
```markdown
state = {``!select distinct state from `/path/to/zips/test/file` ``}(!``select state from `/path/to/zips/test/file` limit 1 ``)
```
+ Create "Show markdown" card 
+ Mirror deck 
+ In mirror create "Setup markdown" card 
+ Type 
```markdown 
city = {``!select distinct city from `/path/to/zips/test/file` where state = :state[0] ``}(!`` select city from `/path/to/zips/test/file` limit 1 ``)
```
+ Create "Show markdown" card
+ Change selected value in the virst deck 

Second
+ Create "API" card 
+ Add there var named "state"
+ Get deck id from url make something like 
```javascript
"?vars=" + encodeURIComponent(JSON.stringify({deckIdFromURL: {state: "AK"}}))
```
+ Add this to url
+ Create "Setup markdown card" 
+ Type 
```markdown
city = {!``select distinct city from `/path/to/zips/test/file` where state = :state ``}(!`` select city from `/path/to/zips/test/file` limit ` ``)
```
+ Change `AK` in url with something like `FL`

Third
+ Create "Setup markdown" card
+ Type `foo = ___`
+ Create "Show markdown" card
+ Type something 
+ Create "Setup markdown" card
+ Type `bar = ___`
+ Create "Show markdown" card
+ Create "Troubleshooting" card 


@natefaubion Please review