### PR TITLE
Use `Affable` to free up `g ~ Aff`

### DIFF
--- a/src/Halogen/Component/Utils/Drag.purs
+++ b/src/Halogen/Component/Utils/Drag.purs
@@ -20,7 +20,6 @@ import Prelude
 
 import Control.Monad.Aff (Canceler(..), forkAff, launchAff, runAff)
 import Control.Monad.Aff.AVar (makeVar, makeVar', takeVar, putVar, AVAR)
-import Control.Monad.Aff.Class (class MonadAff)
 import Control.Monad.Aff.Free (class Affable, fromAff)
 import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Class (liftEff)
@@ -124,7 +123,6 @@ begin ev = fromAff do
 subscribe'
   ∷ ∀ s s' f f' g p eff
   . ( Affable (DragEffects eff) g
-    , MonadAff (DragEffects eff) g
     , Monad g
     )
   ⇒ Event MouseEvent

--- a/src/SlamData/FileSystem.purs
+++ b/src/SlamData/FileSystem.purs
@@ -35,7 +35,7 @@ import Data.Path.Pathy ((</>), rootDir, parseAbsDir, sandbox, currentDir)
 
 import DOM (DOM)
 
-import Halogen.Component (parentState)
+import Halogen.Component (parentState, interpret)
 import Halogen.Driver (Driver, runUI)
 import Halogen.Query (action)
 import Halogen.Util (runHalogenAff, awaitBody)
@@ -47,7 +47,7 @@ import Routing (matchesAff)
 import SlamData.Analytics as Analytics
 import SlamData.Config as Config
 import SlamData.Config.Version (slamDataVersion)
-import SlamData.Effects (SlamDataEffects, SlamDataRawEffects)
+import SlamData.Effects (SlamDataEffects, SlamDataRawEffects, unSlamF)
 import SlamData.FileSystem.Component (QueryP, Query(..), toListing, toDialog, toSearch, toFs, initialState, comp)
 import SlamData.FileSystem.Dialog.Component as Dialog
 import SlamData.FileSystem.Listing.Component as Listing
@@ -76,7 +76,8 @@ main = do
   runHalogenAff do
     forkAff Analytics.enableAnalytics
     wiring ← makeWiring
-    driver ← runUI (comp wiring) (parentState initialState) =<< awaitBody
+    let ui = interpret unSlamF $ comp wiring
+    driver ← runUI ui (parentState initialState) =<< awaitBody
     forkAff do
       setSlamDataTitle slamDataVersion
       driver (left $ action $ SetVersion slamDataVersion)

--- a/src/SlamData/FileSystem/Component.purs
+++ b/src/SlamData/FileSystem/Component.purs
@@ -24,8 +24,6 @@ module SlamData.FileSystem.Component
 import SlamData.Prelude
 
 import Control.Monad.Aff.Bus as Bus
-import Control.Monad.Eff.Exception (error)
-import Control.Monad.Error.Class (throwError)
 import Control.Monad.Except.Trans (ExceptT(..), runExceptT)
 import Control.UI.Browser (setLocation, locationString, clearValue)
 import Control.UI.Browser.Event as Be
@@ -223,9 +221,11 @@ eval wiring (FileListChanged el next) = do
   H.fromEff $ clearValue el
   case head fileArr of
     Nothing →
-      let err ∷ Slam Unit
-          err = throwError $ error "empty filelist"
-      in H.fromAff err
+      -- TODO: notification? this shouldn't be a runtime exception anyway!
+      -- let err ∷ Slam Unit
+      --     err = throwError $ error "empty filelist"
+      -- in H.fromAff err
+      pure unit
     Just f → uploadFileSelected wiring f
   pure next
 

--- a/src/SlamData/FileSystem/Dialog/Mount/SQL2/Component.purs
+++ b/src/SlamData/FileSystem/Dialog/Mount/SQL2/Component.purs
@@ -25,15 +25,13 @@ module SlamData.FileSystem.Dialog.Mount.SQL2.Component
 
 import SlamData.Prelude
 
-import Control.Monad.Eff.Class (liftEff)
-
 import Data.Array (filter)
 import Data.Path.Pathy as Pt
 import Data.StrMap as Sm
 
 import Ace.Editor as Editor
 import Ace.EditSession as Session
-import Ace.Halogen.Component (AceQuery(..), AceState, Autocomplete(..), aceConstructor)
+import Ace.Halogen.Component (AceQuery(..), AceState, Autocomplete(..), aceComponent, initialAceState)
 import Ace.Types (Editor)
 
 import Halogen as H
@@ -62,7 +60,11 @@ render state@{ initialQuery } =
   HH.div
     [ HP.key "mount-sql2" ]
     [ section "SQL² query"
-        [ HH.Slot (aceConstructor unit (aceSetup initialQuery) (Just Live)) ]
+        [ HH.slot unit \_ →
+            { component: aceComponent (aceSetup initialQuery) (Just Live)
+            , initialState: initialAceState
+            }
+        ]
     , section "Query variables" [ propList _vars state ]
     ]
 
@@ -81,7 +83,7 @@ eval wiring (Submit parent name k) = do
   pure $ k $ map (const view) result
 
 aceSetup ∷ Maybe String → Editor → Slam Unit
-aceSetup initialQuery editor = liftEff do
+aceSetup initialQuery editor = H.fromEff do
   Editor.setMinLines 6 editor
   Editor.setMaxLines 10000 editor
   Editor.setAutoScrollEditorIntoView true editor

--- a/src/SlamData/FileSystem/Search/Component.purs
+++ b/src/SlamData/FileSystem/Search/Component.purs
@@ -172,7 +172,6 @@ eval (Typed str next) = do
     Nothing → do
       t' ←
         debouncedEventSource
-          H.fromEff
           H.subscribe
           (Milliseconds Config.searchTimeout)
       H.modify (_trigger .~ pure t')

--- a/src/SlamData/Workspace.purs
+++ b/src/SlamData/Workspace.purs
@@ -35,12 +35,12 @@ import DOM.HTML.Window (document)
 import DOM.Node.Element (setClassName)
 import DOM.HTML.Types (htmlElementToElement)
 
-import Halogen (Driver, runUI, parentState)
+import Halogen (Driver, runUI, parentState, interpret)
 import Halogen.Util (runHalogenAff, awaitBody)
 
 import SlamData.Analytics as Analytics
 import SlamData.Config as Config
-import SlamData.Effects (SlamDataRawEffects, SlamDataEffects)
+import SlamData.Effects (SlamDataRawEffects, SlamDataEffects, unSlamF)
 import SlamData.Workspace.AccessType as AT
 import SlamData.Workspace.Action (Action(..), toAccessType)
 import SlamData.Workspace.Component as Workspace
@@ -64,7 +64,8 @@ main = do
     let st = Workspace.initialState (Just "3.0")
     wiring ← makeWiring
     forkAff (Analytics.consumeEvents wiring.analytics)
-    driver ← runUI (Workspace.comp wiring) (parentState st) =<< awaitBody
+    let ui = interpret unSlamF $ Workspace.comp wiring
+    driver ← runUI ui (parentState st) =<< awaitBody
     forkAff (routeSignal driver)
   StyleLoader.loadStyles
 

--- a/src/SlamData/Workspace/Card/Chart/Component.purs
+++ b/src/SlamData/Workspace/Card/Chart/Component.purs
@@ -18,8 +18,8 @@ module SlamData.Workspace.Card.Chart.Component (chartComponent) where
 
 import SlamData.Prelude
 
+import Control.Monad.Aff (Aff)
 
-import Data.Argonaut (JArray)
 import Data.Array as A
 import Data.Foreign (Foreign, ForeignError(TypeMismatch), readInt, readString)
 import Data.Foreign.Class (readProp)
@@ -43,9 +43,8 @@ import Halogen.HTML.Properties.Indexed as HP
 import Halogen.HTML.Properties.Indexed.ARIA as ARIA
 import Halogen.Themes.Bootstrap3 as B
 
-import SlamData.Effects (Slam)
+import SlamData.Effects (Slam, SlamDataEffects)
 import SlamData.Quasar.Aff (Wiring)
-import SlamData.Quasar.Error as QE
 import SlamData.Quasar.Query as Quasar
 import SlamData.Render.CSS as RC
 import SlamData.Workspace.Card.CardType as CT
@@ -136,7 +135,7 @@ eval wiring = case _ of
         -- Basically something equivalent to the old `needsToUpdate`. -gb
         records ←
           either (const []) id
-            <$> H.fromAff (Quasar.all wiring options.resource ∷ Slam (Either QE.QError JArray))
+            <$> (H.fromAff ∷ Aff SlamDataEffects ~> ChartDSL) (Quasar.all wiring options.resource)
         let optionDSL = BO.buildOptions opts config records
         H.query unit $ H.action $ HEC.Set optionDSL
         H.query unit $ H.action HEC.Resize

--- a/src/SlamData/Workspace/Card/Common/EvalQuery.purs
+++ b/src/SlamData/Workspace/Card/Common/EvalQuery.purs
@@ -26,7 +26,7 @@ module SlamData.Workspace.Card.Common.EvalQuery
 
 import SlamData.Prelude
 
-import Control.Monad.Aff (Aff)
+import Control.Monad.Aff.Free (class Affable)
 import Control.Monad.Aff.AVar (AVAR)
 
 import Halogen as H
@@ -80,31 +80,35 @@ data ModelUpdateType
 -- | Raises a `ModelUpdateType` self-query for a card that is a standalone
 -- | component.
 raiseUpdatedC
-  ∷ ∀ s eff
-  . ModelUpdateType
-  → H.ComponentDSL s CardEvalQuery (Aff (avar ∷ AVAR | eff)) Unit
+  ∷ ∀ s g eff
+  . (Affable (avar ∷ AVAR | eff) g, Functor g)
+  ⇒ ModelUpdateType
+  → H.ComponentDSL s CardEvalQuery g Unit
 raiseUpdatedC updateType = raise $ H.action $ ModelUpdated updateType
 
 -- | Raises a `ModelUpdateType` self-query for a card that is a standalone
 -- | component with an expanded query algebra.
 raiseUpdatedC'
-  ∷ ∀ f s eff
-  . ModelUpdateType
-  → H.ComponentDSL s (CardEvalQuery ⨁ f) (Aff (avar ∷ AVAR | eff)) Unit
+  ∷ ∀ f s g eff
+  . (Affable (avar ∷ AVAR | eff) g, Functor g)
+  ⇒ ModelUpdateType
+  → H.ComponentDSL s (CardEvalQuery ⨁ f) g Unit
 raiseUpdatedC' updateType = raise $ left $ H.action $ ModelUpdated updateType
 
 -- | Raises a `ModelUpdateType` self-query for a card that is a parent
 -- | component.
 raiseUpdatedP
-  ∷ ∀ s s' f' p eff
-  . ModelUpdateType
-  → H.ParentDSL s s' CardEvalQuery f' (Aff (avar ∷ AVAR | eff)) p Unit
+  ∷ ∀ s s' f' p g eff
+  . (Affable (avar ∷ AVAR | eff) g, Functor g)
+  ⇒ ModelUpdateType
+  → H.ParentDSL s s' CardEvalQuery f' g p Unit
 raiseUpdatedP updateType = raise' $ H.action $ ModelUpdated updateType
 
 -- | Raises a `ModelUpdateType` self-query for a card that is a parent
 -- | component with an expanded query algebra.
 raiseUpdatedP'
-  ∷ ∀ s s' f f' p eff
-  . ModelUpdateType
-  → H.ParentDSL s s' (CardEvalQuery ⨁ f) f' (Aff (avar ∷ AVAR | eff)) p Unit
+  ∷ ∀ s s' f f' p g eff
+  . (Affable (avar ∷ AVAR | eff) g, Functor g)
+  ⇒ ModelUpdateType
+  → H.ParentDSL s s' (CardEvalQuery ⨁ f) f' g p Unit
 raiseUpdatedP' updateType = raise' $ left $ H.action $ ModelUpdated updateType

--- a/src/SlamData/Workspace/Component.purs
+++ b/src/SlamData/Workspace/Component.purs
@@ -22,6 +22,7 @@ module SlamData.Workspace.Component
 
 import SlamData.Prelude
 
+import Control.Monad.Aff (Aff)
 import Control.Monad.Aff.Bus as Bus
 import Control.Monad.Aff.Free (class Affable)
 import Control.Monad.Eff.Exception as Exn
@@ -254,7 +255,7 @@ peek wiring = ((const $ pure unit) ⨁ peekDeck) ⨁ (const $ pure unit)
       wrapper = (wrappedDeck defaultPosition oldId) { parent = deck.parent }
 
     error ← lift $ runExceptT do
-      ExceptT $ map (errors "; ") $ (H.fromAff :: Slam ~> WorkspaceDSL) $ runParallel $ traverse parallel
+      ExceptT $ map (errors "; ") $ (H.fromAff :: Aff SlamDataEffects ~> WorkspaceDSL) $ runParallel $ traverse parallel
         [ putDeck path oldId deck' wiring
         , putDeck path newId wrapper wiring
         ]
@@ -320,7 +321,7 @@ peek wiring = ((const $ pure unit) ⨁ peekDeck) ⨁ (const $ pure unit)
           }
         }
     error ← lift $ runExceptT do
-      ExceptT $ map (errors "; ") $ (H.fromAff :: Slam ~> WorkspaceDSL) $ runParallel $ traverse parallel
+      ExceptT $ map (errors "; ") $ (H.fromAff :: Aff SlamDataEffects ~> WorkspaceDSL) $ runParallel $ traverse parallel
         if Array.null oldModel.cards
         then
           let


### PR DESCRIPTION
Includes proof of concept non-`Aff` monad to ensure that it works everywhere in the codebase.