### PR TITLE
Skip auth if there is a permission token in the url

### DIFF
--- a/src/SlamData/FileSystem.purs
+++ b/src/SlamData/FileSystem.purs
@@ -62,6 +62,7 @@ import SlamData.FileSystem.Routing.Search (isSearchQuery, searchPath, filterByQu
 import SlamData.FileSystem.Search.Component as Search
 import SlamData.GlobalError as GE
 import SlamData.Monad (Slam, runSlam)
+import SlamData.Quasar.Auth.Permission as Permission
 import SlamData.Quasar.FS (children) as Quasar
 import SlamData.Quasar.Mount (mountInfo) as Quasar
 import SlamData.Wiring as Wiring
@@ -79,7 +80,8 @@ main = do
   AceConfig.set AceConfig.themePath $ Config.baseUrl ⊕ "js/ace"
 
   runHalogenAff do
-    wiring ← Wiring.make rootDir Editable mempty
+    permissionTokenHashes ← liftEff $ Permission.retrieveTokenHashes
+    wiring ← Wiring.make rootDir Editable mempty permissionTokenHashes
     let ui = interpret (runSlam wiring) comp
     driver ← runUI ui (parentState initialState) =<< awaitBody
 

--- a/src/SlamData/Monad.purs
+++ b/src/SlamData/Monad.purs
@@ -186,6 +186,6 @@ runSlam wiring@(Wiring.Wiring { auth, bus }) = foldFree go ∘ unSlamM
 
   getIdTokenSilentlyIfNoPermissionTokens ∷ Aff SlamDataEffects (Maybe Auth.EIdToken)
   getIdTokenSilentlyIfNoPermissionTokens =
-    if eq 0 $ Array.length auth.permissionTokenHashes
+    if Array.null auth.permissionTokenHashes
       then hush <$> getIdTokenSilently auth.allowedModes auth.requestToken
       else pure Nothing

--- a/src/SlamData/Monad/Auth.purs
+++ b/src/SlamData/Monad/Auth.purs
@@ -16,26 +16,26 @@ limitations under the License.
 
 module SlamData.Monad.Auth where
 
-import SlamData.Prelude
+import Control.Monad.Aff (Aff)
+import Control.Monad.Aff as Aff
+import Control.Monad.Aff.AVar (AVar)
+import Control.Monad.Aff.AVar as AVar
+import Control.Monad.Aff.Bus as Bus
+import Control.Monad.Eff (Eff)
+import Control.Monad.Eff.Class (liftEff)
+import Quasar.Advanced.QuasarAF as QA
+import Quasar.Advanced.Types as QAT
 import SlamData.AuthenticationMode (AuthenticationMode, AllowedAuthenticationModes)
 import SlamData.AuthenticationMode as AuthenticationMode
+import SlamData.Effects (SlamDataEffects)
+import SlamData.Prelude
+import SlamData.Quasar.Aff (runQuasarF)
 import SlamData.Quasar.Auth.Authentication as Auth
 import SlamData.Quasar.Auth.Keys as AuthKeys
-import Control.Monad.Aff as Aff
-import Control.Monad.Aff (Aff)
-import SlamData.Effects (SlamDataEffects)
 import SlamData.Quasar.Error (QError)
-import Control.Monad.Eff.Class (liftEff)
-import Quasar.Advanced.Types as QAT
-import Control.Monad.Aff.AVar (AVar)
-import Utils (passover, singletonValue)
-import Control.Monad.Aff.Bus as Bus
-import SlamData.Quasar.Aff (runQuasarF)
-import Quasar.Advanced.QuasarAF as QA
-import Control.Monad.Eff (Eff)
-import Utils.LocalStorage as LocalStorage
-import Control.Monad.Aff.AVar as AVar
 import SlamData.Quasar.Error as QError
+import Utils (passover, singletonValue)
+import Utils.LocalStorage as LocalStorage
 
 getIdTokenSilently ∷ AllowedAuthenticationModes → Auth.RequestIdTokenBus → Aff SlamDataEffects (Either QError Auth.EIdToken)
 getIdTokenSilently interactionlessSignIn idTokenRequestBus = do

--- a/src/SlamData/Wiring.purs
+++ b/src/SlamData/Wiring.purs
@@ -55,6 +55,8 @@ import SlamData.Workspace.Eval.Graph (EvalGraph)
 import SlamData.Wiring.Cache (Cache)
 import SlamData.Wiring.Cache as Cache
 
+import Quasar.Advanced.Types (TokenHash)
+
 import Utils.Path (DirPath)
 
 data DeckMessage
@@ -95,6 +97,7 @@ type AuthWiring =
   , requestToken ∷ Auth.RequestIdTokenBus
   , signIn ∷ SignInBus
   , allowedModes ∷ AllowedAuthenticationModes
+  , permissionTokenHashes ∷ Array TokenHash
   }
 
 type CacheWiring =
@@ -135,8 +138,9 @@ make
   ⇒ DirPath
   → AccessType
   → StrMap Port.URLVarMap
+  → Array TokenHash
   → m Wiring
-make path accessType vm = fromAff do
+make path accessType vm permissionTokenHashes = fromAff do
   eval ← makeEval
   auth ← makeAuth
   cache ← makeCache
@@ -159,7 +163,7 @@ make path accessType vm = fromAff do
     requestToken ← Auth.authentication
     signIn ← Bus.make
     let allowedModes = allowedAuthenticationModesForAccessType accessType
-    pure { hasIdentified, requestToken, signIn, allowedModes }
+    pure { hasIdentified, requestToken, signIn, allowedModes, permissionTokenHashes }
 
   makeCache = do
     activeState ← Cache.make


### PR DESCRIPTION
The headers for permission tokens are handled by Quasar Advanced rather than SlamData.

The simplest way for SlamData to know about it seems to me to be the location. However there may be a way to work this out from the headers.

Fixes #1293