### PR TITLE
Set literals for checkbox inputs

### DIFF
--- a/src/SlamData/Workspace/Card/Port.purs
+++ b/src/SlamData/Workspace/Card/Port.purs
@@ -44,7 +44,7 @@ import Data.Lens (PrismP, prism', TraversalP, wander)
 import ECharts.Monad (DSL)
 import ECharts.Types.Phantom (OptionI)
 
-import SlamData.Workspace.Card.Port.VarMap (VarMap, URLVarMap, VarMapValue(..), parseVarMapValue, renderVarMapValue, emptyVarMap)
+import SlamData.Workspace.Card.Port.VarMap (VarMap, URLVarMap, VarMapValue(..), renderVarMapValue, emptyVarMap)
 import SlamData.Workspace.Card.BuildChart.PivotTable.Model as PTM
 import SlamData.Workspace.Card.CardType.ChartType (ChartType)
 import SlamData.Workspace.Card.BuildChart.Axis (Axes)

--- a/test/src/Test/SlamData/Feature/Test/Markdown.purs
+++ b/test/src/Test/SlamData/Feature/Test/Markdown.purs
@@ -182,7 +182,7 @@ test = do
     Interact.accessNextCardInLastDeck
     Interact.insertQueryCardInLastDeck
     Interact.provideQueryInLastQueryCard
-      "SELECT * FROM `/test-mount/testDb/olympics` WHERE discipline = :discipline AND type != :type AND gender IN :gender[_] AND year > :year AND country = :country"
+      "SELECT * FROM `/test-mount/testDb/olympics` WHERE discipline = :discipline AND type != :type AND gender IN :gender AND year > :year AND country = :country"
     Interact.runQuery
     Interact.accessNextCardInLastDeck
     Interact.selectBuildChart
@@ -217,7 +217,7 @@ test = do
     Interact.accessNextCardInLastDeck
     Interact.insertQueryCardInLastDeck
     Interact.provideQueryInLastQueryCard
-      "SELECT * FROM `/test-mount/testDb/olympics` WHERE discipline = :discipline AND type != :type AND gender IN :gender[_] AND year > :year AND country = :country"
+      "SELECT * FROM `/test-mount/testDb/olympics` WHERE discipline = :discipline AND type != :type AND gender IN :gender AND year > :year AND country = :country"
     Interact.runQuery
     Interact.accessNextCardInLastDeck
     Interact.selectBuildChart


### PR DESCRIPTION
![checkbox-sets](https://cloud.githubusercontent.com/assets/144058/19162884/47e679a2-8bbf-11e6-95d9-f4ec8e35892c.gif)

I opted to not use the fixed-point encoding because it seemed unnecessary. If we only want to add set literals for the purpose of sending form data to Quasar, then there is no need to have a recursive encoding of sets + ejson. So I just added another variant to `VarMapValue`.

Fixes #1025