### PR TITLE
Propagate error received over port

### DIFF
--- a/src/SlamData/Workspace/Card/Eval.purs
+++ b/src/SlamData/Workspace/Card/Eval.purs
@@ -97,6 +97,7 @@ evalCard
   → m Port.Out
 evalCard trans port varMap = case trans, port of
   Error msg, _ → CEM.throw msg
+  _, Port.CardError msg → CEM.throw msg
   Pass, _ → pure (port × varMap)
   Chart, _ → pure (Port.ResourceKey Port.defaultResourceVar × varMap)
   Composite, _ → Port.varMapOut <$> Common.evalComposite

--- a/src/SlamData/Workspace/Card/Search/Eval.purs
+++ b/src/SlamData/Workspace/Card/Search/Eval.purs
@@ -39,6 +39,7 @@ import SlamData.Workspace.Card.Eval.Monad as CEM
 import SlamData.Workspace.Card.Port as Port
 import SlamData.Workspace.Card.Search.Interpret as Search
 
+import Text.Parsing.Parser as PP
 import Text.SlamSearch as SS
 
 evalSearch
@@ -54,9 +55,11 @@ evalSearch
   → Port.Resource
   → m Port.Out
 evalSearch queryText resource = do
-  let filePath = resource ^. Port._filePath
-  query ← case SS.mkQuery queryText of
-    Left _ → CEM.throw "Incorrect query string"
+  let
+    filePath = resource ^. Port._filePath
+    queryText' = if queryText ≡ "" then "*" else queryText
+  query ← case SS.mkQuery queryText' of
+    Left pe → CEM.throw $ "Unable to parse query: " <> PP.parseErrorMessage pe
     Right q → pure q
 
   fields ← CEM.liftQ do


### PR DESCRIPTION
Card evaluation always walks the full graph. So when a card outputs an error, it still propagates the error to the next cards. I had accidentally removed the `CardError` case in the eval dispatcher when I refactored it, so it was not necessarily propagating an error through the graph. This is why you could sometimes see a next action card instead of an error card (because some cards only care about the var map environment, and thus don't check the port).

Also allows an empty searches (which are evaluated as `*`).

Fixes #1377 