### PR TITLE
Fix restoring selections in Miller columns

### DIFF
--- a/src/SlamData/Workspace/Card/Open/Component.purs
+++ b/src/SlamData/Workspace/Card/Open/Component.purs
@@ -66,7 +66,7 @@ openComponent =
 
 render ∷ State → HTML
 render state =
-  HH.slot unit (MC.component itemSpec) (pure (Left Path.rootDir)) handleMessage
+  HH.slot unit (MC.component itemSpec) (pathToColumnData (Left Path.rootDir)) handleMessage
 
 handleMessage ∷ MC.Message' R.Resource AnyPath Void → Maybe (CC.InnerCardQuery Query Unit)
 handleMessage =
@@ -109,8 +109,7 @@ evalCard = case _ of
     mbRes ← H.get
     pure $ k $ Card.Open (fromMaybe R.root mbRes)
   CC.Load (Card.Open res) next → do
-    let selectedResources = toResourceList res
-    void $ H.query unit $ H.action $ MC.Populate $ R.getPath <$> selectedResources
+    void $ H.query unit $ H.action $ MC.Populate $ pathToColumnData $ R.getPath res
     H.put (Just res)
     pure next
   CC.Load _ next →
@@ -183,15 +182,13 @@ handleError err =
 -- | little bit, as some of the intermediate steps may be mounts, etc. but we
 -- | don't know that so always produce directories, but for the usage here that
 -- | doesn't matter.
-toResourceList ∷ R.Resource → L.List R.Resource
-toResourceList res =
-  (unfoldr \r → Tuple r <$> go r) res `L.snoc` R.Directory Path.rootDir
-  where
-  go ∷ R.Resource → Maybe R.Resource
-  go = map (R.Directory ∘ fst) ∘ either Path.peel Path.peel ∘ R.getPath
-
-getColPath ∷ R.Resource → Maybe (L.List AnyPath)
-getColPath = maybe Nothing (Just ∘ toPathList ∘ Left ∘ fst) ∘ either Path.peel Path.peel ∘ R.getPath
+pathToColumnData ∷ AnyPath → AnyPath × L.List R.Resource
+pathToColumnData path =
+  case L.unsnoc (toPathList path) of
+    Just { init, last } →
+      last × map (either R.Directory R.File) init
+    Nothing →
+      Left Path.rootDir × L.Nil
 
 toPathList ∷ AnyPath → L.List AnyPath
 toPathList res =

--- a/src/SlamData/Workspace/Card/Open/Component.purs
+++ b/src/SlamData/Workspace/Card/Open/Component.purs
@@ -141,17 +141,17 @@ itemSpec =
       }
   , label: R.resourceName
   , load
-  , isLeaf: maybe true isRight ∘ L.head
+  , isLeaf: isRight
   , id: R.getPath
   }
 
 load
   ∷ ∀ r
-  . { path ∷ L.List AnyPath, filter ∷ String | r }
+  . { path ∷ AnyPath, filter ∷ String | r }
   → Slam { items ∷ L.List R.Resource, nextOffset ∷ Maybe Int }
 load { path, filter } =
-  case L.head path of
-    Just (Left p) →
+  case path of
+    Left p →
       Quasar.children p >>= case _ of
         Left err → handleError err $> noResult
         Right rs → do

--- a/src/SlamData/Workspace/Card/Setups/DimensionPicker/Column.purs
+++ b/src/SlamData/Workspace/Card/Setups/DimensionPicker/Column.purs
@@ -22,10 +22,10 @@ import Control.Comonad.Cofree (Cofree)
 import Control.Comonad.Cofree as Cofree
 
 import Data.Argonaut as J
-import Data.List (List(..), (:))
+import Data.List (List, (:))
 import Data.Map as Map
 
-import SlamData.Workspace.Card.Setups.DimensionPicker.Node (discriminateNodes, unNode)
+import SlamData.Workspace.Card.Setups.DimensionPicker.Node (discriminateNodes)
 import SlamData.Workspace.Card.Setups.Chart.PivotTable.Model (Column(..))
 
 type ColumnNode = Either Column Column
@@ -74,21 +74,5 @@ groupColumns ls =
         Nothing → Just (pure v)
       k
 
-flattenColumns
-  ∷ List ColumnNode
-  → Column
-flattenColumns Nil =
-  Column { value: J.JCursorTop, valueAggregation: Nothing }
-flattenColumns (c : cs) =
-  case unNode c of
-    Count → Count
-    Column { value } →
-      case value of
-        J.JField ix _ → mapValue (J.JField ix) (flattenColumns cs)
-        J.JIndex ix _ → mapValue (J.JIndex ix) (flattenColumns cs)
-        J.JCursorTop → flattenColumns cs
-  where
-  mapValue f = case _ of
-    Count → Count
-    Column { value, valueAggregation } →
-      Column { value: f value, valueAggregation }
+flattenColumns ∷ ColumnNode → Column
+flattenColumns = either id id

--- a/src/SlamData/Workspace/Card/Setups/DimensionPicker/JCursor.purs
+++ b/src/SlamData/Workspace/Card/Setups/DimensionPicker/JCursor.purs
@@ -22,10 +22,10 @@ import Control.Comonad.Cofree (Cofree)
 import Control.Comonad.Cofree as Cofree
 
 import Data.Argonaut as J
-import Data.List (List(..), (:))
+import Data.List (List, (:))
 import Data.Map as Map
 
-import SlamData.Workspace.Card.Setups.DimensionPicker.Node (discriminateNodes, unNode)
+import SlamData.Workspace.Card.Setups.DimensionPicker.Node (discriminateNodes)
 
 type JCursorNode = Either J.JCursor J.JCursor
 
@@ -58,12 +58,5 @@ groupJCursors ls = discriminateNodes $ Cofree.mkCofree J.JCursorTop (group ls)
         Nothing → Just (pure v)
       k
 
-flattenJCursors
-  ∷ List JCursorNode
-  → J.JCursor
-flattenJCursors Nil = J.JCursorTop
-flattenJCursors (c : cs) =
-  case unNode c of
-    J.JCursorTop  → flattenJCursors cs
-    J.JField ix _ → J.JField ix (flattenJCursors cs)
-    J.JIndex ix _ → J.JIndex ix (flattenJCursors cs)
+flattenJCursors ∷ JCursorNode → J.JCursor
+flattenJCursors = either id id

--- a/src/SlamData/Workspace/MillerColumns/BasicItem/Component.purs
+++ b/src/SlamData/Workspace/MillerColumns/BasicItem/Component.purs
@@ -18,8 +18,6 @@ module SlamData.Workspace.MillerColumns.BasicItem.Component where
 
 import SlamData.Prelude
 
-import Data.List as L
-
 import Halogen as H
 import Halogen.HTML.Events as HE
 import Halogen.HTML as HH
@@ -50,7 +48,7 @@ component
   ∷ ∀ a i
   . Eq i
   ⇒ ItemSpec a
-  → L.List i
+  → i
   → a
   → H.Component HH.HTML Query MCI.ItemState (MCI.ItemMessage' a Void) Slam
 component ispec path item =

--- a/src/SlamData/Workspace/MillerColumns/Column/Component.purs
+++ b/src/SlamData/Workspace/MillerColumns/Column/Component.purs
@@ -57,15 +57,15 @@ component
   . Ord i
   ⇒ ColumnOptions a i f o
   → L.List i
-  → H.Component HH.HTML (Query a i o) Unit (Message' a i o) Slam
+  → H.Component HH.HTML (Query a i o) (Maybe a) (Message' a i o) Slam
 component ispec colPath =
   H.lifecycleParentComponent
-    { initialState: const initialState
+    { initialState
     , render
     , eval
     , initializer: Just (H.action Init)
     , finalizer: Nothing
-    , receiver: const Nothing
+    , receiver: HE.input SetSelection
     }
   where
 

--- a/src/SlamData/Workspace/MillerColumns/Column/Component.purs
+++ b/src/SlamData/Workspace/MillerColumns/Column/Component.purs
@@ -27,7 +27,6 @@ import Control.Monad.Fork.Class (fork)
 
 import Data.Array as A
 import Data.List as L
-import Data.List ((:))
 import Data.Time.Duration (Milliseconds(..))
 
 import DOM.Classy.Event (currentTarget) as DOM
@@ -56,7 +55,7 @@ component
   ∷ ∀ a i f o
   . Ord i
   ⇒ ColumnOptions a i f o
-  → L.List i
+  → i
   → H.Component HH.HTML (Query a i o) (Maybe a) (Message' a i o) Slam
 component ispec colPath =
   H.lifecycleParentComponent
@@ -139,7 +138,7 @@ component ispec colPath =
     in
       HH.slot
         itemId
-        (ispec.render (itemId : colPath) item)
+        (ispec.render itemId item)
         (if Just itemId == selectedId then I.Selected else I.Deselected)
         (HE.input (HandleMessage itemId))
 
@@ -180,7 +179,7 @@ component ispec colPath =
       case msg of
         Left (I.RaisePopulate a) → do
           H.modify (_ { selected = Just a })
-          H.raise $ Left $ Selected (itemId : colPath) a
+          H.raise $ Left $ Selected itemId a
         Right o → do
           H.raise $ Right o
       pure next

--- a/src/SlamData/Workspace/MillerColumns/Column/Component/Query.purs
+++ b/src/SlamData/Workspace/MillerColumns/Column/Component/Query.purs
@@ -22,8 +22,6 @@ module SlamData.Workspace.MillerColumns.Column.Component.Query
 
 import SlamData.Prelude
 
-import Data.List (List)
-
 import DOM.Node.Types (Element)
 
 import SlamData.Workspace.MillerColumns.Column.Component.Item (ItemMessage')
@@ -40,7 +38,7 @@ data Query a i o b
 
 data Message a i
   = Initialized
-  | Selected (List i) a
+  | Selected i a
   | Deselected
 
 type Message' a i o = Either (Message a i) o

--- a/src/SlamData/Workspace/MillerColumns/Column/Component/State.purs
+++ b/src/SlamData/Workspace/MillerColumns/Column/Component/State.purs
@@ -47,11 +47,11 @@ type State a i o =
   , filterTrigger ∷ DebounceTrigger (Query a i o) Slam
   }
 
-initialState ∷ ∀ a i o. State a i o
+initialState ∷ ∀ a i o. Maybe a → State a i o
 initialState =
   { items: Nil
   , state: Loading
-  , selected: Nothing
+  , selected: _
   , filterText: ""
   , nextOffset: Nothing
   , lastLoadParams: Nothing

--- a/src/SlamData/Workspace/MillerColumns/Column/Options.purs
+++ b/src/SlamData/Workspace/MillerColumns/Column/Options.purs
@@ -26,15 +26,12 @@ import Halogen.HTML as HH
 import SlamData.Monad (Slam)
 import SlamData.Workspace.MillerColumns.Column.Component.Item (ItemMessage', ItemState)
 
-type LoadParams i = { path ∷ L.List i, filter ∷ String, offset ∷ Maybe Int }
+type LoadParams i = { path ∷ i, filter ∷ String, offset ∷ Maybe Int }
 
 type ColumnOptions a i f o =
-  { render
-      ∷ L.List i
-      → a
-      → H.Component HH.HTML f ItemState (ItemMessage' a o) Slam
+  { render ∷ i → a → H.Component HH.HTML f ItemState (ItemMessage' a o) Slam
   , label ∷ a → String
   , load ∷ LoadParams i → Slam { items ∷ L.List a, nextOffset ∷ Maybe Int }
-  , isLeaf ∷ L.List i → Boolean
+  , isLeaf ∷ i → Boolean
   , id ∷ a → i
   }

--- a/src/SlamData/Workspace/MillerColumns/Component.purs
+++ b/src/SlamData/Workspace/MillerColumns/Component.purs
@@ -17,7 +17,6 @@ limitations under the License.
 module SlamData.Workspace.MillerColumns.Component
   ( component
   , module SlamData.Workspace.MillerColumns.Component.Query
-  , module SlamData.Workspace.MillerColumns.Component.State
   , module Exports
   ) where
 
@@ -27,6 +26,7 @@ import Control.Monad.Eff (Eff)
 
 import Data.List ((:))
 import Data.List as L
+import Data.Profunctor.Strong (second)
 
 import DOM (DOM)
 import DOM.Classy.HTMLElement as DOM
@@ -46,15 +46,15 @@ import SlamData.Workspace.MillerColumns.Component.State (State, columnPaths)
 import SlamData.Workspace.MillerColumns.Column.Component (ColumnOptions) as Exports
 
 type HTML a i o = H.ParentHTML (Query a i o) (Column.Query a i o) (L.List i) Slam
-type DSL a i o = H.ParentDSL (State i) (Query a i o) (Column.Query a i o) (L.List i) (Message' a i o) Slam
+type DSL a i o = H.ParentDSL (State a i) (Query a i o) (Column.Query a i o) (L.List i) (Message' a i o) Slam
 
-type RenderRec a i o = { path ∷ L.List i, html ∷ Array (HTML a i o) }
+type RenderRec a i o = { path ∷ Maybe a × L.List i, html ∷ Array (HTML a i o) }
 
 component
   ∷ ∀ a i f o
   . Ord i
   ⇒ Column.ColumnOptions a i f o
-  → H.Component HH.HTML (Query a i o) (L.List i) (Message' a i o) Slam
+  → H.Component HH.HTML (Query a i o) (State a i) (Message' a i o) Slam
 component colSpec =
   H.parentComponent
     { initialState: id
@@ -64,51 +64,52 @@ component colSpec =
     }
   where
 
-  render ∷ State i → HTML a i o
+  render ∷ State a i → HTML a i o
   render state =
     HH.div
       [ HP.class_ (HH.ClassName "sd-miller-columns")
       , HP.ref containerRef
       ]
       $ _.html
-      $ foldr goColumn { path: L.Nil, html: [] } (columnPaths colSpec state)
+      $ foldr goColumn { path: Nothing × L.Nil, html: [] } (columnPaths colSpec state)
 
-  goColumn ∷ L.List i → RenderRec a i o → RenderRec a i o
-  goColumn path acc = { path, html: acc.html <> [renderColumn path] }
+  goColumn ∷ Int × Maybe a × L.List i → RenderRec a i o → RenderRec a i o
+  goColumn (i × path) acc = { path, html: acc.html <> [renderColumn i path] }
 
-  renderColumn ∷ L.List i → HTML a i o
-  renderColumn colPath =
+  renderColumn ∷ Int → Maybe a × L.List i → HTML a i o
+  renderColumn i (sel × colPath) =
     HH.div
       [ HP.class_ (HH.ClassName "sd-miller-column")
       , ARIA.label "Column"
       ]
-      [ HH.slot colPath (Column.component colSpec colPath) unit (HE.input (HandleMessage colPath)) ]
+      [ HH.slot colPath (Column.component colSpec colPath) sel (HE.input (HandleMessage i colPath)) ]
 
   eval ∷ Query a i o ~> DSL a i o
   eval = case _ of
     Populate path next → do
       H.put path
       pure next
-    ChangeRoot root next → do
-      currentPath ← H.get
-      let prefix = L.take (L.length root) root
-      when (prefix /= root) $ H.put root
+    ChangeRoot st@(newRoot × newSelections) next → do
+      (root × selections) ← H.get
+      let
+        prefix = L.drop (L.length selections - L.length newSelections) selections
+        oldIds = colSpec.id <$> prefix
+        newIds = colSpec.id <$> newSelections
+      when (root /= newRoot || oldIds /= newIds) $ H.put st
       pure next
-    HandleMessage colPath msg next → do
+    HandleMessage colIndex colPath msg next → do
       case msg of
         Left Column.Initialized →
           traverse_ (H.liftEff ∘ scrollToRight) =<< H.getHTMLElementRef containerRef
         Left Column.Deselected → do
-          H.put colPath
-          void $ H.query colPath $ H.action $ Column.SetSelection Nothing
+          H.modify $ second \sels → L.drop (L.length sels - colIndex) sels
           let prevCol = L.drop 1 colPath
           selection ← join <$> H.query prevCol (H.request Column.GetSelection)
           let selPath = maybe prevCol (\s → colSpec.id s : prevCol) selection
           H.raise $ Left (SelectionChanged selPath selection)
-        Left (Column.Selected itemPath selection) → do
-          H.put itemPath
-          void $ H.query colPath $ H.action $ Column.SetSelection (Just selection)
-          H.raise $ Left (SelectionChanged itemPath (Just selection))
+        Left (Column.Selected itemPath item) → do
+          H.modify $ second \sels → item : L.drop (L.length sels - colIndex) sels
+          H.raise $ Left (SelectionChanged itemPath (Just item))
         Right o →
           H.raise (Right o)
       pure next

--- a/src/SlamData/Workspace/MillerColumns/Component.purs
+++ b/src/SlamData/Workspace/MillerColumns/Component.purs
@@ -42,18 +42,18 @@ import Halogen.HTML.Properties.ARIA as ARIA
 import SlamData.Monad (Slam)
 import SlamData.Workspace.MillerColumns.Column.Component as Column
 import SlamData.Workspace.MillerColumns.Component.Query (Query(..), Message(..), Message')
-import SlamData.Workspace.MillerColumns.Component.State (State, columnPaths)
+import SlamData.Workspace.MillerColumns.Component.State (ColumnsData, columnPaths)
 
 import SlamData.Workspace.MillerColumns.Column.Component (ColumnOptions) as Exports
 
 type HTML a i o = H.ParentHTML (Query a i o) (Column.Query a i o) i Slam
-type DSL a i o = H.ParentDSL (State a i) (Query a i o) (Column.Query a i o) i (Message' a i o) Slam
+type DSL a i o = H.ParentDSL (ColumnsData a i) (Query a i o) (Column.Query a i o) i (Message' a i o) Slam
 
 component
   ∷ ∀ a i f o
   . Ord i
   ⇒ Column.ColumnOptions a i f o
-  → H.Component HH.HTML (Query a i o) (State a i) (Message' a i o) Slam
+  → H.Component HH.HTML (Query a i o) (ColumnsData a i) (Message' a i o) Slam
 component colSpec =
   H.parentComponent
     { initialState: id
@@ -63,13 +63,12 @@ component colSpec =
     }
   where
 
-  render ∷ State a i → HTML a i o
+  render ∷ ColumnsData a i → HTML a i o
   render state =
     HH.div
       [ HP.class_ (HH.ClassName "sd-miller-columns")
       , HP.ref containerRef
       ]
-      $ A.reverse
       $ A.fromFoldable
       $ map renderColumn (columnPaths colSpec state)
 

--- a/src/SlamData/Workspace/MillerColumns/Component/Query.purs
+++ b/src/SlamData/Workspace/MillerColumns/Component/Query.purs
@@ -24,9 +24,9 @@ import SlamData.Workspace.MillerColumns.Column.Component as Column
 data Query a i o b
   = Populate (i × List a) b
   | ChangeRoot (i × List a) b
-  | HandleMessage Int (List i) (Column.Message' a i o) b
+  | HandleMessage Int i (Column.Message' a i o) b
 
 data Message a i
-  = SelectionChanged (List i) (Maybe a)
+  = SelectionChanged i (Maybe a)
 
 type Message' a i o = Either (Message a i) o

--- a/src/SlamData/Workspace/MillerColumns/Component/Query.purs
+++ b/src/SlamData/Workspace/MillerColumns/Component/Query.purs
@@ -18,12 +18,12 @@ module SlamData.Workspace.MillerColumns.Component.Query where
 
 import SlamData.Prelude
 
-import Data.List (List)
 import SlamData.Workspace.MillerColumns.Column.Component as Column
+import SlamData.Workspace.MillerColumns.Component.State (ColumnsData)
 
 data Query a i o b
-  = Populate (i × List a) b
-  | ChangeRoot (i × List a) b
+  = Populate (ColumnsData a i) b
+  | ChangeRoot (ColumnsData a i) b
   | HandleMessage Int i (Column.Message' a i o) b
 
 data Message a i

--- a/src/SlamData/Workspace/MillerColumns/Component/Query.purs
+++ b/src/SlamData/Workspace/MillerColumns/Component/Query.purs
@@ -22,9 +22,9 @@ import Data.List (List)
 import SlamData.Workspace.MillerColumns.Column.Component as Column
 
 data Query a i o b
-  = Populate (List i) b
-  | ChangeRoot (List i) b
-  | HandleMessage (List i) (Column.Message' a i o) b
+  = Populate (i × List a) b
+  | ChangeRoot (i × List a) b
+  | HandleMessage Int (List i) (Column.Message' a i o) b
 
 data Message a i
   = SelectionChanged (List i) (Maybe a)

--- a/src/SlamData/Workspace/MillerColumns/Component/State.purs
+++ b/src/SlamData/Workspace/MillerColumns/Component/State.purs
@@ -20,7 +20,6 @@ import SlamData.Prelude
 
 import Data.List ((:))
 import Data.List as L
-import Data.Traversable (scanr)
 
 import SlamData.Workspace.MillerColumns.Column.Component as Column
 
@@ -32,10 +31,10 @@ columnPaths
   ∷ ∀ a i f o
   . Column.ColumnOptions a i f o
   → State a i
-  → L.List (Int × Maybe a × L.List i)
+  → L.List (Int × Maybe a × i)
 columnPaths colSpec (root × selection) =
   let
-    paths = scanr (:) L.Nil $ (colSpec.id <$> selection) `L.snoc` root
+    paths = (colSpec.id <$> selection) `L.snoc` root
     sels = Nothing : (Just <$> selection)
     cols = snd $ foldr (\item (i × acc) → i + 1 × ((i × item) : acc)) (0 × L.Nil) $ L.zip sels paths
   in

--- a/src/SlamData/Workspace/MillerColumns/Component/State.purs
+++ b/src/SlamData/Workspace/MillerColumns/Component/State.purs
@@ -23,21 +23,46 @@ import Data.List as L
 
 import SlamData.Workspace.MillerColumns.Column.Component as Column
 
-type State a i = i × L.List a
+-- | The current state of the columns component - the `i` value is the root
+-- | path id, the list of `a`s is the items selected in each column. The list
+-- | is in "reverse" order, where the head item corresponds to the last
+-- | selection in the view, and the last item is the selection in the first
+-- | column.
+type ColumnsData a i = i × L.List a
 
--- | Mash the values in the state into a list where each item corresponds to a
--- | path for a column and the selected item within that column.
+-- | Mash the values in the state into a list where each item corresponds to an
+-- | index for the column, the selected item within that column, and the path
+-- | id for the column.
+-- |
+-- | For example, if the input state is `A × [D, C, B]` the result will be:
+-- | ```
+-- | [ 0 × Just B × A
+-- | , 1 × Just C × B
+-- | , 2 × Just D × C
+-- | , 3 × Nothing × D
+-- | ]
+-- | ```
+-- |
+-- | The exception to this is if the last selection is a leaf according to the
+-- | provided `ColumnOptions`, in which case the last entry will be omitted:
+-- | ```
+-- | [ 0 × Just B × A
+-- | , 1 × Just C × B
+-- | , 2 × Just D × C
+-- | ]
+-- | ```
 columnPaths
   ∷ ∀ a i f o
   . Column.ColumnOptions a i f o
-  → State a i
+  → ColumnsData a i
   → L.List (Int × Maybe a × i)
 columnPaths colSpec (root × selection) =
   let
     paths = (colSpec.id <$> selection) `L.snoc` root
     sels = Nothing : (Just <$> selection)
-    cols = snd $ foldr (\item (i × acc) → i + 1 × ((i × item) : acc)) (0 × L.Nil) $ L.zip sels paths
+    cols = L.zip sels paths
   in
-    case L.head paths of
-      Just selPath | colSpec.isLeaf selPath → L.drop 1 cols
-      _ → cols
+    L.mapWithIndex (flip Tuple) $ L.reverse $
+      case L.head paths of
+        Just selPath | colSpec.isLeaf selPath → L.drop 1 cols
+        _ → cols

--- a/src/SlamData/Workspace/MillerColumns/TreeData.purs
+++ b/src/SlamData/Workspace/MillerColumns/TreeData.purs
@@ -25,6 +25,7 @@ import Data.Foldable (find)
 import Data.List as L
 
 import SlamData.Workspace.MillerColumns.Column.BasicFilter (mkFilter)
+import SlamData.Workspace.MillerColumns.Component.State (ColumnsData)
 
 type Tree a = CF.Cofree L.List a
 
@@ -49,5 +50,5 @@ loadFromTree label tree { path, filter } =
       Just subtree → extract <$> CF.tail subtree
       Nothing → CF.tail <$> branches >>= go
 
-initialStateFromTree ∷ ∀ a. Tree a → a × L.List a
+initialStateFromTree ∷ ∀ a. Tree a → ColumnsData a a
 initialStateFromTree t = extract t × L.Nil

--- a/src/SlamData/Workspace/MillerColumns/TreeData.purs
+++ b/src/SlamData/Workspace/MillerColumns/TreeData.purs
@@ -25,7 +25,6 @@ import Data.Foldable (find)
 import Data.List ((:))
 import Data.List as L
 
-import SlamData.Workspace.MillerColumns.Component.State as S
 import SlamData.Workspace.MillerColumns.Column.BasicFilter (mkFilter)
 
 type Tree a = CF.Cofree L.List a
@@ -54,5 +53,5 @@ loadFromTree f label tree { path, filter } =
       in
         { items, nextOffset: Nothing }
 
-initialStateFromTree ∷ ∀ a i. (a → i) → Tree a → S.State i
-initialStateFromTree f = L.singleton <<< f <<< extract
+initialStateFromTree ∷ ∀ a i. (a → i) → Tree a → i × L.List a
+initialStateFromTree f t = f (extract t) × L.Nil


### PR DESCRIPTION
After various way over-complicated iterations on this, it turned out there's a relatively simple representation.

We can't represent a column selection without having an `a` for that column, so now we just store those, plus a root `i` (path) value. The intermediate path values are reconstructed from the `a`s, as we can do that thanks to `ColumnOptions`.

Additionally, this representation ensures no unrepresentable column configurations can arise, as now we know for sure there is a selected element for each column up to the last point, which can have a selection if it is a leaf, or can be left open if an item has not yet been selected in that column.