### PR TITLE
Lazy child deck evaluation

### DIFF
--- a/src/SlamData/Workspace/Card/Eval.purs
+++ b/src/SlamData/Workspace/Card/Eval.purs
@@ -107,7 +107,7 @@ evalCard trans port varMap = case trans, port of
   _, Port.CardError msg → CEM.throw msg
   Pass, _ → pure (port × varMap)
   Chart, _ → pure (Port.ResourceKey Port.defaultResourceVar × varMap)
-  Composite deckIds, _ → Port.varMapOut <$> Common.evalComposite deckIds
+  Composite, _ → Port.varMapOut <$> Common.evalComposite
   Query sql, _ → Query.evalQuery sql varMap
   Markdown txt, _ → MDE.evalMarkdown txt varMap
   MarkdownForm model, Port.SlamDown doc → MDE.evalMarkdownForm model doc varMap
@@ -160,7 +160,7 @@ modelToEval card = case card of
   Model.Open res → Open res
   Model.Variables model → Variables model
   Model.DownloadOptions model → DownloadOptions model
-  Model.Draftboard model → Composite (Model.childDeckIds card)
+  Model.Draftboard model → Composite
   Model.BuildMetric model  → BuildMetric model
   Model.BuildSankey model → BuildSankey model
   Model.BuildGauge model → BuildGauge model

--- a/src/SlamData/Workspace/Card/Eval/Class.purs
+++ b/src/SlamData/Workspace/Card/Eval/Class.purs
@@ -17,14 +17,16 @@ limitations under the License.
 module SlamData.Workspace.Card.Eval.Class where
 
 import SlamData.Prelude
+import Data.List (List)
 import SlamData.Workspace.Eval.Deck as Deck
 import SlamData.Workspace.Card.Port (Out)
 
 import Unsafe.Coerce (unsafeCoerce)
 
 class DeckEvalDSL m where
+  childDecks ∷ m (List Deck.Id)
   evalDeck ∷ Deck.Id → m (Deck.Model × Out)
-  parEvalDecks ∷ ∀ f a. Traversable f ⇒ (Deck.Model → Out → a) → f Deck.Id → m (f a)
+  evalDecks ∷ ∀ f a. Traversable f ⇒ (Deck.Model → Out → a) → f Deck.Id → m (f a)
 
 data ParEvalDecks' f a b =
   ParEvalDecks

--- a/src/SlamData/Workspace/Card/Eval/Class.purs
+++ b/src/SlamData/Workspace/Card/Eval/Class.purs
@@ -1,0 +1,25 @@
+{-
+Copyright 2016 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
+module SlamData.Workspace.Card.Eval.Class where
+
+import SlamData.Prelude
+import SlamData.Workspace.Eval.Deck as Deck
+import SlamData.Workspace.Card.Port (Out)
+
+class DeckEvalDSL m where
+  evalDeck ∷ Deck.Id → m (Deck.Model × Out)
+  parEvalDecks ∷ ∀ f a. Traversable f ⇒ (Deck.Model → Out → a) → f Deck.Id → m (f a)

--- a/src/SlamData/Workspace/Card/Eval/Transition.purs
+++ b/src/SlamData/Workspace/Card/Eval/Transition.purs
@@ -18,6 +18,8 @@ module SlamData.Workspace.Card.Eval.Transition
 
 import SlamData.Prelude
 
+import Data.List (List)
+
 import Quasar.Types (SQL)
 
 import SlamData.FileSystem.Resource as R
@@ -45,11 +47,12 @@ import SlamData.Workspace.Card.Setups.FormInput.Labeled.Model as SetupLabeled
 import SlamData.Workspace.Card.Setups.FormInput.TextLike.Model as SetupTextLike
 import SlamData.Workspace.Card.Setups.FormInput.Static.Model as SetupStatic
 import SlamData.Workspace.Card.FormInput.Model as FormInput
+import SlamData.Workspace.Eval.Deck as Deck
 
 data Eval
   = Pass
-  | Composite
   | Chart
+  | Composite (List Deck.Id)
   | Query SQL
   | Search String
   | Cache (Maybe String)
@@ -90,7 +93,7 @@ data Eval
 tagEval ∷ Eval → String
 tagEval = case _ of
   Pass → "Pass"
-  Composite → "Composite"
+  Composite _ → "Composite"
   Chart → "Chart"
   Query str → "Query " <> show str
   Search str → "Search " <> show str

--- a/src/SlamData/Workspace/Card/Eval/Transition.purs
+++ b/src/SlamData/Workspace/Card/Eval/Transition.purs
@@ -18,8 +18,6 @@ module SlamData.Workspace.Card.Eval.Transition
 
 import SlamData.Prelude
 
-import Data.List (List)
-
 import Quasar.Types (SQL)
 
 import SlamData.FileSystem.Resource as R
@@ -47,12 +45,11 @@ import SlamData.Workspace.Card.Setups.FormInput.Labeled.Model as SetupLabeled
 import SlamData.Workspace.Card.Setups.FormInput.TextLike.Model as SetupTextLike
 import SlamData.Workspace.Card.Setups.FormInput.Static.Model as SetupStatic
 import SlamData.Workspace.Card.FormInput.Model as FormInput
-import SlamData.Workspace.Eval.Deck as Deck
 
 data Eval
   = Pass
   | Chart
-  | Composite (List Deck.Id)
+  | Composite
   | Query SQL
   | Search String
   | Cache (Maybe String)
@@ -93,7 +90,7 @@ data Eval
 tagEval ∷ Eval → String
 tagEval = case _ of
   Pass → "Pass"
-  Composite _ → "Composite"
+  Composite → "Composite"
   Chart → "Chart"
   Query str → "Query " <> show str
   Search str → "Search " <> show str

--- a/src/SlamData/Workspace/Eval/Card.purs
+++ b/src/SlamData/Workspace/Eval/Card.purs
@@ -39,7 +39,7 @@ import Data.Set (Set)
 
 import SlamData.Workspace.Card.CardId (CardId)
 import SlamData.Workspace.Card.Eval (Eval, runCard, modelToEval)
-import SlamData.Workspace.Card.Eval.Monad (CardEnv(..), ChildOut, EvalState, AdditionalSource(..))
+import SlamData.Workspace.Card.Eval.Monad (CardEnv(..), EvalState, AdditionalSource(..))
 import SlamData.Workspace.Card.Model (AnyCardModel, modelCardType, cardModelOfType, childDeckIds)
 import SlamData.Workspace.Card.Port (Port(..), Out, emptyOut, portOut, resourceOut)
 import SlamData.Workspace.Eval.Deck as Deck


### PR DESCRIPTION
This extends card eval with the ability to lazily evaluate child decks. Previously, child evaluation was "call-by-value", in that the eval loop would ensure all children were evaluated before evaluating the parent. By letting parents explicitly control child evaluation, we can have cards that act like control-structures. The main eval loop is simplified by this, but I'd like some advice on the implementation.

The main restriction is that I really don't want `CardEvalM` to implement `Parallel` or `MonadFork`. I feel like these open up a huge can of worms, so I've opted to expose `DSL` classes that have explicit parallel operations. This lets us have explicit actions that make sense when parallel (quasar requests, child evaluation) without having to try and reason about any single card's evaluation being forked mid-eval.

For example, I've written this class:

```purescript
class DeckEvalDSL m where
  evalDeck ∷ Deck.Id → m (Deck.Model × Out)
  parEvalDecks ∷ ∀ f a. Traversable f ⇒ (Deck.Model → Out → a) → f Deck.Id → m (f a)
```

Which means Dashboard evaluation is as simple as:

```purescript
evalComposite deckIds =
  foldl merge SM.empty <$> parEvalDecks Tuple deckIds
  where
  ...
```

The problem is that boxing up the `Traversable` constraint, so I can implement this using a `Free` DSL, is awkward (if fairly straightforward, would be nice to have constraint kinds and `Dict`). If you check out `Card/Eval/Monad.purs` you can see the machinery. Any thoughts on a better way to phrase these constraints? For the  Quasar DSL, I was able to get away with simply pre-applying the `traverse` using `FreeAp`, but it's not so simple with deck eval because I need to reflect it.