### PR TITLE
don't run card if it's going to run anyway in evalmodel update handler

### DIFF
--- a/src/SlamData/Workspace/Card/BuildChart/Parallel/Eval.purs
+++ b/src/SlamData/Workspace/Card/BuildChart/Parallel/Eval.purs
@@ -158,7 +158,7 @@ buildParallel r records axes = do
 
   where
   parallelData ∷ Array Series
-  parallelData = spy $ buildParallelData r records
+  parallelData = buildParallelData r records
 
   serieNames = A.mapMaybe _.name parallelData
 

--- a/src/SlamData/Workspace/Deck/Component.purs
+++ b/src/SlamData/Workspace/Deck/Component.purs
@@ -604,12 +604,10 @@ peekCardEvalQuery cardCoord = case _ of
   CEQ.ModelUpdated CEQ.EvalModelUpdate _ → do
     st ← H.get
     let
-      pendingCoord = st.pendingCard
-      coordsToCheck =
-        [cardCoord]
-        ⊕ (Array.takeWhile (_ ≠ cardCoord) $ map DCS.coordModelToCoord st.modelCards)
-    unless (any (eq pendingCoord) $ map Just coordsToCheck) do
-      runCard cardCoord
+      ord = fromMaybe LT do
+        pending ← st.pendingCard
+        DCS.compareCoordCards cardCoord pending st.modelCards
+    when (ord ≡ LT) $ runCard cardCoord
     triggerSave (Just cardCoord)
   CEQ.ZoomIn _ → raise' $ H.action ZoomIn
   _ → pure unit

--- a/src/Utils.purs
+++ b/src/Utils.purs
@@ -46,4 +46,5 @@ passover ∷ ∀ a b m. (Applicative m) ⇒ (a → m b) → a → m a
 passover f x =
   f x *> pure x
 
+
 foreign import prettyJson ∷ J.Json → String


### PR DESCRIPTION
Fixes #1169 

The reason of #1169 is that eval model update is raised before eval is completed. 
This pr adds a check that there is no cards before or equal to one that has raised model update. 

@natefaubion Please take a look