### PR TITLE
Date.UTC month fix

### DIFF
--- a/src/SlamData/Workspace/Card/Markdown/Interpret.purs
+++ b/src/SlamData/Workspace/Card/Markdown/Interpret.purs
@@ -109,7 +109,7 @@ formFieldValueToVarMapValue v =
       JSD.toISOString $
         JSD.jsdate
           { year: Int.toNumber localDateTime.date.year
-          , month: Int.toNumber localDateTime.date.month
+          , month: (Int.toNumber localDateTime.date.month) - one
           , day: Int.toNumber localDateTime.date.day
           , hour: Int.toNumber localDateTime.time.hours
           , minute: Int.toNumber localDateTime.time.minutes


### PR DESCRIPTION
fixes #1063 

Mardown uses 1 based months, Date.UTC -- zero based :) 

@natefaubion Please take a look