### PR TITLE
Batch workspace requests

### DIFF
--- a/src/SlamData/Workspace/Card/Draftboard/Common.purs
+++ b/src/SlamData/Workspace/Card/Draftboard/Common.purs
@@ -137,7 +137,7 @@ deleteGraph path parentId = fromAff $ runExceptT do
 
 replacePointer
   ∷ DeckId
-  → DeckId
+  → Maybe DeckId
   → CardId
   → Array (CM.Model)
   → Array (CM.Model)
@@ -155,7 +155,7 @@ replacePointer from to cid = map replace
       Just rect →
         decks
           # Map.delete from
-          # Map.insert to rect
+          # maybe id (flip Map.insert rect) to
 
 -- | This shouldn't be done in general, but since draftboards have no inputs or
 -- | outputs it's OK to just swap out the model for the cached card eval.

--- a/src/SlamData/Workspace/Component.purs
+++ b/src/SlamData/Workspace/Component.purs
@@ -24,12 +24,15 @@ import SlamData.Prelude
 
 import Control.Monad.Aff.Bus as Bus
 import Control.Monad.Aff.Free (class Affable)
+import Control.Monad.Aff.Par (Par(..), runPar)
 import Control.Monad.Eff.Exception as Exn
 import Control.Monad.Eff.Ref as Ref
+import Control.Monad.Except.Trans (ExceptT(..), runExceptT)
 import Control.Monad.Maybe.Trans (MaybeT(..), runMaybeT)
 import Control.UI.Browser (setHref, locationObject)
 
 import Data.Array as Array
+import Data.Foldable (intercalate)
 import Data.Lens ((^.), (.~), (?~))
 import Data.List as List
 import Data.Map as Map
@@ -209,69 +212,65 @@ peek ∷ ∀ a. Wiring → ChildQuery a → WorkspaceDSL Unit
 peek wiring = ((const $ pure unit) ⨁ peekDeck) ⨁ (const $ pure unit)
   where
   peekDeck (Deck.DoAction (Deck.Unwrap decks) _) = void $ runMaybeT do
-    state ← lift H.get
-    path ← MaybeT $ pure state.path
-    oldId ← MaybeT $ queryDeck $ H.request Deck.GetId
+    state  ← lift H.get
+    path   ← MaybeT $ pure state.path
+    oldId  ← MaybeT $ queryDeck $ H.request Deck.GetId
     parent ← lift $ join <$> queryDeck (H.request Deck.GetParent)
     newId × (_ × deck) ← MaybeT $ pure $ List.head $ Map.toList decks
+
     let deck' = deck { parent = parent }
 
-    lift do
-      queryDeck $ H.action $ Deck.SetModel newId deck' DL.root
-      queryDeck $ H.action $ Deck.Save Nothing
+    error ← lift $ runExceptT do
+      req1 ← ExceptT $ putDeck path newId deck' wiring.decks
+      updateParentPointer wiring path oldId newId parent
 
-      case parent of
-        Just parentCoord@(Tuple deckId cardId) → do
-          getDeck path deckId wiring.decks >>= case _ of
-            Left err → Notify.loadParentFail err wiring.notify
-            Right parentDeck → void do
-              let cards = DBC.replacePointer oldId newId cardId parentDeck.cards
-              notifyWith Notify.saveDeckFail wiring.notify
-                $ putDeck path deckId (parentDeck { cards = cards }) wiring.decks
-          varMaps ← H.fromEff $ Ref.readRef wiring.urlVarMaps
-          let deckHash = mkWorkspaceHash (Deck.deckPath' path newId) (WA.Load state.accessType) varMaps
-          H.fromEff $ locationObject >>= Location.setHash deckHash
-        Nothing → do
-          let index = path </> Pathy.file "index"
-          void $ Model.setRoot index newId
+    case error of
+      Left err → Notify.error_ "Failed to unwrap deck." (Just err) Nothing wiring.notify
+      Right _  → updateHash wiring path state.accessType newId
 
   peekDeck (Deck.DoAction Deck.Wrap _) = void $ runMaybeT do
-    path ← MaybeT $ H.gets _.path
-    let index = path </> Pathy.file "index"
-    parent ← lift $ join <$> queryDeck (H.request Deck.GetParent)
+    state ← lift H.get
+    path  ← MaybeT $ pure state.path
+    deck  ← MaybeT $ queryDeck (H.request Deck.GetModel)
     oldId ← MaybeT $ queryDeck (H.request Deck.GetId)
     newId ← lift $ H.fromEff freshDeckId
 
-    let transitionDeck newDeck = do
-          traverse_ (queryDeck ∘ H.action)
-            [ Deck.SetParent (Tuple newId (CID.CardId 0))
-            , Deck.Save Nothing
-            , Deck.Reset path
-            , Deck.SetModel newId newDeck DL.root
-            , Deck.Save Nothing
-            ]
+    let
+      deck' = deck { parent = Just (newId × CID.CardId 0) }
+      wrapper = (wrappedDeck defaultPosition oldId) { parent = deck.parent }
 
-    lift case parent of
-      Just (Tuple deckId cardId) → do
-        getDeck path deckId wiring.decks >>= case _ of
-          Left err → Notify.loadParentFail err wiring.notify
-          Right parentDeck → void do
-            let cards = DBC.replacePointer oldId newId cardId parentDeck.cards
-            notifyWith Notify.saveDeckFail wiring.notify
-              $ putDeck path deckId (parentDeck { cards = cards }) wiring.decks
-            for_ cards (DBC.unsafeUpdateCachedDraftboard wiring deckId)
-            transitionDeck $ (wrappedDeck defaultPosition oldId) { parent = parent }
-      Nothing → void do
-        transitionDeck $ wrappedDeck defaultPosition oldId
-        notifyWith Notify.setRootFail wiring.notify
-          $ Model.setRoot index newId
-  peekDeck (Deck.DoAction Deck.DeleteDeck _) = do
-    st ← H.get
-    for_ st.path \path → do
-      res ← Quasar.delete $ Left path
-      case res of
-        Left err → Notify.deleteDeckFail (Exn.message err) wiring.notify
-        Right _ → void $ H.fromEff $ setHref $ parentURL $ Left path
+    error ← lift $ runExceptT do
+      ExceptT $ map (errors "; ") $ H.fromAff $ runPar $ traverse Par
+        [ putDeck path oldId deck' wiring.decks
+        , putDeck path newId wrapper wiring.decks
+        ]
+      updateParentPointer wiring path oldId newId deck.parent
+
+    case error of
+      Left err → Notify.error_ "Failed to wrap deck." (Just err) Nothing wiring.notify
+      Right _  → updateHash wiring path state.accessType newId
+
+  peekDeck (Deck.DoAction Deck.DeleteDeck _) = void $ runMaybeT do
+    state  ← lift H.get
+    path   ← MaybeT $ pure state.path
+    oldId  ← MaybeT $ queryDeck (H.request Deck.GetId)
+    parent ← lift $ join <$> queryDeck (H.request Deck.GetParent)
+    error  ← lift $ runExceptT do
+      case parent of
+        Just (deckId × cardId) → do
+          parentDeck ← ExceptT $ getDeck path deckId wiring.decks
+          let cards = DBC.replacePointer oldId Nothing cardId parentDeck.cards
+          lift $ for_ cards (DBC.unsafeUpdateCachedDraftboard wiring deckId)
+          ExceptT $ putDeck path deckId (parentDeck { cards = cards }) wiring.decks
+        Nothing →
+          ExceptT $ map (lmap Exn.message) $ Quasar.delete $ Left path
+
+    case error of
+      Left err → Notify.deleteDeckFail err wiring.notify
+      Right _  → case parent of
+        Just (deckId × _) → updateHash wiring path state.accessType deckId
+        Nothing → void $ H.fromEff $ setHref $ parentURL $ Left path
+
   peekDeck (Deck.DoAction Deck.Mirror _) = void $ runMaybeT do
     state ← lift H.get
     path ← MaybeT $ pure state.path
@@ -281,7 +280,6 @@ peek wiring = ((const $ pure unit) ⨁ peekDeck) ⨁ (const $ pure unit)
     oldId ← MaybeT $ queryDeck (H.request Deck.GetId)
     oldModel ← MaybeT $ queryDeck (H.request Deck.GetModel)
     let
-      index = path </> Pathy.file "index"
       freshCard = CID.CardId 0
       parentRef = Just (newIdParent × freshCard)
       wrappedDeck = DM.emptyDeck
@@ -297,42 +295,35 @@ peek wiring = ((const $ pure unit) ⨁ peekDeck) ⨁ (const $ pure unit)
             }
           }
         }
-    if Array.null oldModel.cards
-      then do
-        let mirrored = oldModel { parent = parentRef }
-        traverse_ (notifyWith Notify.saveDeckFail wiring.notify)
-          [ putDeck path oldId mirrored wiring.decks
-          , putDeck path newIdMirror mirrored wiring.decks
-          ]
-      else do
-        let
-          mirrored = oldModel
-            { parent = parentRef
-            , mirror = oldModel.mirror <> map (Tuple newIdShared ∘ _.cardId) oldModel.cards
-            , cards = []
-            , name = oldModel.name
-            }
-        traverse_ (notifyWith Notify.saveDeckFail wiring.notify)
-          [ putDeck path oldId mirrored wiring.decks
-          , putDeck path newIdMirror (mirrored { name = "" }) wiring.decks
-          , putDeck path newIdShared (oldModel { name = "" }) wiring.decks
-          ]
-    notifyWith Notify.saveDeckFail wiring.notify
-      $ putDeck path newIdParent wrappedDeck wiring.decks
-    lift case oldModel.parent of
-      Just (Tuple deckId cardId) →
-        getDeck path deckId wiring.decks >>= case _ of
-          Left err → Notify.loadParentFail err wiring.notify
-          Right parentDeck → void do
-            let cards = DBC.replacePointer oldId newIdParent cardId parentDeck.cards
-            notifyWith Notify.saveDeckFail wiring.notify
-              $ putDeck path deckId (parentDeck { cards = cards }) wiring.decks
-            for_ cards (DBC.unsafeUpdateCachedDraftboard wiring deckId)
-      Nothing →
-        void $ Model.setRoot index newIdParent
-    varMaps ← H.fromEff $ Ref.readRef wiring.urlVarMaps
-    let deckHash = mkWorkspaceHash (Deck.deckPath' path newIdParent) (WA.Load state.accessType) varMaps
-    H.fromEff $ locationObject >>= Location.setHash deckHash
+    error ← lift $ runExceptT do
+      ExceptT $ map (errors "; ") $ H.fromAff $ runPar $ traverse Par
+        if Array.null oldModel.cards
+        then
+          let
+            mirrored = oldModel { parent = parentRef }
+          in
+            [ putDeck path oldId mirrored wiring.decks
+            , putDeck path newIdMirror mirrored wiring.decks
+            ]
+        else
+          let
+            mirrored = oldModel
+              { parent = parentRef
+              , mirror = oldModel.mirror <> map (Tuple newIdShared ∘ _.cardId) oldModel.cards
+              , cards = []
+              , name = oldModel.name
+              }
+          in
+            [ putDeck path oldId mirrored wiring.decks
+            , putDeck path newIdMirror (mirrored { name = "" }) wiring.decks
+            , putDeck path newIdShared (oldModel { name = "" }) wiring.decks
+            ]
+      ExceptT $ putDeck path newIdParent wrappedDeck wiring.decks
+      updateParentPointer wiring path oldId newIdParent oldModel.parent
+
+    case error of
+      Left err → Notify.error_ "Failed to mirror deck." (Just err) Nothing wiring.notify
+      Right _  → updateHash wiring path state.accessType newIdParent
 
   peekDeck _ = pure unit
 
@@ -359,3 +350,45 @@ notifyWith notify bus action =
   action >>= case _ of
     Left err → notify err bus
     Right _  → pure unit
+
+lefts ∷ ∀ a b. Array (Either a b) → Array a
+lefts = Array.mapMaybe fromLeft
+
+fromLeft ∷ ∀ a b. Either a b → Maybe a
+fromLeft = either Just (const Nothing)
+
+errors ∷ ∀ m b. (Monoid m) ⇒ m → Array (Either m b) → Either m Unit
+errors m es = case (lefts es) of
+  [] → Right unit
+  ss → Left $ intercalate m ss
+
+updateParentPointer
+  ∷ ∀ m
+  . (Affable SlamDataEffects m, Monad m)
+  ⇒ Wiring
+  → UP.DirPath
+  → DeckId
+  → DeckId
+  → Maybe (DeckId × CID.CardId)
+  → ExceptT String m Unit
+updateParentPointer wiring path oldId newId = case _ of
+  Just (deckId × cardId) → do
+    parentDeck ← ExceptT $ getDeck path deckId wiring.decks
+    let cards = DBC.replacePointer oldId (Just newId) cardId parentDeck.cards
+    lift $ for_ cards (DBC.unsafeUpdateCachedDraftboard wiring deckId)
+    ExceptT $ putDeck path deckId (parentDeck { cards = cards }) wiring.decks
+  Nothing →
+    ExceptT $ Model.setRoot (path </> Pathy.file "index") newId
+
+updateHash
+  ∷ ∀ m
+  . (Affable SlamDataEffects m)
+  ⇒ Wiring
+  → UP.DirPath
+  → AT.AccessType
+  → DeckId
+  → m Unit
+updateHash wiring path accessType newId = H.fromEff do
+  varMaps ← Ref.readRef wiring.urlVarMaps
+  let deckHash = mkWorkspaceHash (Deck.deckPath' path newId) (WA.Load accessType) varMaps
+  locationObject >>= Location.setHash deckHash

--- a/src/SlamData/Workspace/Deck/BackSide/Component.purs
+++ b/src/SlamData/Workspace/Deck/BackSide/Component.purs
@@ -200,7 +200,7 @@ render state =
         , HP.buttonType HP.ButtonButton
         ] ⊕ if enabled then [ HE.onClick (HE.input_ (DoAction action)) ] else [ ]
 
-      enabled = Str.contains filterString (Str.toLower $ labelAction action)
+      enabled = Str.contains filterString (Str.toLower $ labelAction action) && actionEnabled state action
       lbl = labelAction action ⊕ if enabled then "" else " disabled"
       icon = actionGlyph action
 

--- a/src/SlamData/Workspace/Wiring.purs
+++ b/src/SlamData/Workspace/Wiring.purs
@@ -128,7 +128,7 @@ putDeck
   → DeckId
   → Deck
   → Cache DeckId DeckRef
-  → m (Either String Deck)
+  → m (Either String Unit)
 putDeck path deckId deck cache = fromAff do
   ref ← defer do
     res ← Quasar.save (deckIndex path deckId) $ encode deck
@@ -136,7 +136,7 @@ putDeck path deckId deck cache = fromAff do
       modifyVar (Map.delete deckId) cache
     pure $ bimap message (const deck) res
   modifyVar (Map.insert deckId ref) cache
-  wait ref
+  rmap (const unit) <$> wait ref
 
 putDeck'
   ∷ ∀ m


### PR DESCRIPTION
Also fixes a few other bugs. The delete case on the workspace was incorrect and always removed the entire workspace instead of removing the deck from its parent. Correctly disables the backside buttons.

Fixes #961

I didn't really touch the Draftboard because those were about as good as they'd get while still being relatively "safe".