### PR TITLE
Unverified id token details on sign in.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -42,7 +42,7 @@
     "purescript-parallel": "^1.1.0",
     "purescript-pathy": "^2.0.0",
     "purescript-profunctor-lenses": "^1.0.0",
-    "purescript-quasar": "^8.0.0",
+    "purescript-quasar": "^9.0.0",
     "purescript-routing": "^2.0.0",
     "purescript-search": "^1.0.0",
     "purescript-these": "^1.0.0",

--- a/bower.json
+++ b/bower.json
@@ -38,7 +38,7 @@
     "purescript-markdown-halogen": "^2.0.0",
     "purescript-markdown": "^7.0.0",
     "purescript-minimatch": "^0.2.0",
-    "purescript-oidc-crypt-utils": "^3.0.0",
+    "purescript-oidc-crypt-utils": "^4.0.0",
     "purescript-parallel": "^1.1.0",
     "purescript-pathy": "^2.0.0",
     "purescript-profunctor-lenses": "^1.0.0",

--- a/src/SlamData/Effects.purs
+++ b/src/SlamData/Effects.purs
@@ -27,7 +27,6 @@ import Data.JSDate (LOCALE)
 import ECharts.Types (ECHARTS)
 import Halogen (HalogenEffects)
 import Network.HTTP.Affjax (AJAX)
-import OIDC.Crypt (RSASIGNTIME)
 import ZClipboard (ZCLIPBOARD)
 
 type SlamDataEffects = HalogenEffects SlamDataRawEffects
@@ -42,7 +41,6 @@ type SlamDataRawEffects =
   , now ∷ NOW
   , ref ∷ REF
   , timer ∷ TIMER
-  , rsaSignTime ∷ RSASIGNTIME
   , zClipboard ∷ ZCLIPBOARD
   , locale ∷ LOCALE
   )

--- a/src/SlamData/GlobalMenu/Component.purs
+++ b/src/SlamData/GlobalMenu/Component.purs
@@ -30,6 +30,8 @@ import Data.Time.Duration (Milliseconds(Milliseconds))
 import Control.UI.Browser as Browser
 import Control.Monad.Aff.AVar as AVar
 import Control.Monad.Aff.Bus as Bus
+import Control.Monad.Eff as Eff
+import Control.Monad.Eff.Exception as Exception
 
 import Halogen as H
 import Halogen.HTML.Core (className)
@@ -43,17 +45,17 @@ import OIDC.Crypt as Crypt
 
 import Quasar.Advanced.Types (ProviderR)
 
-import SlamData.Monad (Slam)
-import SlamData.Quasar as Api
-import SlamData.Notification (NotificationOptions)
-import SlamData.Notification as Notification
-import SlamData.Quasar.Auth as Auth
-import SlamData.Quasar.Auth.Authentication (AuthenticationError(..))
-import SlamData.Quasar.Auth.Store as AuthStore
 import SlamData.GlobalMenu.Bus (SignInMessage(..))
 import SlamData.GlobalMenu.Component.State (State, initialState)
 import SlamData.GlobalMenu.Menu.Component.Query (QueryP) as MenuQuery
 import SlamData.GlobalMenu.Menu.Component.State as MenuState
+import SlamData.Monad (Slam)
+import SlamData.Notification (NotificationOptions)
+import SlamData.Notification as Notification
+import SlamData.Quasar as Api
+import SlamData.Quasar.Auth as Auth
+import SlamData.Quasar.Auth.Authentication (AuthenticationError(..))
+import SlamData.Quasar.Auth.Store as AuthStore
 import SlamData.Wiring (Wiring(Wiring))
 
 
@@ -105,14 +107,17 @@ eval (Init next) = update $> next
 
 update ∷ GlobalMenuDSL Unit
 update = do
-  mbIdToken ← H.liftH $ H.liftH $ Auth.getIdToken
-  maybe
-    retrieveProvidersAndUpdateMenu
-    putEmailToMenu
-    mbIdToken
+  maybeIdToken ← H.liftH $ H.liftH $ Auth.getIdToken
+  case maybeIdToken of
+    Just idToken → do
+      either
+        (const retrieveProvidersAndUpdateMenu)
+        putEmailToMenu
+        (Eff.runPure $ Exception.try $ Crypt.readPayload idToken)
+    Nothing → retrieveProvidersAndUpdateMenu
   where
-  putEmailToMenu ∷ Crypt.IdToken → GlobalMenuDSL Unit
-  putEmailToMenu token = do
+  putEmailToMenu ∷ Crypt.Payload → GlobalMenuDSL Unit
+  putEmailToMenu payload = do
     queryMenu
       $ H.action
       $ HalogenMenu.SetMenu
@@ -120,7 +125,8 @@ update = do
       $ [ { label:
               fromMaybe "unknown user"
               $ map Crypt.runEmail
-              $ Crypt.pluckEmail token
+              $ Crypt.pluckEmail
+              $ payload
           , submenu:
               [ { label: "🔒 Sign out"
                 , shortcutLabel: Nothing

--- a/src/SlamData/GlobalMenu/Component.purs
+++ b/src/SlamData/GlobalMenu/Component.purs
@@ -25,8 +25,6 @@ module SlamData.GlobalMenu.Component
 
 import SlamData.Prelude
 
-import Data.Time.Duration (Milliseconds(Milliseconds))
-
 import Control.UI.Browser as Browser
 import Control.Monad.Aff.AVar as AVar
 import Control.Monad.Aff.Bus as Bus
@@ -50,11 +48,9 @@ import SlamData.GlobalMenu.Component.State (State, initialState)
 import SlamData.GlobalMenu.Menu.Component.Query (QueryP) as MenuQuery
 import SlamData.GlobalMenu.Menu.Component.State as MenuState
 import SlamData.Monad (Slam)
-import SlamData.Notification (NotificationOptions)
-import SlamData.Notification as Notification
 import SlamData.Quasar as Api
 import SlamData.Quasar.Auth as Auth
-import SlamData.Quasar.Auth.Authentication (AuthenticationError(..))
+import SlamData.Quasar.Auth.Authentication (AuthenticationError, toNotificationOptions)
 import SlamData.Quasar.Auth.Store as AuthStore
 import SlamData.Wiring (Wiring(Wiring))
 
@@ -259,37 +255,6 @@ authenticate =
     Wiring wiringR ← H.liftH $ H.liftH $ ask
     H.fromAff $ maybe (pure unit) (flip Bus.write wiringR.notify) (toNotificationOptions error)
     H.fromAff $ (Bus.write SignInFailure $ wiringR.signInBus)
-
-  toNotificationOptions ∷ AuthenticationError → Maybe NotificationOptions
-  toNotificationOptions =
-    case _ of
-      IdTokenInvalid error →
-        Just
-          { notification: Notification.Error $ "Sign in failed: Authentication provider provided invalid id token."
-          , detail: Notification.SimpleDetail ∘ Exception.message <$> error
-          , timeout
-          }
-      IdTokenUnavailable detail →
-        Just
-          { notification: Notification.Error $ "Sign in failed: Authentication provider didn't provide a token."
-          , detail: Just $ Notification.SimpleDetail detail
-          , timeout
-          }
-      PromptDismissed →
-        Just
-          { notification: Notification.Warning $ "Sign in prompt closed."
-          , detail: Nothing
-          , timeout
-          }
-      ProviderError detail →
-        Just
-          { notification: Notification.Error $ "Sign in failed: There was a problem with your provider configuration, please update your SlamData configuration and try again."
-          , detail: Just $ Notification.SimpleDetail detail
-          , timeout
-          }
-      DOMError _ → Nothing
-    where
-    timeout = Just $ Milliseconds 5000.0
 
 presentHelp ∷ String → GlobalMenuDSL Unit
 presentHelp = H.fromEff ∘ Browser.newTab

--- a/src/SlamData/GlobalMenu/Component.purs
+++ b/src/SlamData/GlobalMenu/Component.purs
@@ -263,10 +263,10 @@ authenticate =
   toNotificationOptions ∷ AuthenticationError → Maybe NotificationOptions
   toNotificationOptions =
     case _ of
-      IdTokenInvalid →
+      IdTokenInvalid error →
         Just
           { notification: Notification.Error $ "Sign in failed: Authentication provider provided invalid id token."
-          , detail: Nothing
+          , detail: Notification.SimpleDetail ∘ Exception.message <$> error
           , timeout
           }
       IdTokenUnavailable detail →

--- a/src/SlamData/Quasar/Aff.purs
+++ b/src/SlamData/Quasar/Aff.purs
@@ -24,6 +24,7 @@ import Control.Monad.Aff.Free (class Affable, fromAff, fromEff)
 import Control.Monad.Eff.Exception as Exn
 import Control.Monad.Eff.Random (RANDOM)
 import Control.Monad.Eff.Console (CONSOLE)
+import Control.Monad.Eff.Now (NOW)
 import Control.Monad.Eff.Ref as Ref
 
 import Control.Monad.Reader.Trans (runReaderT)
@@ -42,7 +43,7 @@ import SlamData.GlobalMenu.Bus (SignInBus)
 
 import OIDC.Crypt as OIDC
 
-type QEff eff = (console ∷ CONSOLE, rsaSignTime ∷ OIDC.RSASIGNTIME, random ∷ RANDOM, ajax ∷ AX.AJAX, dom ∷ DOM, avar ∷ AVar.AVAR, ref ∷ Ref.REF, err ∷ Exn.EXCEPTION | eff)
+type QEff eff = (console ∷ CONSOLE, now ∷ NOW, random ∷ RANDOM, ajax ∷ AX.AJAX, dom ∷ DOM, avar ∷ AVar.AVAR, ref ∷ Ref.REF, err ∷ Exn.EXCEPTION | eff)
 
 type Wiring r =
   { requestNewIdTokenBus ∷ RequestIdTokenBus

--- a/src/SlamData/Quasar/Auth/Authentication.purs
+++ b/src/SlamData/Quasar/Auth/Authentication.purs
@@ -17,7 +17,6 @@ limitations under the License.
 module SlamData.Quasar.Auth.Authentication
   ( authentication
   , getIdTokenFromBusSilently
-  , fromEither
   , toNotificationOptions
   , AuthEffects
   , EIdToken
@@ -59,10 +58,8 @@ import DOM.HTML.Window as DOMHTMLWindow
 import DOM.Node.Document as DOMNodeDocument
 import DOM.Node.Node as DOMNode
 import DOM.Node.Types (Node, Element)
-import Data.Either as E
 import Data.Foldable as F
 import Data.Foreign as Foreign
-import Data.Maybe as M
 import Data.Nullable as Nullable
 import Data.Time.Duration (Milliseconds(Milliseconds), Seconds(Seconds))
 import Data.Traversable as T
@@ -85,9 +82,6 @@ import Text.Parsing.StringParser (ParseError(..))
 import Utils (passover)
 import Utils.LocalStorage as LocalStorage
 import Utils.DOM as DOMUtils
-
-fromEither ∷ ∀ a b. E.Either a b → M.Maybe b
-fromEither = E.either (\_ → M.Nothing) (M.Just)
 
 getIdTokenFromBusSilently ∷ ∀ eff. RequestIdTokenBus → Aff (AuthEffects eff) (Either String EIdToken)
 getIdTokenFromBusSilently requestNewIdTokenBus =

--- a/src/SlamData/Quasar/Auth/Authentication.purs
+++ b/src/SlamData/Quasar/Auth/Authentication.purs
@@ -379,13 +379,15 @@ verify providerR unhashedNonce idToken =
           providerR.openIDConfiguration.jwks
   where
   accumulateErrorsAcceptTrues ∷ Either Error Boolean → Either Error Boolean → Either Error Boolean
-  accumulateErrorsAcceptTrues _ (Right true) = Right true
-  accumulateErrorsAcceptTrues (Right true) _ = Right true
-  accumulateErrorsAcceptTrues (Left acc) (Left error) =
-    Left $ Exception.error $ (Exception.message acc) <> " " <> (Exception.message error)
-  accumulateErrorsAcceptTrues (Right false) (Left error) = Left error
-  accumulateErrorsAcceptTrues (Right false) (Right false) = Right false
-  accumulateErrorsAcceptTrues (Left acc) (Right false) = Left acc
+  accumulateErrorsAcceptTrues =
+    case _, _ of
+      _, Right true → Right true
+      Right true, _ → Right true
+      Left acc, Left error →
+        Left $ Exception.error $ (Exception.message acc) <> " " <> (Exception.message error)
+      Right false, Left error → Left error
+      Right false, Right false → Right false
+      Left acc, Right false → Left acc
 
 verifyWithJwk ∷ ∀ eff. ProviderR → UnhashedNonce → IdToken → JSONWebKey → Eff (AuthEffects eff) (Either Error Boolean)
 verifyWithJwk providerR unhashedNonce idToken jwk = do

--- a/src/SlamData/Quasar/Auth/Authentication.purs
+++ b/src/SlamData/Quasar/Auth/Authentication.purs
@@ -322,8 +322,8 @@ getIdTokenUsingLocalStorage providerR = do
   eitherUnhashedNonce ← getUnhashedNonceUsingLocalStorage
   case Tuple eitherIdToken eitherUnhashedNonce of
     Tuple (Right idToken) (Right unhashedNonce) →
-      liftEff $ verify providerR unhashedNonce idToken
-        >>= either (const $ pure Nothing) (if _ then (pure $ Just idToken) else (pure Nothing))
+      either (const $ Nothing) (if _ then (Just idToken) else Nothing)
+        <$> (liftEff $ verify providerR unhashedNonce idToken)
     Tuple _ _ → pure Nothing
 
 getUnverifiedIdTokenUsingLocalStorage ∷ ∀ eff. Aff (AuthEffects eff) (Either String IdToken)
@@ -350,10 +350,10 @@ getIdTokenFromLSOnChange providerR unhashedNonce =
           Left localStorageError →
             pure $ Left $ IdTokenUnavailable localStorageError
           Right idToken →
-            liftEff $ verify providerR unhashedNonce idToken
-              >>= either
-                    (pure ∘ Left ∘ IdTokenInvalid ∘ Just )
-                    (if _ then pure $ Right idToken else pure $ Left $ IdTokenInvalid Nothing)
+            either
+              (Left ∘ IdTokenInvalid ∘ Just )
+              (if _ then Right idToken else Left $ IdTokenInvalid Nothing)
+              <$> (liftEff $ verify providerR unhashedNonce idToken)
 
 getUnverifiedIdTokenFromLSOnChange
   ∷ ∀ eff

--- a/src/SlamData/Workspace/Deck/Dialog/Export/Component.purs
+++ b/src/SlamData/Workspace/Deck/Dialog/Export/Component.purs
@@ -468,7 +468,6 @@ workspaceTokenName workspacePath idToken =
       ⊕ " for "
       ⊕ workspace
 
-
 updateCopyVal ∷ DSL Unit
 updateCopyVal = do
   locString ← H.fromEff locationString

--- a/src/Utils.purs
+++ b/src/Utils.purs
@@ -46,4 +46,7 @@ passover ∷ ∀ a b m. (Applicative m) ⇒ (a → m b) → a → m a
 passover f x =
   f x *> pure x
 
+censor ∷ ∀ a b. Either a b → Maybe b
+censor = either (\_ → Nothing) (Just)
+
 foreign import prettyJson ∷ J.Json → String


### PR DESCRIPTION
This presents the error causing a sign in to fail due to an invalid id token as the details of a notification. It also updates to the latest `purescript-oidc-crypt-utils`.

A later PR will make this error be presented as the details of a notification on reauth. I'm submitting this part first to keep the PRs smaller.