### PR TITLE
Search p fix

### DIFF
--- a/src/SlamData/Monad.purs
+++ b/src/SlamData/Monad.purs
@@ -30,6 +30,7 @@ import Control.Monad.Eff.Ref (readRef, writeRef)
 import Control.Monad.Fork (class MonadFork, fork)
 import Control.Monad.Free (Free, liftF, foldFree)
 import Control.Monad.Reader (ReaderT, runReaderT)
+import Control.Monad.Rec.Class (class MonadRec, tailRecM, Step(..))
 import Control.Parallel (parallel, sequential)
 
 import Data.Map as Map
@@ -108,6 +109,11 @@ instance monadForkSlamM ∷ MonadFork Error (SlamM eff) where
 instance monadAskSlamM ∷ MonadAsk Wiring (SlamM eff) where
   ask = SlamM $ liftF $ Ask id
 
+instance monadRecSlamM ∷ MonadRec (SlamM eff) where
+  tailRecM k a = k a >>= case _ of
+    Loop b → tailRecM k b
+    Done r → pure r
+
 instance quasarAuthDSLSlamM ∷ QuasarAuthDSL (SlamM eff) where
   getIdToken = SlamM $ liftF $ GetAuthIdToken id
 
@@ -127,6 +133,7 @@ instance globalErrorDSLSlamM ∷ GE.GlobalErrorDSL (SlamM eff) where
 instance workspaceDSLSlamM ∷ WorkspaceDSL (SlamM eff) where
   getURLVarMaps = SlamM $ liftF $ GetURLVarMaps id
   putURLVarMaps = SlamM ∘ liftF ∘ flip PutURLVarMaps unit
+
 
 newtype SlamA eff a = SlamA (FreeAp (SlamM eff) a)
 


### PR DESCRIPTION
fixes #1205 

Basically whole `SlamData.Filesystem` is rewritten, I think that it's possible to remove `AVar` at all or make it more "local", although this is ASAP and it works :) (and have no that awful `Tuple` and recursive `Aff` anymore). 

Actually I have no idea what should be value of `maxParallelRequests` and `requestDelay`. Seems that Chrome use maximum 20 and 16 is close enough for this, 64ms is something that I can't see but drastically improves responsiveness. 

Also added `MonadRec` for `SlamM` 

@garyb please review, when you have time 