### PR TITLE
SD-1865: Set embedded/published non-board card background to white

### DIFF
--- a/less/main.less
+++ b/less/main.less
@@ -39,14 +39,6 @@ body {
     background: #fff;
 }
 
-body.sd-workspace-page {
-  background: #eee;
-}
-
-body.sd-workspace-page.sd-embedded {
-  background: transparent;
-}
-
 ::-webkit-input-placeholder {
     color: #e0e0e0;
 }

--- a/less/workspace.less
+++ b/less/workspace.less
@@ -1,3 +1,12 @@
+body.sd-workspace-page.sd-embedded {
+  background: transparent;
+
+    // override the background for an embedded deck when the root card is a board
+    .sd-workspace.sd-published > div > .sd-deck-container > .sd-deck > .sd-card-slider > .sd-card > div > .sd-deck-card > div.sd-card-draftboard {
+      background: none;
+    }
+}
+
 .sd-workspace.sd-published {
 
   .sd-card-header {
@@ -13,6 +22,13 @@
   }
 
   > div > .sd-deck-container {
+
+    > .sd-deck > .sd-card-slider > .sd-card > div > .sd-deck-card {
+      // set the background colour for a published deck when the root card is a board
+      > div.sd-card-draftboard { background: #eee; }
+      // set the background colour for any other card (less specific selector)
+      > div { background: #fff; }
+    }
 
     > .sd-deck-frame {
      display: none;


### PR DESCRIPTION
Without this the card background is grey in publish mode and transparent when embedded - we only want that when the root card is a board card.