### PR TITLE
Update to latest pulp & psa

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
     "build-lite": "gulp replace-crlf less bundle",
     "property-tests": "gulp bundle-property-tests && node tmp/js/property-tests",
     "test": "gulp bundle-test && node test",
-    "psa": "pulp build -I test/src --censor-lib --strict --stash",
-    "psa-raw": "psa \"bower_components/purescript-*/src/**/*.purs\" \"src/**/*.purs\" \"test/src/**/*.purs\" --censor-lib --stash"
+    "psa": "pulp build -I test/src -- --censor-lib --strict --stash"
   },
   "license": "Apache-2.0",
   "bugs": {
@@ -42,9 +41,9 @@
     "gulp-trimlines": "^1.0.0",
     "json-loader": "^0.5.4",
     "platform": "^1.3.0",
-    "pulp": "^9.1.0",
+    "pulp": "^10.0.0",
     "purescript": "^0.10.2",
-    "purescript-psa": "^0.3.9",
+    "purescript-psa": "^0.4.0",
     "rimraf": "^2.4.3",
     "run-sequence": "^1.1.5",
     "selenium-webdriver": "2.53.2",


### PR DESCRIPTION
No need for `psa-raw` after this, as the latest pulp doesn't buffer the compile progress messages, and instead pipes them as they occur :tada: