### PR TITLE
Add editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*.{js,json,purs,less}]
+charset = utf-8
+indent_style = space
+ident_size = 2
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ public/css/*.css
 npm-debug.log
 !.gitignore
 !.travis.yml
+!.editorconfig


### PR DESCRIPTION
As mentioned in #1095 

A bunch of text editors have native support for `.editorconfig` files, and those that don't probably have a plugin that makes it work instead: http://editorconfig.org/