### PR TITLE
Prevent card title flickering in draftboard

### DIFF
--- a/src/SlamData/Workspace/Card/Draftboard/Component/State.purs
+++ b/src/SlamData/Workspace/Card/Draftboard/Component/State.purs
@@ -35,7 +35,6 @@ import SlamData.Prelude
 import Data.Function (on)
 import Data.List as List
 import Data.Map as Map
-import Data.Ordering (invert)
 import Data.Rational (Rational)
 import DOM.HTML.Types (HTMLElement)
 
@@ -139,15 +138,13 @@ recalc
 recalc rect layout = _
   { rootRect = rect
   , layout = layout
-  , cellLayout = List.sortBy (icompare `on` _.value) (Layout.absoluteCells rect (Layout.cells layout))
+  , cellLayout = List.sortBy (flip compare `on` _.value) (Layout.absoluteCells rect (Layout.cells layout))
   , edgeLayout = Layout.absoluteEdges rect (Layout.edges layout)
   , cursors = walkWithCursor goCursors mempty layout
   }
   where
   goCursors c m (Cell (Just deckId)) = Map.insert deckId c m
   goCursors _ m _ = m
-
-  icompare a b = invert (compare a b)
 
 updateRect ∷ Rect Number → State → State
 updateRect rect st = recalc rect st.layout st

--- a/src/SlamData/Workspace/Card/Draftboard/Component/State.purs
+++ b/src/SlamData/Workspace/Card/Draftboard/Component/State.purs
@@ -32,8 +32,10 @@ module SlamData.Workspace.Card.Draftboard.Component.State
   ) where
 
 import SlamData.Prelude
+import Data.Function (on)
 import Data.List as List
 import Data.Map as Map
+import Data.Ordering (invert)
 import Data.Rational (Rational)
 import DOM.HTML.Types (HTMLElement)
 
@@ -137,13 +139,15 @@ recalc
 recalc rect layout = _
   { rootRect = rect
   , layout = layout
-  , cellLayout = Layout.absoluteCells rect (Layout.cells layout)
+  , cellLayout = List.sortBy (icompare `on` _.value) (Layout.absoluteCells rect (Layout.cells layout))
   , edgeLayout = Layout.absoluteEdges rect (Layout.edges layout)
   , cursors = walkWithCursor goCursors mempty layout
   }
   where
   goCursors c m (Cell (Just deckId)) = Map.insert deckId c m
   goCursors _ m _ = m
+
+  icompare a b = invert (compare a b)
 
 updateRect ∷ Rect Number → State → State
 updateRect rect st = recalc rect st.layout st


### PR DESCRIPTION
Previously, if you were in a draftboard, any deck where you had switched cards would flicker the title if you added or removed cells from the draftboard. This is due to some transition classes, and the fact that the ordering of the cell elements was unstable (so they get removed and reinserted. retriggering the transitions). This never happened in the previous draftboard because the decks were ordered in the DOM consistently by their deck id. This change does just that for draftboard cells.