### PR TITLE
Guide authors to add card using next card (and access next card guide changes)

### DIFF
--- a/less/deck.less
+++ b/less/deck.less
@@ -256,7 +256,7 @@ button.sd-zoom-deck {
   background-size: 100% 100%;
 }
 
-.sd-add-card-guide {
+.sd-access-next-card-guide {
   position: absolute;
   top: 50%;
   right: 0;
@@ -268,14 +268,14 @@ button.sd-zoom-deck {
   animation-fill-mode: both;
 }
 
-.sd-add-card-guide .sd-notification {
+.sd-access-next-card-guide .sd-notification {
   display: block;
   border-top: 3px solid #337ab7;
   margin: 0;
   box-shadow: 0 2px 8px rgba(0,0,0,0.125);
 }
 
-.sd-add-card-guide .sd-notification::after, .sd-add-card-guide .sd-notification::before {
+.sd-access-next-card-guide .sd-notification::after, .sd-access-next-card-guide .sd-notification::before {
   left: 100%;
   top: 50%;
   border: solid transparent;
@@ -286,22 +286,18 @@ button.sd-zoom-deck {
   pointer-events: none;
 }
 
-.sd-add-card-guide .sd-notification::after {
+.sd-access-next-card-guide .sd-notification::after {
   border-color: rgba(255, 255, 255, 0);
   border-left-color: #FFF;
   border-width: 8px;
   margin-top: -8px;
 }
 
-.sd-add-card-guide .sd-notification::before {
+.sd-access-next-card-guide .sd-notification::before {
   border-color: rgba(204, 204, 204, 0);
   border-left-color: #cccccc;
   border-width: 9px;
   margin-top: -9px;
-}
-
-.sd-add-card-guide-dismiss {
-  float: right;
 }
 
 @import "deck/card";

--- a/less/deck/next-card.less
+++ b/less/deck/next-card.less
@@ -1,4 +1,34 @@
 @import "common";
+@keyframes pointDown {
+  from, 20%, 53%, 80%, to {
+    animation-timing-function: cubic-bezier(0.215, 0.610, 0.355, 1.000);
+    transform: translate3d(0, 0, 0);
+  }
+
+  40%, 43% {
+    animation-timing-function: cubic-bezier(0.755, 0.050, 0.855, 0.060);
+    transform: translate3d(0, -20%, 0);
+  }
+
+  70% {
+    animation-timing-function: cubic-bezier(0.755, 0.050, 0.855, 0.060);
+    transform: translate3d(0, -15%, 0);
+  }
+
+  90% {
+    transform: translate3d(0, -4%, 0);
+  }
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
 
 .sd-deck-backside, .sd-card-next-action {
 
@@ -65,7 +95,7 @@
     overflow: hidden;
     margin: 0;
     padding: 0;
-    min-height: ~"calc(100% - 4rem)";
+    min-height: ~"calc(100% - 128px)";
     li {
         display: inline-block;
         float: left;
@@ -155,4 +185,56 @@
       padding-bottom: 16.66666%;
     }
   }
+}
+
+.sd-add-card-guide {
+  margin: 0 auto 1.5rem auto;
+  z-index: 1000;
+  animation-name: pointDown, fadeIn;
+  animation-duration: 1s, 0.5s;
+  animation-fill-mode: both;
+  max-width: 100%;
+  width: 29rem;
+  max-height: 4rem;
+  position: static;
+}
+
+.sd-add-card-guide .sd-notification {
+  display: block;
+  transform: translate3d(0, 0.5rem, 0);
+  position: relative;
+  right: 0;
+  border-top: 3px solid #337ab7;
+  margin: 0;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.125);
+  width: 100%;
+}
+
+.sd-add-card-guide .sd-notification-text {
+  width: 100%;
+}
+
+.sd-add-card-guide .sd-notification::after, .sd-add-card-guide .sd-notification::before {
+  left: 50%;
+  top: 100%;
+  border: solid transparent;
+  content: " ";
+  height: 0;
+  width: 0;
+  position: absolute;
+  pointer-events: none;
+}
+
+.sd-add-card-guide .sd-notification::after {
+  border-color: rgba(255, 255, 255, 0);
+  border-top-color: #fff;
+  border-width: 8px;
+  margin-left: -8px;
+}
+
+.sd-add-card-guide .sd-notification::before {
+  border-color: rgba(204, 204, 204, 0);
+  border-top-color: #ccc;
+  border-width: 9px;
+  margin-left: -9px;
 }

--- a/less/deck/next-card.less
+++ b/less/deck/next-card.less
@@ -95,7 +95,7 @@
     overflow: hidden;
     margin: 0;
     padding: 0;
-    min-height: ~"calc(100% - 128px)";
+    min-height: ~"calc(100% - 4rem)";
     li {
         display: inline-block;
         float: left;

--- a/src/SlamData/Workspace/Card/Next/Component.purs
+++ b/src/SlamData/Workspace/Card/Next/Component.purs
@@ -81,7 +81,7 @@ render state =
         Guide.render
           (HH.className "sd-add-card-guide")
           (right ∘ DismissAddCardGuide)
-          addCardGuideTextEmptyDeck)
+          (addCardGuideText state.input))
     ⊕ [ HH.ul_ $ map nextButton CT.insertableCardTypes ]
   where
 
@@ -110,13 +110,9 @@ render state =
         ⊕ (guard enabled
              $> HE.onClick (HE.input_ (right ∘ addCardOrPresentReason state.input cty)))
 
-  cardGuideText =
-    "Cards retreive, process and present data, forms, charts and more."
-      ⊕ " Every card creates an output which can be passed to another."
-      ⊕ " By stacking cards into decks you can find valuable insights"
-      ⊕ " and do amazing things."
   addCardGuideTextEmptyDeck = "To get this deck started press one of these buttons to add a card."
   addCardGuideTextNonEmptyDeck = "To do more with this deck press one of these buttons to add a card."
+  addCardGuideText = maybe addCardGuideTextEmptyDeck (const addCardGuideTextNonEmptyDeck)
 
 eval ∷ QueryP ~> NextDSL
 eval = coproduct cardEval nextEval

--- a/src/SlamData/Workspace/Card/Next/Component.purs
+++ b/src/SlamData/Workspace/Card/Next/Component.purs
@@ -34,13 +34,17 @@ import Halogen.Themes.Bootstrap3 as B
 
 import SlamData.Monad (Slam)
 import SlamData.Render.Common (glyph)
+import SlamData.Workspace.Guide as Guide
 import SlamData.Workspace.Card.CardType as CT
 import SlamData.Workspace.Card.Component as CC
 import SlamData.Workspace.Card.Model as Card
 import SlamData.Workspace.Card.Next.Component.Query (QueryP, Query(..), _AddCardType, _PresentReason)
-import SlamData.Workspace.Card.Next.Component.State (State, initialState, _input, _filterString)
+import SlamData.Workspace.Card.Next.Component.State (State)
+import SlamData.Workspace.Card.Next.Component.State as State
 import SlamData.Workspace.Card.Port as Port
 import SlamData.Workspace.Card.InsertableCardType as ICT
+
+import Utils.LocalStorage as LocalStorage
 
 type NextHTML = H.ComponentHTML QueryP
 type NextDSL = H.ComponentDSL State QueryP Slam
@@ -48,8 +52,8 @@ type NextDSL = H.ComponentDSL State QueryP Slam
 nextCardComponent ∷ CC.CardComponent
 nextCardComponent = CC.makeCardComponent
   { cardType: CT.NextAction
-  , component: H.component {render, eval}
-  , initialState: initialState
+  , component: H.lifecycleComponent { initializer: Just $ right $ H.action $ Init, finalizer: Nothing, render, eval}
+  , initialState: State.initialState
   , _State: CC._NextState
   , _Query: CC.makeQueryPrism CC._NextQuery
   }
@@ -57,7 +61,8 @@ nextCardComponent = CC.makeCardComponent
 render ∷ State → NextHTML
 render state =
   HH.div_
-    [ HH.form_
+    $ (guard (not state.presentAddCardGuide) $>
+      HH.form_
         [ HH.div_
             [ HH.input
                 [ HP.value state.filterString
@@ -71,9 +76,13 @@ render state =
                 ]
                 [ glyph B.glyphiconRemove ]
             ]
-        ]
-    , HH.ul_ $ map nextButton CT.insertableCardTypes
-    ]
+        ])
+    ⊕ (guard state.presentAddCardGuide $>
+        Guide.render
+          (HH.className "sd-add-card-guide")
+          (right ∘ DismissAddCardGuide)
+          addCardGuideTextEmptyDeck)
+    ⊕ [ HH.ul_ $ map nextButton CT.insertableCardTypes ]
   where
 
   filterString ∷ String
@@ -101,6 +110,13 @@ render state =
         ⊕ (guard enabled
              $> HE.onClick (HE.input_ (right ∘ addCardOrPresentReason state.input cty)))
 
+  cardGuideText =
+    "Cards retreive, process and present data, forms, charts and more."
+      ⊕ " Every card creates an output which can be passed to another."
+      ⊕ " By stacking cards into decks you can find valuable insights"
+      ⊕ " and do amazing things."
+  addCardGuideTextEmptyDeck = "To get this deck started press one of these buttons to add a card."
+  addCardGuideTextNonEmptyDeck = "To do more with this deck press one of these buttons to add a card."
 
 eval ∷ QueryP ~> NextDSL
 eval = coproduct cardEval nextEval
@@ -108,7 +124,7 @@ eval = coproduct cardEval nextEval
 cardEval ∷ CC.CardEvalQuery ~> NextDSL
 cardEval = case _ of
   CC.EvalCard value output next →
-    H.modify (_input .~ value.input) $> next
+    H.modify (State._input .~ value.input) $> next
   CC.Activate next →
     pure next
   CC.Deactivate next →
@@ -139,8 +155,26 @@ addCardOrPresentReason input cardType a =
      then AddCard cardType a
      else PresentReason input cardType a
 
+dismissedAddCardGuideKey ∷ String
+dismissedAddCardGuideKey = "dismissedAddCardGuide"
+
+getDismissedAddCardGuideBefore ∷ NextDSL Boolean
+getDismissedAddCardGuideBefore =
+  H.liftH
+    $ either (const $ false) id
+    <$> LocalStorage.getLocalStorage dismissedAddCardGuideKey
+
+storeDismissedAddCardGuide ∷ NextDSL Unit
+storeDismissedAddCardGuide =
+  H.liftH $ LocalStorage.setLocalStorage dismissedAddCardGuideKey true
+
 nextEval ∷ Query ~> NextDSL
 nextEval (AddCard _ next) = pure next
 nextEval (PresentReason io card next) = pure next
 nextEval (UpdateFilter str next) =
-  H.modify (_filterString .~ str) $> next
+  H.modify (State._filterString .~ str) $> next
+nextEval (DismissAddCardGuide next) =
+  H.modify (State._presentAddCardGuide .~ false) *> storeDismissedAddCardGuide $> next
+nextEval (Init next) = do
+  H.modify ∘ (State._presentAddCardGuide .~ _) ∘ not =<< getDismissedAddCardGuideBefore
+  pure next

--- a/src/SlamData/Workspace/Card/Next/Component.purs
+++ b/src/SlamData/Workspace/Card/Next/Component.purs
@@ -168,13 +168,15 @@ storeDismissedAddCardGuide ∷ NextDSL Unit
 storeDismissedAddCardGuide =
   H.liftH $ LocalStorage.setLocalStorage dismissedAddCardGuideKey true
 
+dismissAddCardGuide ∷ NextDSL Unit
+dismissAddCardGuide =
+  H.modify (State._presentAddCardGuide .~ false) *> storeDismissedAddCardGuide
+
 nextEval ∷ Query ~> NextDSL
-nextEval (AddCard _ next) = pure next
+nextEval (AddCard _ next) = dismissAddCardGuide $> next
 nextEval (PresentReason io card next) = pure next
-nextEval (UpdateFilter str next) =
-  H.modify (State._filterString .~ str) $> next
-nextEval (DismissAddCardGuide next) =
-  H.modify (State._presentAddCardGuide .~ false) *> storeDismissedAddCardGuide $> next
+nextEval (UpdateFilter str next) = H.modify (State._filterString .~ str) $> next
+nextEval (DismissAddCardGuide next) = dismissAddCardGuide $> next
 nextEval (Init next) = do
   H.modify ∘ (State._presentAddCardGuide .~ _) ∘ not =<< getDismissedAddCardGuideBefore
   pure next

--- a/src/SlamData/Workspace/Card/Next/Component/Query.purs
+++ b/src/SlamData/Workspace/Card/Next/Component/Query.purs
@@ -26,6 +26,8 @@ data Query a
   = AddCard CardType a
   | PresentReason (Maybe Port) CardType a
   | UpdateFilter String a
+  | DismissAddCardGuide a
+  | Init a
 
 _AddCardType :: forall a. TraversalP (Query a) CardType
 _AddCardType =
@@ -33,6 +35,8 @@ _AddCardType =
     AddCard cty next → flip AddCard next <$> f cty
     PresentReason io card next → pure s
     UpdateFilter filter next → pure s
+    DismissAddCardGuide next → pure s
+    Init next → pure s
 
 _PresentReason :: forall a. TraversalP (Query a) (Tuple (Maybe Port) CardType)
 _PresentReason =
@@ -40,5 +44,7 @@ _PresentReason =
     AddCard cty next → pure s
     PresentReason io card next → (#) next <<< uncurry PresentReason <$> f (Tuple io card)
     UpdateFilter filter next → pure s
+    DismissAddCardGuide next → pure s
+    Init next → pure s
 
 type QueryP = CardEvalQuery ⨁ Query

--- a/src/SlamData/Workspace/Card/Next/Component/State.purs
+++ b/src/SlamData/Workspace/Card/Next/Component/State.purs
@@ -19,6 +19,7 @@ module SlamData.Workspace.Card.Next.Component.State
   , initialState
   , _input
   , _filterString
+  , _presentAddCardGuide
   ) where
 
 import SlamData.Prelude
@@ -30,11 +31,13 @@ import SlamData.Workspace.Card.Port (Port)
 type State =
   { input ∷ Maybe Port
   , filterString ∷ String
+  , presentAddCardGuide ∷ Boolean
   }
 
 initialState :: State
 initialState =
   { input: Nothing
+  , presentAddCardGuide: true
   , filterString: ""
   }
 
@@ -43,3 +46,6 @@ _input = lens _.input (_ { input = _ })
 
 _filterString ∷ ∀ a r. LensP { filterString ∷ a | r } a
 _filterString = lens _.filterString (_ { filterString = _ })
+
+_presentAddCardGuide ∷ ∀ a r. LensP { presentAddCardGuide ∷ a | r } a
+_presentAddCardGuide = lens _.presentAddCardGuide (_ { presentAddCardGuide = _ })

--- a/src/SlamData/Workspace/Deck/Component.purs
+++ b/src/SlamData/Workspace/Deck/Component.purs
@@ -129,7 +129,6 @@ eval opts = case _ of
       eb ← subscribeToBus' (H.action ∘ HandleError) wiring.globalError
       H.modify $ DCS._breakers %~ (Array.cons eb)
     updateCardSize
-    presentAccessNextActionCardGuideAfterDelay
     pure next
   PresentAccessNextActionCardGuide next → do
     H.modify (DCS._presentAccessNextActionCardGuide .~ true) $> next
@@ -513,6 +512,7 @@ updateBackSide { cursor } = do
 
 createCard ∷ CT.CardType → DeckDSL Unit
 createCard cardType = do
+  presentAccessNextActionCardGuideAfterDelay
   SA.track (SA.AddCard cardType)
   deckId ← H.gets _.id
   (st × newCardId) ← H.gets ∘ DCS.addCard' $ Card.cardModelOfType cardType
@@ -955,6 +955,7 @@ setModel opts model = do
   H.modify
     $ (DCS._stateMode .~ Preparing)
     ∘ DCS.fromModel model
+  presentAccessNextActionCardGuideAfterDelay
   case Array.head model.modelCards of
     Just _ → runInitialEval
     Nothing → runCardUpdates opts model.id L.Nil

--- a/src/SlamData/Workspace/Deck/Component/Query.purs
+++ b/src/SlamData/Workspace/Deck/Component/Query.purs
@@ -43,8 +43,8 @@ import Utils.Path as UP
 
 data Query a
   = Init a
-  | PresentAddCardGuide a
-  | HideAddCardGuide a
+  | PresentAccessNextActionCardGuide a
+  | HideAccessNextActionCardGuide a
   | Finish a
   | RunPendingCards PendingMessage a
   | QueuePendingCard a

--- a/src/SlamData/Workspace/Deck/Component/State.purs
+++ b/src/SlamData/Workspace/Deck/Component/State.purs
@@ -29,8 +29,8 @@ module SlamData.Workspace.Deck.Component.State
   , _displayCards
   , _activeCardIndex
   , _path
-  , _presentAddCardGuideCanceler
-  , _presentAddCardGuide
+  , _presentAccessNextActionCardGuideCanceler
+  , _presentAccessNextActionCardGuide
   , _saveTrigger
   , _runTrigger
   , _pendingCard
@@ -135,8 +135,8 @@ type State =
   , cardsToLoad ∷ Set.Set (DeckId × CardId)
   , activeCardIndex ∷ Maybe Int
   , path ∷ DirPath
-  , presentAddCardGuideCanceler ∷ Maybe (Canceler SlamDataEffects)
-  , presentAddCardGuide ∷ Boolean
+  , presentAccessNextActionCardGuideCanceler ∷ Maybe (Canceler SlamDataEffects)
+  , presentAccessNextActionCardGuide ∷ Boolean
   , saveTrigger ∷ Maybe (DebounceTrigger Query Slam)
   , runTrigger ∷ Maybe (DebounceTrigger Query Slam)
   , pendingCard ∷ Maybe (DeckId × CardId)
@@ -172,8 +172,8 @@ initialDeck path deckId =
   , cardsToLoad: mempty
   , activeCardIndex: Nothing
   , path
-  , presentAddCardGuideCanceler: Nothing
-  , presentAddCardGuide: false
+  , presentAccessNextActionCardGuideCanceler: Nothing
+  , presentAccessNextActionCardGuide: false
   , saveTrigger: Nothing
   , runTrigger: Nothing
   , pendingCard: Nothing
@@ -230,12 +230,12 @@ _path = lens _.path _{path = _}
 
 -- | An optional canceler for the delayed guiding of the user to add a card. Can
 -- | be used to reset the delay of this guiding.
-_presentAddCardGuideCanceler ∷ ∀ a r. LensP {presentAddCardGuideCanceler ∷ a |r} a
-_presentAddCardGuideCanceler = lens _.presentAddCardGuideCanceler _{presentAddCardGuideCanceler = _}
+_presentAccessNextActionCardGuideCanceler ∷ ∀ a r. LensP {presentAccessNextActionCardGuideCanceler ∷ a |r} a
+_presentAccessNextActionCardGuideCanceler = lens _.presentAccessNextActionCardGuideCanceler _{presentAccessNextActionCardGuideCanceler = _}
 
 -- | Whether the add card guide should be presented or not.
-_presentAddCardGuide ∷ ∀ a r. LensP {presentAddCardGuide ∷ a |r} a
-_presentAddCardGuide = lens _.presentAddCardGuide _{presentAddCardGuide = _}
+_presentAccessNextActionCardGuide ∷ ∀ a r. LensP {presentAccessNextActionCardGuide ∷ a |r} a
+_presentAccessNextActionCardGuide = lens _.presentAccessNextActionCardGuide _{presentAccessNextActionCardGuide = _}
 
 -- | The debounced trigger for deck save actions.
 _saveTrigger ∷ ∀ a r. LensP {saveTrigger ∷ a|r} a

--- a/src/SlamData/Workspace/Guide.purs
+++ b/src/SlamData/Workspace/Guide.purs
@@ -1,0 +1,43 @@
+{-
+Copyright 2016 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+module SlamData.Workspace.Guide where
+
+import Prelude
+import Halogen.HTML.Events.Indexed as HE
+import Halogen.HTML.Indexed as HH
+import Halogen.HTML.Properties.Indexed as HP
+import Halogen.HTML.Properties.Indexed.ARIA as ARIA
+
+render ∷ ∀ f a. HH.ClassName → (Unit → f Unit) → String → HH.HTML a (f Unit)
+render className dismissQuery text =
+  HH.div
+    [ HP.class_ className ]
+    [ HH.div
+        [ HP.class_ $ HH.className "sd-notification" ]
+        [ HH.div
+            [ HP.class_ $ HH.className "sd-notification-text" ]
+            [ HH.text text ]
+        , HH.div
+            [ HP.class_ $ HH.className "sd-notification-buttons" ]
+            [ HH.button
+                [ HP.classes [ HH.className "sd-notification-dismiss" ]
+                , HE.onClick (HE.input_ dismissQuery)
+                , ARIA.label "Dismiss"
+                ]
+                [ HH.text "×" ]
+            ]
+        ]
+    ]


### PR DESCRIPTION
![screen shot 2016-09-02 at 05 51 43](https://cloud.githubusercontent.com/assets/457901/18193033/98016d56-70d1-11e6-9ed1-70e5b542c907.png)

Struggled to find a way of presenting the guide clearly without disrupting the existing layout. I ended up making the guide take the place of the search field as new authors most likely don't know the names of the cards yet and so won't find it particularly useful. This leaves the layout quite unchanged and doesn't obscure any of the add card buttons.

I'm pretty happy with this but would love to hear some other ideas too.

FYI there is another more detailed guide which will be presented to authors who have never seen a deck before coming soon. This will be presented before this guide and explains cards.