### PR TITLE
added boundary gap

### DIFF
--- a/src/SlamData/Workspace/Card/BuildChart/Bar/Eval.purs
+++ b/src/SlamData/Workspace/Card/BuildChart/Bar/Eval.purs
@@ -154,6 +154,7 @@ buildBar r records axes = do
 
   E.xAxis do
     E.axisType xAxisConfig.axisType
+    E.enabledBoundaryGap
     traverse_ E.interval xAxisConfig.interval
     case xAxisConfig.axisType of
       ET.Category →


### PR DESCRIPTION
Fixes #1215 

I couldn't reproduce bug. This shouldn't ever happen, because boundary gap is enabled by default. 

@garyb 