### PR TITLE
Propagate card scopes

### DIFF
--- a/src/SlamData/Workspace/Card/Eval.purs
+++ b/src/SlamData/Workspace/Card/Eval.purs
@@ -27,6 +27,8 @@ import Control.Monad.State.Class (class MonadState)
 import Control.Monad.Throw (class MonadThrow)
 import Control.Monad.Writer.Class (class MonadTell)
 
+import Data.StrMap (union)
+
 import SlamData.Effects (SlamDataEffects)
 import SlamData.Quasar.Class (class QuasarDSL, class ParQuasarDSL)
 import SlamData.Workspace.Card.Setups.Chart.Area.Eval as BuildArea
@@ -98,7 +100,7 @@ evalCard
   → Port.Port
   → Port.DataMap
   → m Port.Out
-evalCard trans port varMap = case trans, port of
+evalCard trans port varMap = map (_ `union` varMap) <$> case trans, port of
   Error msg, _ → CEM.throw msg
   _, Port.CardError msg → CEM.throw msg
   Pass, _ → pure (port × varMap)

--- a/src/SlamData/Workspace/Card/Eval/Common.purs
+++ b/src/SlamData/Workspace/Card/Eval/Common.purs
@@ -78,10 +78,19 @@ evalComposite = do
         case val, _ of
           Right (Port.SetLiteral s1), Just (Right (Port.SetLiteral s2)) →
             Just (Right (Port.SetLiteral (s1 <> s2)))
-          _, Just (Right (Port.SetLiteral s)) →
-            Just (Right (Port.SetLiteral (Array.snoc s (toValue val))))
+          _, rhs@(Just (Right (Port.SetLiteral s))) →
+            let
+              val' = toValue val
+            in if Array.elem val' s
+              then rhs
+              else Just (Right (Port.SetLiteral (Array.snoc s val')))
           _, Just v →
-            Just (Right (Port.SetLiteral [ toValue v, toValue val ]))
+            let
+              v1 = toValue val
+              v2 = toValue v
+            in if v1 ≡ v2
+              then Just val
+              else Just (Right (Port.SetLiteral [ v1, v2 ]))
           _, Nothing →
             Just val
         (mkKey key)

--- a/src/SlamData/Workspace/Card/InsertableCardType.purs
+++ b/src/SlamData/Workspace/Card/InsertableCardType.purs
@@ -63,7 +63,7 @@ inputs ∷ Array (InsertableCardType × (Array InsertableCardIOType))
 inputs =
   [ CacheCard × [ Data ]
   , DraftboardCard × [ None ]
-  , OpenCard × [ None ]
+  , OpenCard × [ None, Variables ]
   , QueryCard × [ None, Data, Variables ]
   , SearchCard × [ Data ]
   , SetupChartCard × [ Data ]


### PR DESCRIPTION
Fixes #1423 

This makes a change to `union` var maps when evaling. This means variables introduced by previous cards can be used in subsequent cards. If a variable conflicts, it's shadowed by the most recent card. I also made a change to do some basic deduping when making a composite scope.