### PR TITLE
Prevent activity when pending

### DIFF
--- a/less/deck/card.less
+++ b/less/deck/card.less
@@ -24,6 +24,18 @@
   }
 }
 
+.sd-card {
+  .sd-pending-overlay {
+    display: none;
+  }
+
+  &.pending {
+    .sd-pending-overlay {
+      display: block;
+    }
+  }
+}
+
 .sd-card-header {
   .noselect;
   position: absolute;

--- a/less/deck/pending.less
+++ b/less/deck/pending.less
@@ -1,5 +1,5 @@
-.sd-card-pending > div {
-
+.sd-card-pending > div,
+.sd-pending-overlay > div {
   position: absolute;
   height: auto;
   text-align: center;
@@ -13,5 +13,26 @@
     height: 32px;
     background: url(../img/spin.gif);
     margin: 0 auto 0.5rem;
+  }
+}
+
+.sd-pending-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 1000;
+
+  > div {
+    display: none;
+  }
+
+  &:hover {
+    background-color: rgba(255,255,255,.8);
+
+    > div {
+      display: block;
+    }
   }
 }

--- a/src/SlamData/Render/CSS.purs
+++ b/src/SlamData/Render/CSS.purs
@@ -208,6 +208,9 @@ openCardMenu = className "open-card-menu"
 loading ∷ ClassName
 loading = className "loading"
 
+pending ∷ ClassName
+pending = className "pending"
+
 cardSlider ∷ ClassName
 cardSlider = className "sd-card-slider"
 

--- a/src/SlamData/Workspace/Deck/Component.purs
+++ b/src/SlamData/Workspace/Deck/Component.purs
@@ -205,6 +205,7 @@ eval opts = case _ of
     st ← H.get
     let pendingCoord = DCS.coordModelToCoord pendingCard
     when (any (DCS.eqCoordModel pendingCoord) st.modelCards) do
+      H.modify $ DCS.addPendingCard pendingCoord
       runPendingCards opts source pendingCard cards
     pure next
   QueuePendingCard next → do
@@ -666,6 +667,7 @@ runPendingCards opts source pendingCard pendingCards = do
     input ← join <$> for prevCard (flip getCache wiring.cards)
     steps ← resume wiring st (input >>= _.output <#> map fst) cards
     runCardUpdates opts source steps
+    H.modify $ DCS.removePendingCard $ DCS.coordModelToCoord pendingCard
 
   where
   resume wiring st = go L.Nil where

--- a/src/SlamData/Workspace/Deck/Component.purs
+++ b/src/SlamData/Workspace/Deck/Component.purs
@@ -525,7 +525,8 @@ createCard cardType = do
   deckId ← H.gets _.id
   (st × newCardId) ← H.gets ∘ DCS.addCard' $ Card.cardModelOfType cardType
   H.set st
-  queuePendingCard (deckId × newCardId)
+  when (isNothing st.pendingCard) do
+    queuePendingCard (deckId × newCardId)
   triggerSave $ Just (deckId × newCardId)
 
 dismissedAccessNextActionCardGuideKey ∷ String


### PR DESCRIPTION
This places an overlay over cards after the currently pending card to provide feedback and prevent interaction.
![pending-overlay](https://cloud.githubusercontent.com/assets/144058/19402780/ab71748a-9228-11e6-8185-db9a2bfa1c5a.gif)
