### PR TITLE
Bump purescript dependency so it works with node 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "platform": "^1.3.0",
     "pngparse": "^2.0.1",
     "pulp": "^8.1.1",
-    "purescript": "^0.8.5",
+    "purescript": "^0.8.6-rc.1",
     "purescript-psa": "^0.3.6",
     "rimraf": "^2.4.3",
     "run-sequence": "^1.1.5",


### PR DESCRIPTION
0.8.6-rc.1 is just PureScript 0.8.5, but a version that will work with node 6.