### PR TITLE
run card if it's currently running

### DIFF
--- a/src/SlamData/Workspace/Card/BuildChart/Bar/Eval.purs
+++ b/src/SlamData/Workspace/Card/BuildChart/Bar/Eval.purs
@@ -49,6 +49,7 @@ import SlamData.Workspace.Card.BuildChart.Common.Positioning as BCP
 import SlamData.Workspace.Card.Eval.CardEvalT as CET
 import SlamData.Workspace.Card.Port as Port
 
+
 eval
   ∷ ∀ m
   . (Monad m, QuasarDSL m)

--- a/src/SlamData/Workspace/Card/Eval.purs
+++ b/src/SlamData/Workspace/Card/Eval.purs
@@ -225,22 +225,22 @@ evalOpen
   → R.Resource
   → CET.CardEvalT m Port.TaggedResourcePort
 evalOpen info res = do
-   filePath ←
-     maybe (QE.throw "No resource is selected") pure
-       $ res ^? R._filePath
-   msg ←
-     CET.liftQ
-       $ QFS.messageIfFileNotFound
-         filePath
-         ("File " ⊕ Path.printPath filePath ⊕ " doesn't exist")
-   case msg of
-     Nothing → do
-       axes ←
-         CET.liftQ $ QQ.axes filePath 20
-       CET.addSource filePath
-       pure { resource: filePath, tag: Nothing, axes, varMap: Nothing }
-     Just err →
-       QE.throw err
+  filePath ←
+    maybe (QE.throw "No resource is selected") pure
+      $ res ^? R._filePath
+  msg ←
+    CET.liftQ
+      $ QFS.messageIfFileNotFound
+        filePath
+        ("File " ⊕ Path.printPath filePath ⊕ " doesn't exist")
+  case msg of
+    Nothing → do
+      axes ←
+        CET.liftQ $ QQ.axes filePath 20
+      CET.addSource filePath
+      pure { resource: filePath, tag: Nothing, axes, varMap: Nothing }
+    Just err →
+      QE.throw err
 
 evalQuery
   ∷ ∀ f m
@@ -293,6 +293,7 @@ evalSearch info queryText resource = do
     outputResource = CET.temporaryOutputResource info
 
   compileResult ← lift $ QQ.compile (Right resource) sql SM.empty
+
   case compileResult of
     Left err →
       case GE.fromQError err of

--- a/src/SlamData/Workspace/Deck/Component.purs
+++ b/src/SlamData/Workspace/Deck/Component.purs
@@ -610,7 +610,7 @@ peekCardEvalQuery cardCoord = case _ of
       ord = fromMaybe LT do
         pending ← st.pendingCard
         DCS.compareCoordCards cardCoord pending st.modelCards
-    when (ord ≡ LT) $ runCard cardCoord
+    when (ord < GT) $ runCard cardCoord
     triggerSave (Just cardCoord)
   CEQ.ZoomIn _ → raise' $ H.action ZoomIn
   _ → pure unit


### PR DESCRIPTION
Fixes #1257 and hopefully shouldn't reintroduce #1169 

For some reasons all requests for couch base mount return 500 with file system error, so I emulated long query run by just `lift $ later 10000 $ pure unit` to check #1169. 

@garyb Please, take a look 