### PR TITLE
Contain label

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -29,7 +29,7 @@
     "purescript-generics": "^1.0.1",
     "purescript-halogen-bootstrap": "^3.0.0",
     "purescript-halogen-css": "^3.0.0",
-    "purescript-halogen-echarts": "3e7cbc08cd83ae37e52d9aadf90c147d5f2a34b9",
+    "purescript-halogen-echarts": "d734bb269ab1bc38ff337dd5e54f34af2b315282",
     "purescript-halogen-menu": "^2.0.0",
     "purescript-halogen": "^0.11.0",
     "purescript-js-timers": "^1.0.0",

--- a/src/SlamData/Workspace/Card/BuildChart/Area/Component.purs
+++ b/src/SlamData/Workspace/Card/BuildChart/Area/Component.purs
@@ -20,7 +20,6 @@ module SlamData.Workspace.Card.BuildChart.Area.Component
 
 import SlamData.Prelude
 
-import Data.Int as Int
 import Data.Lens ((^?), (^.), (?~), (.~))
 import Data.Lens as Lens
 import Data.List as List
@@ -100,7 +99,7 @@ renderHighLOD state =
     , renderSeries state
     , HH.hr_
     , row [ renderIsStacked state, renderIsSmooth state ]
-    , row [ renderAxisLabelAngle state, renderAxisLabelFontSize state ]
+    , row [ renderAxisLabelAngle state ]
     , renderPicker state
     ]
 
@@ -179,21 +178,6 @@ renderAxisLabelAngle state =
         ]
     ]
 
-renderAxisLabelFontSize ∷ ST.State → HTML
-renderAxisLabelFontSize state =
-  HH.form
-    [ HP.classes [ B.colXs6, CSS.axisLabelParam ]
-    , Cp.nonSubmit
-    ]
-    [ HH.label [ HP.classes [ B.controlLabel ] ] [ HH.text "Label font size" ]
-    , HH.input
-        [ HP.classes [ B.formControl ]
-        , HP.value $ show $ state.axisLabelFontSize
-        , ARIA.label "Axis label font size"
-        , HE.onValueChange $ HE.input (\s → right ∘ Q.SetAxisLabelFontSize s)
-        ]
-    ]
-
 renderIsStacked ∷ ST.State → HTML
 renderIsStacked state =
   HH.form
@@ -250,7 +234,6 @@ cardEval = case _ of
         , isStacked: st.isStacked
         , isSmooth: st.isSmooth
         , axisLabelAngle: st.axisLabelAngle
-        , axisLabelFontSize: st.axisLabelFontSize
         }
         <$> (st.dimension ^. _value)
         <*> (st.value ^. _value)
@@ -261,7 +244,6 @@ cardEval = case _ of
     H.modify _{ isStacked = model.isStacked
               , isSmooth = model.isSmooth
               , axisLabelAngle = model.axisLabelAngle
-              , axisLabelFontSize = model.axisLabelFontSize
               }
     pure next
   CC.Load card next →
@@ -288,12 +270,6 @@ areaBuilderEval = case _ of
     let fl = readFloat str
     unless (isNaN fl) do
       H.modify _{axisLabelAngle = fl}
-      CC.raiseUpdatedP' CC.EvalModelUpdate
-    pure next
-  Q.SetAxisLabelFontSize str next → do
-    let mbFS = Int.fromString str
-    for_ mbFS \fs → do
-      H.modify _{axisLabelFontSize = fs}
       CC.raiseUpdatedP' CC.EvalModelUpdate
     pure next
   Q.ToggleSmooth next → do

--- a/src/SlamData/Workspace/Card/BuildChart/Area/Component/Query.purs
+++ b/src/SlamData/Workspace/Card/BuildChart/Area/Component/Query.purs
@@ -35,7 +35,6 @@ data Selection f
 
 data Query a
   = SetAxisLabelAngle String a
-  | SetAxisLabelFontSize String a
   | ToggleSmooth a
   | ToggleStacked a
   | Select (Selection SelectAction) a

--- a/src/SlamData/Workspace/Card/BuildChart/Area/Component/State.purs
+++ b/src/SlamData/Workspace/Card/BuildChart/Area/Component/State.purs
@@ -36,7 +36,6 @@ type State =
   { axes ∷ Axes
   , levelOfDetails ∷ LevelOfDetails
   , axisLabelAngle ∷ Number
-  , axisLabelFontSize ∷ Int
   , isStacked ∷ Boolean
   , isSmooth ∷ Boolean
   , dimension ∷ Select JCursor
@@ -51,7 +50,6 @@ initialState =
   { axes: initialAxes
   , levelOfDetails: High
   , axisLabelAngle: zero
-  , axisLabelFontSize: zero
   , isStacked: false
   , isSmooth: false
   , dimension: emptySelect

--- a/src/SlamData/Workspace/Card/BuildChart/Area/Eval.purs
+++ b/src/SlamData/Workspace/Card/BuildChart/Area/Eval.purs
@@ -48,7 +48,7 @@ import SlamData.Workspace.Card.BuildChart.Aggregation as Ag
 import SlamData.Workspace.Card.BuildChart.Axis as Ax
 import SlamData.Workspace.Card.BuildChart.Semantics (getMaybeString, getValues)
 import SlamData.Workspace.Card.BuildChart.ColorScheme (colors, getShadeColor)
-
+import SlamData.Workspace.Card.BuildChart.Common.Positioning as BCP
 import SlamData.Workspace.Card.Eval.CardEvalT as CET
 import SlamData.Workspace.Card.Port as Port
 
@@ -143,7 +143,6 @@ buildArea r records axes = do
     E.axisType ET.Value
     E.axisLabel $ E.textStyle do
       E.fontFamily "Ubuntu, sans"
-      E.fontSize r.axisLabelFontSize
     E.axisLine $ E.lineStyle do
       E.color $ C.rgba 184 184 184 1.0
       E.width 1
@@ -170,12 +169,11 @@ buildArea r records axes = do
     E.axisLabel do
       E.rotate r.axisLabelAngle
       E.textStyle do
-        E.fontSize r.axisLabelFontSize
         E.fontFamily "Ubuntu, sans"
 
   E.colors colors
 
-  E.grid $ E.containLabel true
+  E.grid BCP.cartesian
 
   E.legend do
     E.textStyle $ E.fontFamily "Ubuntu, sans"

--- a/src/SlamData/Workspace/Card/BuildChart/Area/Eval.purs
+++ b/src/SlamData/Workspace/Card/BuildChart/Area/Eval.purs
@@ -26,20 +26,15 @@ import Color as C
 import Data.Argonaut (JArray, Json)
 import Data.Array ((!!))
 import Data.Array as A
-import Data.Foldable as F
 import Data.Lens ((^?))
 import Data.Map as M
-import Data.Int as Int
 import Data.Set as Set
-import Data.String as Str
 
 import ECharts.Monad (DSL)
 import ECharts.Commands as E
 import ECharts.Types as ET
 import ECharts.Types.Phantom (OptionI)
 import ECharts.Types.Phantom as ETP
-
-import Math as Math
 
 import Quasar.Types (FilePath)
 
@@ -58,7 +53,6 @@ import SlamData.Workspace.Card.Eval.CardEvalT as CET
 import SlamData.Workspace.Card.Port as Port
 
 import Utils.Array (enumerate)
-import Utils.DOM (getTextWidthPure)
 
 eval
   ∷ ∀ m
@@ -181,7 +175,7 @@ buildArea r records axes = do
 
   E.colors colors
 
-  E.grid $ E.bottomPx labelHeight
+  E.grid $ E.containLabel true
 
   E.legend do
     E.textStyle $ E.fontFamily "Ubuntu, sans"
@@ -195,28 +189,6 @@ buildArea r records axes = do
 
   xAxisConfig ∷ Ax.EChartsAxisConfiguration
   xAxisConfig = Ax.axisConfiguration $ Ax.axisType r.dimension axes
-
-  labelHeight ∷ Int
-  labelHeight =
-    let
-      longest =
-        fromMaybe ""
-          $ F.maximumBy (\a b → compare (Str.length a) (Str.length b)) xValues
-
-      width =
-        getTextWidthPure longest
-          $ "normal " ⊕ show r.axisLabelFontSize ⊕ "px Ubuntu"
-
-      minHeight = 24.0
-
-    in
-     mul xAxisConfig.heightMult
-        $ Int.round
-        $ add minHeight
-        $ max (Int.toNumber r.axisLabelFontSize + 2.0)
-        $ Math.abs
-        $ width
-        * Math.sin (r.axisLabelAngle / 180.0 * Math.pi)
 
   xSortFn ∷ String → String → Ordering
   xSortFn = Ax.compareWithAxisType $ Ax.axisType r.dimension axes

--- a/src/SlamData/Workspace/Card/BuildChart/Area/Model.purs
+++ b/src/SlamData/Workspace/Card/BuildChart/Area/Model.purs
@@ -35,7 +35,6 @@ type AreaR =
   , isStacked ∷ Boolean
   , isSmooth ∷ Boolean
   , axisLabelAngle ∷ Number
-  , axisLabelFontSize ∷ Int
   }
 
 type Model = Maybe AreaR
@@ -53,7 +52,6 @@ eqAreaR r1 r2 =
     , r1.isSmooth ≡ r2.isSmooth
     , r1.series ≡ r2.series
     , r1.axisLabelAngle ≡ r2.axisLabelAngle
-    , r1.axisLabelFontSize ≡ r2.axisLabelFontSize
     ]
 
 eqModel ∷ Model → Model → Boolean
@@ -74,7 +72,6 @@ genModel = do
     isSmooth ← arbitrary
     series ← map (map runArbJCursor) arbitrary
     axisLabelAngle ← arbitrary
-    axisLabelFontSize ← arbitrary
     pure { dimension
          , value
          , valueAggregation
@@ -82,7 +79,6 @@ genModel = do
          , isSmooth
          , series
          , axisLabelAngle
-         , axisLabelFontSize
          }
 
 
@@ -97,7 +93,6 @@ encode (Just r) =
   ~> "isSmooth" := r.isSmooth
   ~> "series" := r.series
   ~> "axisLabelAngle" := r.axisLabelAngle
-  ~> "axisLabelFontSize" := r.axisLabelFontSize
   ~> jsonEmptyObject
 
 decode ∷ Json → String ⊹ Model
@@ -115,7 +110,6 @@ decode js
     isSmooth ← obj .? "isSmooth"
     series ← obj .? "series"
     axisLabelAngle ← obj .? "axisLabelAngle"
-    axisLabelFontSize ← obj .? "axisLabelFontSize"
     pure { dimension
          , value
          , valueAggregation
@@ -123,5 +117,4 @@ decode js
          , isSmooth
          , series
          , axisLabelAngle
-         , axisLabelFontSize
          }

--- a/src/SlamData/Workspace/Card/BuildChart/Axis.purs
+++ b/src/SlamData/Workspace/Card/BuildChart/Axis.purs
@@ -241,13 +241,12 @@ dependsOn a b = a ≠ b ∧
 type EChartsAxisConfiguration =
   { axisType ∷ ET.AxisType
   , interval ∷ Maybe Int
-  , heightMult ∷ Int
   }
 
 axisConfiguration ∷ AxisType → EChartsAxisConfiguration
 axisConfiguration = case _ of
-  Measure → {axisType: ET.Category, interval: Nothing, heightMult: 1}
-  Time → {axisType: ET.Category, interval: Just 0, heightMult: 2}
-  Date → {axisType: ET.Time, interval: Just 0, heightMult: 2}
-  DateTime → {axisType: ET.Time, interval: Just 0, heightMult: 2}
-  Category → {axisType: ET.Category, interval: Just 0, heightMult: 1}
+  Measure → {axisType: ET.Category, interval: Nothing }
+  Time → {axisType: ET.Category, interval: Just 0 }
+  Date → {axisType: ET.Time, interval: Just 0 }
+  DateTime → {axisType: ET.Time, interval: Just 0 }
+  Category → {axisType: ET.Category, interval: Just 0 }

--- a/src/SlamData/Workspace/Card/BuildChart/Bar/Component.purs
+++ b/src/SlamData/Workspace/Card/BuildChart/Bar/Component.purs
@@ -20,7 +20,6 @@ module SlamData.Workspace.Card.BuildChart.Bar.Component
 
 import SlamData.Prelude
 
-import Data.Int as Int
 import Data.Lens ((^?), (^.), (?~), (.~))
 import Data.Lens as Lens
 import Data.List as List
@@ -99,7 +98,7 @@ renderHighLOD state =
     , renderStack state
     , renderParallel state
     , HH.hr_
-    , row [ renderAxisLabelAngle state, renderAxisLabelFontSize state ]
+    , row [ renderAxisLabelAngle state ]
     , renderPicker state
     ]
 
@@ -192,21 +191,6 @@ renderAxisLabelAngle state =
         ]
     ]
 
-renderAxisLabelFontSize ∷ ST.State → HTML
-renderAxisLabelFontSize state =
-  HH.form
-    [ HP.classes [ B.colXs6, CSS.axisLabelParam ]
-    , Cp.nonSubmit
-    ]
-    [ HH.label [ HP.classes [ B.controlLabel ] ] [ HH.text "Label font size" ]
-    , HH.input
-        [ HP.classes [ B.formControl ]
-        , HP.value $ show $ state.axisLabelFontSize
-        , ARIA.label "Axis label font size"
-        , HE.onValueChange $ HE.input (\s → right ∘ Q.SetAxisLabelFontSize s)
-        ]
-    ]
-
 eval ∷ Q.QueryC ~> DSL
 eval = cardEval ⨁ pieBuilderEval
 
@@ -231,7 +215,6 @@ cardEval = case _ of
         , stack: st.stack ^. _value
         , parallel: st.parallel ^. _value
         , axisLabelAngle: st.axisLabelAngle
-        , axisLabelFontSize: st.axisLabelFontSize
         }
         <$> (st.category ^. _value)
         <*> (st.value ^. _value)
@@ -240,7 +223,6 @@ cardEval = case _ of
   CC.Load (Card.BuildBar (Just model)) next → do
     loadModel model
     H.modify _{ axisLabelAngle = model.axisLabelAngle
-              , axisLabelFontSize = model.axisLabelFontSize
               }
     pure next
   CC.Load card next →
@@ -267,12 +249,6 @@ pieBuilderEval = case _ of
     let fl = readFloat str
     unless (isNaN fl) do
       H.modify _{axisLabelAngle = fl}
-      CC.raiseUpdatedP' CC.EvalModelUpdate
-    pure next
-  Q.SetAxisLabelFontSize str next → do
-    let mbFS = Int.fromString str
-    for_ mbFS \fs → do
-      H.modify _{axisLabelFontSize = fs}
       CC.raiseUpdatedP' CC.EvalModelUpdate
     pure next
   Q.Select sel next → do

--- a/src/SlamData/Workspace/Card/BuildChart/Bar/Component/Query.purs
+++ b/src/SlamData/Workspace/Card/BuildChart/Bar/Component/Query.purs
@@ -36,7 +36,6 @@ data Selection f
 
 data Query a
   = SetAxisLabelAngle String a
-  | SetAxisLabelFontSize String a
   | Select (Selection SelectAction) a
 
 type QueryC = CardEvalQuery ⨁ Query

--- a/src/SlamData/Workspace/Card/BuildChart/Bar/Component/State.purs
+++ b/src/SlamData/Workspace/Card/BuildChart/Bar/Component/State.purs
@@ -36,7 +36,6 @@ type State =
   { axes ∷ Axes
   , levelOfDetails ∷ LevelOfDetails
   , axisLabelAngle ∷ Number
-  , axisLabelFontSize ∷ Int
   , category ∷ Select JCursor
   , value ∷ Select JCursor
   , valueAgg ∷ Select Aggregation
@@ -50,7 +49,6 @@ initialState =
   { axes: initialAxes
   , levelOfDetails: High
   , axisLabelAngle: zero
-  , axisLabelFontSize: zero
   , category: emptySelect
   , value: emptySelect
   , valueAgg: emptySelect

--- a/src/SlamData/Workspace/Card/BuildChart/Bar/Eval.purs
+++ b/src/SlamData/Workspace/Card/BuildChart/Bar/Eval.purs
@@ -46,6 +46,7 @@ import SlamData.Workspace.Card.BuildChart.Axis (Axes)
 import SlamData.Workspace.Card.BuildChart.Axis as Ax
 import SlamData.Workspace.Card.BuildChart.Semantics (getMaybeString, getValues)
 import SlamData.Workspace.Card.BuildChart.ColorScheme (colors)
+import SlamData.Workspace.Card.BuildChart.Common.Positioning as BCP
 import SlamData.Workspace.Card.Eval.CardEvalT as CET
 import SlamData.Workspace.Card.Port as Port
 
@@ -158,14 +159,12 @@ buildBar r records axes = do
     E.axisLabel do
       E.rotate r.axisLabelAngle
       E.textStyle do
-        E.fontSize r.axisLabelFontSize
         E.fontFamily "Ubuntu, sans"
 
   E.yAxis do
     E.axisType ET.Value
     E.axisLabel $ E.textStyle do
       E.fontFamily "Ubuntu, sans"
-      E.fontSize r.axisLabelFontSize
     E.axisLine $ E.lineStyle $ E.width 1
     E.splitLine $ E.lineStyle $ E.width 1
 
@@ -178,7 +177,7 @@ buildBar r records axes = do
     E.leftLeft
     E.topBottom
 
-  E.grid $ E.containLabel true
+  E.grid BCP.cartesian
 
   E.series series
 

--- a/src/SlamData/Workspace/Card/BuildChart/Bar/Model.purs
+++ b/src/SlamData/Workspace/Card/BuildChart/Bar/Model.purs
@@ -34,7 +34,6 @@ type BarR =
   , stack ∷ Maybe JCursor
   , parallel ∷ Maybe JCursor
   , axisLabelAngle ∷ Number
-  , axisLabelFontSize ∷ Int
   }
 
 type Model = Maybe BarR
@@ -51,7 +50,6 @@ eqBarR r1 r2 =
     , r1.stack ≡ r2.stack
     , r1.parallel ≡ r2.parallel
     , r1.axisLabelAngle ≡ r2.axisLabelAngle
-    , r1.axisLabelFontSize ≡ r2.axisLabelFontSize
     ]
 
 eqModel ∷ Model → Model → Boolean
@@ -71,8 +69,7 @@ genModel = do
     stack ← map (map runArbJCursor) arbitrary
     parallel ← map (map runArbJCursor) arbitrary
     axisLabelAngle ← arbitrary
-    axisLabelFontSize ← arbitrary
-    pure { category, value, valueAggregation, stack, parallel, axisLabelAngle, axisLabelFontSize }
+    pure { category, value, valueAggregation, stack, parallel, axisLabelAngle }
 
 encode ∷ Model → Json
 encode Nothing = jsonNull
@@ -84,7 +81,6 @@ encode (Just r) =
   ~> "stack" := r.stack
   ~> "parallel" := r.parallel
   ~> "axisLabelAngle" := r.axisLabelAngle
-  ~> "axisLabelFontSize" := r.axisLabelFontSize
   ~> jsonEmptyObject
 
 decode ∷ Json → String ⊹ Model
@@ -101,5 +97,4 @@ decode js
     stack ← obj .? "stack"
     parallel ← obj .? "parallel"
     axisLabelAngle ← obj .? "axisLabelAngle"
-    axisLabelFontSize ← obj .? "axisLabelFontSize"
-    pure { category, value, valueAggregation, stack, parallel, axisLabelAngle, axisLabelFontSize }
+    pure { category, value, valueAggregation, stack, parallel, axisLabelAngle }

--- a/src/SlamData/Workspace/Card/BuildChart/Common/Eval.purs
+++ b/src/SlamData/Workspace/Card/BuildChart/Common/Eval.purs
@@ -1,3 +1,19 @@
+{-
+Copyright 2016 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
 module SlamData.Workspace.Card.BuildChart.Common.Eval
   ( records
   , type (>>)

--- a/src/SlamData/Workspace/Card/BuildChart/Common/Positioning.purs
+++ b/src/SlamData/Workspace/Card/BuildChart/Common/Positioning.purs
@@ -319,3 +319,10 @@ rectangularGrids poss = E.grids $ for_ poss \{w, h, x, y} → E.grid do
   for_ y $ E.top ∘ ET.Percent
   for_ w E.widthPct
   for_ h E.heightPct
+
+cartesian ∷ ∀ i. DSL (left ∷ ETP.I, right ∷ ETP.I, top ∷ ETP.I, containLabel ∷ ETP.I|i)
+cartesian = do
+  E.left $ ET.Pixel 30
+  E.right $ ET.Pixel 30
+  E.top $ ET.Pixel 30
+  E.containLabel true

--- a/src/SlamData/Workspace/Card/BuildChart/Legacy.purs
+++ b/src/SlamData/Workspace/Card/BuildChart/Legacy.purs
@@ -59,7 +59,6 @@ decodeCC = J.decodeJson >=> \obj → do
 type BuildOptions =
   { chartType ∷ ChartType
   , axisLabelAngle ∷ Int
-  , axisLabelFontSize ∷ Int
   , areaStacked ∷ Boolean
   , smooth ∷ Boolean
   , bubbleMinSize ∷ Number
@@ -74,13 +73,12 @@ type BuildOptions =
 
 decodeBO ∷ J.Json → Either String BuildOptions
 decodeBO = J.decodeJson >=> \obj →
-  { chartType: _, axisLabelAngle: _, axisLabelFontSize: _
+  { chartType: _, axisLabelAngle: _
   , areaStacked: _, smooth: _, bubbleMinSize:_, bubbleMaxSize: _
   , funnelOrder: _, funnelAlign: _, minColorVal: _, maxColorVal: _
   , colorScheme: _, colorReversed: _ }
     <$> (obj .? "chartType")
     <*> (obj .? "axisLabelAngle")
-    <*> (obj .? "axisLabelFontSize")
     <*> ((obj .? "areaStacked") <|> (pure false))
     <*> ((obj .? "smooth") <|> (pure false))
     <*> ((obj .? "bubbleMinSize") <|> (pure 1.0))
@@ -177,8 +175,6 @@ decode cturs js = do
         20.0
       axisLabelAngle =
         Int.toNumber bo.axisLabelAngle
-      axisLabelFontSize =
-        bo.axisLabelFontSize
 
       lineR =
         { dimension: _
@@ -191,7 +187,6 @@ decode cturs js = do
         , minSize
         , maxSize
         , axisLabelAngle
-        , axisLabelFontSize
         , series
         }
         <$> dimension
@@ -214,8 +209,6 @@ decode cturs js = do
         cc.series A.!! 1 >>= view S._value
       axisLabelAngle =
         Int.toNumber bo.axisLabelAngle
-      axisLabelFontSize =
-        bo.axisLabelFontSize
 
       barR =
         { category: _
@@ -224,7 +217,6 @@ decode cturs js = do
         , stack
         , parallel
         , axisLabelAngle
-        , axisLabelFontSize
         }
         <$> category
         <*> value
@@ -250,8 +242,6 @@ decode cturs js = do
         bo.smooth
       axisLabelAngle =
         Int.toNumber bo.axisLabelAngle
-      axisLabelFontSize =
-        bo.axisLabelFontSize
 
       areaR =
         { dimension: _
@@ -261,7 +251,6 @@ decode cturs js = do
         , isStacked
         , isSmooth
         , axisLabelAngle
-        , axisLabelFontSize
         }
         <$> dimension
         <*> value

--- a/src/SlamData/Workspace/Card/BuildChart/Line/Component.purs
+++ b/src/SlamData/Workspace/Card/BuildChart/Line/Component.purs
@@ -23,7 +23,6 @@ import SlamData.Prelude
 import Data.Lens ((^?), (^.), (.~), (?~))
 import Data.Lens as Lens
 import Data.List as List
-import Data.Int as Int
 
 import Global (readFloat, isNaN)
 
@@ -103,7 +102,7 @@ renderHighLOD state =
     , renderSize state
     , row [ renderMinSize state, renderMaxSize state ]
     , HH.hr_
-    , row [ renderAxisLabelAngle state, renderAxisLabelFontSize state ]
+    , row [ renderAxisLabelAngle state ]
     , renderPicker state
     ]
 
@@ -212,21 +211,6 @@ renderAxisLabelAngle state =
         ]
     ]
 
-renderAxisLabelFontSize ∷ ST.State → HTML
-renderAxisLabelFontSize state =
-  HH.form
-    [ HP.classes [ B.colXs6, CSS.axisLabelParam ]
-    , Cp.nonSubmit
-    ]
-    [ HH.label [ HP.classes [ B.controlLabel ] ] [ HH.text "Label font size" ]
-    , HH.input
-        [ HP.classes [ B.formControl ]
-        , HP.value $ show $ state.axisLabelFontSize
-        , ARIA.label "Axis label font size"
-        , HE.onValueChange $ HE.input (\s → right ∘ Q.SetAxisLabelFontSize s)
-        ]
-    ]
-
 renderMinSize ∷ ST.State → HTML
 renderMinSize state =
   HH.form
@@ -287,7 +271,6 @@ cardEval = case _ of
         , maxSize: st.maxSize
         , minSize: st.minSize
         , axisLabelAngle: st.axisLabelAngle
-        , axisLabelFontSize: st.axisLabelFontSize
         }
         <$> (st.dimension ^. _value)
         <*> (st.value ^. _value)
@@ -299,7 +282,6 @@ cardEval = case _ of
       { maxSize = model.maxSize
       , minSize = model.minSize
       , axisLabelAngle = model.axisLabelAngle
-      , axisLabelFontSize = model.axisLabelFontSize
       }
     pure next
   CC.Load card next →
@@ -326,12 +308,6 @@ lineBuilderEval = case _ of
     let fl = readFloat str
     unless (isNaN fl) do
       H.modify _{axisLabelAngle = fl}
-      CC.raiseUpdatedP' CC.EvalModelUpdate
-    pure next
-  Q.SetAxisLabelFontSize str next → do
-    let mbFS = Int.fromString str
-    for_ mbFS \fs → do
-      H.modify _{axisLabelFontSize = fs}
       CC.raiseUpdatedP' CC.EvalModelUpdate
     pure next
   Q.SetMinSymbolSize str next → do

--- a/src/SlamData/Workspace/Card/BuildChart/Line/Component/Query.purs
+++ b/src/SlamData/Workspace/Card/BuildChart/Line/Component/Query.purs
@@ -39,7 +39,6 @@ data Selection f
 
 data Query a
   = SetAxisLabelAngle String a
-  | SetAxisLabelFontSize String a
   | SetMaxSymbolSize String a
   | SetMinSymbolSize String a
   | Select (Selection SelectAction) a

--- a/src/SlamData/Workspace/Card/BuildChart/Line/Component/State.purs
+++ b/src/SlamData/Workspace/Card/BuildChart/Line/Component/State.purs
@@ -36,7 +36,6 @@ type State =
   { axes ∷ Axes
   , levelOfDetails ∷ LevelOfDetails
   , axisLabelAngle ∷ Number
-  , axisLabelFontSize ∷ Int
   , minSize ∷ Number
   , maxSize ∷ Number
   , dimension ∷ Select JCursor
@@ -55,7 +54,6 @@ initialState =
   { axes: initialAxes
   , levelOfDetails: High
   , axisLabelAngle: zero
-  , axisLabelFontSize: zero
   , minSize: 2.0
   , maxSize: 20.0
   , dimension: emptySelect

--- a/src/SlamData/Workspace/Card/BuildChart/Line/Eval.purs
+++ b/src/SlamData/Workspace/Card/BuildChart/Line/Eval.purs
@@ -48,6 +48,7 @@ import SlamData.Workspace.Card.BuildChart.Axis (Axes)
 import SlamData.Workspace.Card.BuildChart.Axis as Ax
 import SlamData.Workspace.Card.BuildChart.ColorScheme (colors)
 import SlamData.Workspace.Card.BuildChart.Semantics (getMaybeString, getValues)
+import SlamData.Workspace.Card.BuildChart.Common.Positioning as BCP
 import SlamData.Workspace.Card.Eval.CardEvalT as CET
 import SlamData.Workspace.Card.Port as Port
 
@@ -197,7 +198,7 @@ buildLine ∷ LineR → JArray → Axes → DSL OptionI
 buildLine r records axes = do
   E.tooltip E.triggerItem
   E.colors colors
-  E.grid $ E.containLabel true
+  E.grid BCP.cartesian
   E.series series
 
   E.xAxis do
@@ -207,7 +208,6 @@ buildLine r records axes = do
     E.axisLabel do
       E.rotate r.axisLabelAngle
       E.textStyle do
-        E.fontSize r.axisLabelFontSize
         E.fontFamily "Ubuntu, sans"
 
   E.yAxes do
@@ -272,4 +272,3 @@ buildLine r records axes = do
     E.axisType ET.Value
     E.axisLabel $ E.textStyle do
       E.fontFamily "Ubuntu, sans"
-      E.fontSize r.axisLabelFontSize

--- a/src/SlamData/Workspace/Card/BuildChart/Line/Eval.purs
+++ b/src/SlamData/Workspace/Card/BuildChart/Line/Eval.purs
@@ -24,19 +24,16 @@ import SlamData.Prelude
 import Data.Argonaut (JArray, Json)
 import Data.Array as A
 import Data.Foldable as F
+import Data.Int as Int
 import Data.Lens ((^?))
 import Data.Map as M
-import Data.Int as Int
 import Data.Set as Set
-import Data.String as Str
 
 import ECharts.Monad (DSL)
 import ECharts.Commands as E
 import ECharts.Types as ET
 import ECharts.Types.Phantom (OptionI)
 import ECharts.Types.Phantom as ETP
-
-import Math as Math
 
 import Quasar.Types (FilePath)
 
@@ -53,8 +50,6 @@ import SlamData.Workspace.Card.BuildChart.ColorScheme (colors)
 import SlamData.Workspace.Card.BuildChart.Semantics (getMaybeString, getValues)
 import SlamData.Workspace.Card.Eval.CardEvalT as CET
 import SlamData.Workspace.Card.Port as Port
-
-import Utils.DOM (getTextWidthPure)
 
 eval
   ∷ ∀ m
@@ -202,7 +197,7 @@ buildLine ∷ LineR → JArray → Axes → DSL OptionI
 buildLine r records axes = do
   E.tooltip E.triggerItem
   E.colors colors
-  E.grid $ E.bottomPx labelHeight
+  E.grid $ E.containLabel true
   E.series series
 
   E.xAxis do
@@ -232,27 +227,6 @@ buildLine r records axes = do
 
   xSortFn ∷ String → String → Ordering
   xSortFn = Ax.compareWithAxisType $ Ax.axisType r.dimension axes
-
-  labelHeight ∷ Int
-  labelHeight =
-    let
-      longest =
-        fromMaybe ""
-          $ F.maximumBy (\a b → compare (Str.length a) (Str.length b)) xValues
-
-      width =
-        getTextWidthPure longest
-          $ "normal " ⊕ show r.axisLabelFontSize ⊕ "px Ubuntu"
-
-      minHeight = 24.0
-    in
-      mul xAxisConfig.heightMult
-        $ Int.round
-        $ add minHeight
-        $ max (Int.toNumber r.axisLabelFontSize + 2.0)
-        $ Math.abs
-        $ width
-        * Math.sin (r.axisLabelAngle / 180.0 * Math.pi)
 
   xValues ∷ Array String
   xValues =

--- a/src/SlamData/Workspace/Card/BuildChart/Line/Model.purs
+++ b/src/SlamData/Workspace/Card/BuildChart/Line/Model.purs
@@ -39,7 +39,6 @@ type LineR =
   , maxSize ∷ Number
   , minSize ∷ Number
   , axisLabelAngle ∷ Number
-  , axisLabelFontSize ∷ Int
   }
 
 type Model = Maybe LineR
@@ -62,7 +61,6 @@ eqLineR r1 r2 =
     , r1.maxSize ≡ r2.maxSize
     , r1.minSize ≡ r2.minSize
     , r1.axisLabelAngle ≡ r2.axisLabelAngle
-    , r1.axisLabelFontSize ≡ r2.axisLabelFontSize
     ]
 
 eqModel ∷ Model → Model → Boolean
@@ -87,7 +85,6 @@ genModel = do
     maxSize ← arbitrary
     minSize ← arbitrary
     axisLabelAngle ← arbitrary
-    axisLabelFontSize ← arbitrary
     pure { dimension
          , value
          , valueAggregation
@@ -99,7 +96,6 @@ genModel = do
          , maxSize
          , minSize
          , axisLabelAngle
-         , axisLabelFontSize
          }
 
 encode ∷ Model → Json
@@ -117,7 +113,6 @@ encode (Just r) =
   ~> "maxSize" := r.maxSize
   ~> "minSize" := r.minSize
   ~> "axisLabelAngle" := r.axisLabelAngle
-  ~> "axisLabelFontSize" := r.axisLabelFontSize
   ~> jsonEmptyObject
 
 decode ∷ Json → String ⊹ Model
@@ -139,7 +134,6 @@ decode js
     maxSize ← obj .? "maxSize"
     minSize ← obj .? "minSize"
     axisLabelAngle ← obj .? "axisLabelAngle"
-    axisLabelFontSize ← obj .? "axisLabelFontSize"
     pure { dimension
          , value
          , valueAggregation
@@ -151,5 +145,4 @@ decode js
          , maxSize
          , minSize
          , axisLabelAngle
-         , axisLabelFontSize
          }

--- a/src/SlamData/Workspace/Card/BuildChart/Scatter/Eval.purs
+++ b/src/SlamData/Workspace/Card/BuildChart/Scatter/Eval.purs
@@ -49,6 +49,7 @@ import SlamData.Workspace.Card.CardType.ChartType (ChartType(Scatter))
 import SlamData.Workspace.Card.BuildChart.Aggregation as Ag
 import SlamData.Workspace.Card.BuildChart.ColorScheme (colors, getTransparentColor)
 import SlamData.Workspace.Card.BuildChart.Semantics (getMaybeString, getValues)
+import SlamData.Workspace.Card.BuildChart.Common.Positioning as BCP
 import SlamData.Workspace.Card.Eval.CardEvalT as CET
 import SlamData.Workspace.Card.Port as Port
 
@@ -202,6 +203,7 @@ buildScatter r records = do
         E.solidLine
   E.colors colors
 
+  E.grid BCP.cartesian
   E.xAxis valueAxis
   E.yAxis valueAxis
 

--- a/src/SlamData/Workspace/Card/BuildChart/Semantics.purs
+++ b/src/SlamData/Workspace/Card/BuildChart/Semantics.purs
@@ -50,8 +50,9 @@ printTime time =
     minute = fromEnum $ Dt.minute time
     second = fromEnum $ Dt.second time
     millisecond = fromEnum $ Dt.millisecond time
+    show' n = (if n > 9 then "" else "0") ⊕ show n
   in
-    show hour ⊕ ":" ⊕ show minute ⊕ ":" ⊕ show second ⊕ "." ⊕ show millisecond
+    show' hour ⊕ ":" ⊕ show' minute ⊕ ":" ⊕ show' second ⊕ "." ⊕ show millisecond
 -- We _can_ user purescript-formatters here, but printing semantics is used
 -- heavily in axis analysis, so, simple printing used here instead of Μ stuff
 printDate ∷ Dd.Date → String


### PR DESCRIPTION
Fixes #1101 

+ Use `containLabel` instead of calculated `bottom` 
+ Removed `axisLabelFontSize` because `containLabel` works only with default font sizes (And actually we added that field only to make labels adjustable). 
+ Made grid paddings smaller for cartesian charts. 

@garyb please review 