### PR TITLE
Fast webpack watcher for dev

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,7 +11,8 @@ var gulp = require("gulp"),
     less = require("gulp-less"),
     sequence = require("run-sequence"),
     replace = require("gulp-replace"),
-    footer = require("gulp-footer");
+    footer = require("gulp-footer"),
+    path = require("path");
 
 var slamDataSources = [
   "src/**/*.purs",
@@ -161,8 +162,10 @@ var mkBundleTask = function (name, main) {
     return gulp.src("tmp/" + name + ".js")
           .pipe(webpack({
               resolve: {
-                  modulesDirectories: ["node_modules"]
-
+                  modulesDirectories: ["node_modules"],
+                  alias: {
+                      "package.json": path.join(__dirname, "package.json")
+                  }
               },
               output: { filename: name + ".js" },
               module: {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "build-lite": "gulp replace-crlf less bundle",
     "property-tests": "gulp bundle-property-tests && node tmp/js/property-tests",
     "test": "gulp bundle-test && node test",
-    "psa": "pulp build -I test/src -- --censor-lib --strict --stash"
+    "psa": "pulp build -I test/src -- --censor-lib --strict --stash",
+    "webpack-dev": "webpack --config=webpack.conf.js --watch"
   },
   "license": "Apache-2.0",
   "bugs": {

--- a/src/SlamData/Config/Version.js
+++ b/src/SlamData/Config/Version.js
@@ -1,7 +1,3 @@
-// module SlamData.Config.Version
-
-// This path is relative to the tmp directory during bundling, not the actual
-// location of this current file
-var packageInfo = require("../package.json");
+var packageInfo = require("package.json");
 
 exports.slamDataVersion = packageInfo.version;

--- a/webpack.conf.js
+++ b/webpack.conf.js
@@ -1,0 +1,27 @@
+var path = require("path");
+var baseConf = {
+  devtool: null,
+  module: {
+    loaders: [
+      { test: /\.less$/, loader: "less-loader" },
+      { test: /\.json$/, loader: "json-loader" }
+    ]
+  },
+  resolve: {
+    alias: {
+      "package.json": path.join(__dirname, "package.json")
+    }
+  }
+};
+module.exports = [
+  Object.assign(baseConf, {
+    entry: {
+      workspace: "./webpack.entry.workspace.js",
+      filesystem: "./webpack.entry.filesystem.js",
+      auth_redirect: "./webpack.entry.auth_redirect.js",
+    },
+    output: {
+      filename: "./public/js/[name].js"
+    }
+  })
+];

--- a/webpack.entry.auth_redirect.js
+++ b/webpack.entry.auth_redirect.js
@@ -1,0 +1,1 @@
+require("./output/SlamData.AuthRedirect").main();

--- a/webpack.entry.filesystem.js
+++ b/webpack.entry.filesystem.js
@@ -1,0 +1,1 @@
+require("./output/SlamData.FileSystem").main();

--- a/webpack.entry.workspace.js
+++ b/webpack.entry.workspace.js
@@ -1,0 +1,1 @@
+require("./output/SlamData.Workspace").main();


### PR DESCRIPTION
I use psc-ide with my editor for fast compiles. This watches the output js folder and rebundles in less than a second. Since it forgoes `psc-bundle` it will also bundle the entire project from scratch in less than 10s. For comparison, `gulp bundle-workspace` alone takes me about 20s.