### PR TITLE
Delete fresh deck in dashboard

### DIFF
--- a/src/SlamData/Wiring/Cache.purs
+++ b/src/SlamData/Wiring/Cache.purs
@@ -22,6 +22,7 @@ module SlamData.Wiring.Cache
   , restore
   , get
   , alter
+  , modify
   , put
   , remove
   , clear
@@ -91,6 +92,16 @@ alter key fn (Cache cache) = do
     Nothing, Nothing → putVar cache vals
     Just _ , Nothing → putVar cache (Map.delete key vals)
     _      , Just v  → putVar cache (Map.insert key v vals)
+
+modify
+  ∷ ∀ eff m k v
+  . (MonadAff (avar ∷ AVAR | eff) m, Ord k)
+  ⇒ k
+  → (v → v)
+  → Cache k v
+  → m Unit
+modify key fn (Cache cache) = liftAff do
+  modifyVar (Map.update (Just ∘ fn) key) cache
 
 put
   ∷ ∀ eff m k v

--- a/src/SlamData/Workspace/Card/Draftboard/Component.purs
+++ b/src/SlamData/Workspace/Card/Draftboard/Component.purs
@@ -366,8 +366,9 @@ recalcRect = do
     H.modify (updateRect rect)
 
 addDeck ∷ CardOptions → Pane.Cursor → DraftboardDSL Unit
-addDeck _ cursor = do
+addDeck opts cursor = do
   deckId × _ ← liftH' $ P.freshDeck emptyDeck (ED.Completed Port.emptyOut)
+  liftH' $ P.linkToParent opts.cardId deckId
   st ← H.get
   let
     layout = Pane.modifyAt (const (Pane.Cell (Just deckId))) cursor st.layout

--- a/src/SlamData/Workspace/Eval/Persistence.purs
+++ b/src/SlamData/Workspace/Eval/Persistence.purs
@@ -510,6 +510,12 @@ cloneActiveStateTo state to from = do
   for_ (activeState <|> state) \as →
     Cache.put to as cache.activeState
 
+linkToParent ∷ ∀ f m. Persist f m (Card.Id → Deck.Id → m Unit)
+linkToParent parentId deckId = do
+  { eval } ← Wiring.expose
+  Cache.modify parentId (\cell → cell { decks = Set.insert deckId cell.decks }) eval.cards
+  Cache.modify deckId (_ { parent = Just parentId }) eval.decks
+
 makeDeckCell ∷ ∀ m. MonadAff SlamDataEffects m ⇒ Deck.Model → Deck.EvalStatus → m Deck.Cell
 makeDeckCell model status =  do
   bus ← liftAff Bus.make


### PR DESCRIPTION
When inserting a fresh deck in a dashboard, it was not getting properly linked to its parent in the graph.

Fixes #1380 