### PR TITLE
full access to .tmp dir of workspace

### DIFF
--- a/less/deck/pending.less
+++ b/less/deck/pending.less
@@ -28,11 +28,9 @@
     display: none;
   }
 
-  &:hover {
-    background-color: rgba(255,255,255,.8);
+  background-color: rgba(255,255,255,.8);
 
-    > div {
-      display: block;
-    }
+  > div {
+    display: block;
   }
 }

--- a/src/SlamData/Workspace/Deck/Dialog/Share/Model.purs
+++ b/src/SlamData/Workspace/Deck/Dialog/Share/Model.purs
@@ -48,8 +48,8 @@ printShareResume Edit = "Edit"
 sharingActions ∷ SharingInput → ShareResume → Array QT.ActionR
 sharingActions {workspacePath, sources, caches, deckId} View =
   (workspacePath </> Pt.dir ".tmp" # QT.Dir ⋙ \resource → do
-      operation ← [ QT.Read ]
-      accessType ← [ QT.Structural, QT.Content ]
+      operation ← [ QT.Read, QT.Modify, QT.Delete, QT.Add ]
+      accessType ← [ QT.Structural, QT.Content, QT.Mount ]
       pure { operation, resource, accessType }
   )
   ⊕ (workspacePath


### PR DESCRIPTION
That's probably fixes #1262 

I have a problem with building QA -- this pr is wip though. 

I think that we could allow user full access to `.tmp` directory under published workspace. There is nothing really private, and actually noone can access it through current workspace. 