### PR TITLE
Bump versions for RC4 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "type": "git",
     "url": "https://github.com/slamdata/slamdata"
   },
-  "version": "v3.1.0-rc.3",
+  "version": "v4.0.0-rc.4",
   "contributors": [
     "Maxim Zimaliev <zimaliev@yandex.ru>",
     "Gary Burgess <gary@slamdata.com>",

--- a/quasar-versions.json
+++ b/quasar-versions.json
@@ -1,7 +1,7 @@
 { "quasar":
     { "owner": "quasar-analytics"
     , "repo": "quasar"
-    , "tag": "v12.3.6-quasar-web"
+    , "tag": "v12.4.15-quasar-web"
     }
 , "quasar-advanced":
     { "owner": "slamdata"


### PR DESCRIPTION
@jdegoes should I ask for a new QAdv build to be made too? If not, the installer version will only have frontend changes since RC3.