### PR TITLE
Table eval

### DIFF
--- a/less/deck/table-card.less
+++ b/less/deck/table-card.less
@@ -3,10 +3,6 @@
   @pagination-height: @grid-size * 2;
   overflow: hidden !important;
 
-  img {
-      width: 16px;
-      vertical-align: text-top;
-  }
   table {
     width: 100%;
   }

--- a/less/deck/table-card.less
+++ b/less/deck/table-card.less
@@ -3,6 +3,10 @@
   @pagination-height: @grid-size * 2;
   overflow: hidden !important;
 
+  img {
+      width: 16px;
+      vertical-align: text-top;
+  }
   table {
     width: 100%;
   }

--- a/src/SlamData/Workspace/Card/Common/EvalQuery.purs
+++ b/src/SlamData/Workspace/Card/Common/EvalQuery.purs
@@ -67,12 +67,14 @@ data CardEvalMessage
 -- | the model changes in a way that will affect the evaluated output of the
 -- | card.
 data ModelUpdateType
-  = StateOnlyUpdate
-  | EvalModelUpdate
-  | EvalStateUpdate EvalState
+  = EvalModelUpdate
+  | EvalStateUpdate (Maybe EvalState → Maybe EvalState)
 
 modelUpdate ∷ CardEvalMessage
 modelUpdate = ModelUpdated EvalModelUpdate
 
 stateUpdate ∷ EvalState → CardEvalMessage
-stateUpdate = ModelUpdated ∘ EvalStateUpdate
+stateUpdate = ModelUpdated ∘ EvalStateUpdate ∘ const ∘ Just
+
+stateAlter ∷ (Maybe EvalState → Maybe EvalState) → CardEvalMessage
+stateAlter = ModelUpdated ∘ EvalStateUpdate

--- a/src/SlamData/Workspace/Card/Component.purs
+++ b/src/SlamData/Workspace/Card/Component.purs
@@ -196,9 +196,8 @@ makeCardComponent cardType component options =
         EQ.ModelUpdated EQ.EvalModelUpdate → do
           model ← H.query unit (left (H.request EQ.Save))
           for_ model (H.lift ∘ P.publishCardChange displayCoord)
-        EQ.ModelUpdated (EQ.EvalStateUpdate es) → do
-          H.lift $ P.publishCardStateChange displayCoord es
-        EQ.ModelUpdated EQ.StateOnlyUpdate → pure unit
+        EQ.ModelUpdated (EQ.EvalStateUpdate fn) → do
+          H.lift $ P.publishCardStateChange displayCoord fn
       pure next
     CQ.ZoomIn next → do
       H.lift $ navigateToDeck options.cursor

--- a/src/SlamData/Workspace/Card/Eval.purs
+++ b/src/SlamData/Workspace/Card/Eval.purs
@@ -105,7 +105,7 @@ evalCard trans port varMap = map (_ `union` varMap) <$> case trans, port of
   Error msg, _ → CEM.throw msg
   _, Port.CardError msg → CEM.throw msg
   Pass, _ → pure (port × varMap)
-  Table, _ → Table.eval port varMap
+  Table m, _ → Table.eval m port varMap
   Chart, _ → pure (Port.ResourceKey Port.defaultResourceVar × varMap)
   Composite, _ → Port.varMapOut <$> Common.evalComposite
   Terminal, _ → pure Port.terminalOut
@@ -190,5 +190,5 @@ modelToEval = case _ of
   Model.SetupDatetime model → SetupDatetime model
   Model.FormInput model → FormInput model
   Model.Tabs _ → Terminal
-  Model.Table _ → Table
+  Model.Table model → Table model
   _ → Pass

--- a/src/SlamData/Workspace/Card/Eval.purs
+++ b/src/SlamData/Workspace/Card/Eval.purs
@@ -31,6 +31,19 @@ import Data.StrMap (union)
 
 import SlamData.Effects (SlamDataEffects)
 import SlamData.Quasar.Class (class QuasarDSL, class ParQuasarDSL)
+import SlamData.Workspace.Card.Cache.Eval as Cache
+import SlamData.Workspace.Card.CardType as CT
+import SlamData.Workspace.Card.DownloadOptions.Eval as DOptions
+import SlamData.Workspace.Card.Eval.Common as Common
+import SlamData.Workspace.Card.Eval.Monad as CEM
+import SlamData.Workspace.Card.Eval.Transition (Eval(..), tagEval)
+import SlamData.Workspace.Card.FormInput.Eval as FormInput
+import SlamData.Workspace.Card.Markdown.Eval as MDE
+import SlamData.Workspace.Card.Model as Model
+import SlamData.Workspace.Card.Open.Eval as Open
+import SlamData.Workspace.Card.Port as Port
+import SlamData.Workspace.Card.Query.Eval as Query
+import SlamData.Workspace.Card.Search.Eval as Search
 import SlamData.Workspace.Card.Setups.Chart.Area.Eval as BuildArea
 import SlamData.Workspace.Card.Setups.Chart.Bar.Eval as BuildBar
 import SlamData.Workspace.Card.Setups.Chart.Boxplot.Eval as BuildBoxplot
@@ -48,27 +61,15 @@ import SlamData.Workspace.Card.Setups.Chart.PunchCard.Eval as BuildPunchCard
 import SlamData.Workspace.Card.Setups.Chart.Radar.Eval as BuildRadar
 import SlamData.Workspace.Card.Setups.Chart.Sankey.Eval as BuildSankey
 import SlamData.Workspace.Card.Setups.Chart.Scatter.Eval as BuildScatter
-import SlamData.Workspace.Card.Cache.Eval as Cache
-import SlamData.Workspace.Card.CardType as CT
-import SlamData.Workspace.Card.DownloadOptions.Eval as DOptions
-import SlamData.Workspace.Card.Eval.Common as Common
-import SlamData.Workspace.Card.Eval.Monad as CEM
-import SlamData.Workspace.Card.Eval.Transition (Eval(..), tagEval)
-import SlamData.Workspace.Card.Markdown.Eval as MDE
-import SlamData.Workspace.Card.Model as Model
-import SlamData.Workspace.Card.Open.Eval as Open
-import SlamData.Workspace.Card.Port as Port
-import SlamData.Workspace.Card.Query.Eval as Query
-import SlamData.Workspace.Card.Search.Eval as Search
-import SlamData.Workspace.Card.Setups.FormInput.Labeled.Eval as SetupLabeled
 import SlamData.Workspace.Card.Setups.FormInput.Date.Eval as SetupDate
 import SlamData.Workspace.Card.Setups.FormInput.Datetime.Eval as SetupDatetime
+import SlamData.Workspace.Card.Setups.FormInput.Labeled.Eval as SetupLabeled
 import SlamData.Workspace.Card.Setups.FormInput.Numeric.Eval as SetupNumeric
+import SlamData.Workspace.Card.Setups.FormInput.Static.Eval as SetupStatic
 import SlamData.Workspace.Card.Setups.FormInput.Text.Eval as SetupText
 import SlamData.Workspace.Card.Setups.FormInput.Time.Eval as SetupTime
-import SlamData.Workspace.Card.Setups.FormInput.Static.Eval as SetupStatic
+import SlamData.Workspace.Card.Table.Eval as Table
 import SlamData.Workspace.Card.Variables.Eval as VariablesE
-import SlamData.Workspace.Card.FormInput.Eval as FormInput
 
 runCard
   ∷ ∀ f m
@@ -104,6 +105,7 @@ evalCard trans port varMap = map (_ `union` varMap) <$> case trans, port of
   Error msg, _ → CEM.throw msg
   _, Port.CardError msg → CEM.throw msg
   Pass, _ → pure (port × varMap)
+  Table, _ → Table.eval port varMap
   Chart, _ → pure (Port.ResourceKey Port.defaultResourceVar × varMap)
   Composite, _ → Port.varMapOut <$> Common.evalComposite
   Terminal, _ → pure Port.terminalOut
@@ -188,4 +190,5 @@ modelToEval = case _ of
   Model.SetupDatetime model → SetupDatetime model
   Model.FormInput model → FormInput model
   Model.Tabs _ → Terminal
+  Model.Table _ → Table
   _ → Pass

--- a/src/SlamData/Workspace/Card/Eval/State.purs
+++ b/src/SlamData/Workspace/Card/Eval/State.purs
@@ -19,6 +19,7 @@ module SlamData.Workspace.Card.Eval.State
   , initialEvalState
   , AnalysisR
   , AutoSelectR
+  , TableR
   , _Analysis
   , _Axes
   , _Records
@@ -26,6 +27,7 @@ module SlamData.Workspace.Card.Eval.State
   , _LastUsedResource
   , _AutoSelect
   , _ActiveTab
+  , _Table
   ) where
 
 import SlamData.Prelude
@@ -51,10 +53,19 @@ type AutoSelectR =
   , autoSelect ∷ Set.Set Sem.Semantics
   }
 
+type TableR =
+  { resource ∷ Resource
+  , result ∷ String ⊹ Array Json
+  , page ∷ Int
+  , pageSize ∷ Int
+  , size ∷ Int
+  }
+
 data EvalState
   = Analysis AnalysisR
   | AutoSelect AutoSelectR
   | ActiveTab Int
+  | Table TableR
 
 initialEvalState ∷ CM.AnyCardModel → Maybe EvalState
 initialEvalState = case _ of
@@ -79,6 +90,7 @@ _Records = wander \f s → case s of
 _Resource ∷ Traversal' EvalState Resource
 _Resource = wander \f s → case s of
   Analysis r@{ resource } → Analysis ∘ r { resource = _} <$> f resource
+  Table r@{ resource } → Table ∘ r { resource = _ } <$> f resource
   _ → pure s
 
 _LastUsedResource ∷ Traversal' EvalState Resource
@@ -95,3 +107,13 @@ _ActiveTab ∷ Prism' EvalState Int
 _ActiveTab = prism' ActiveTab case _ of
   ActiveTab n → Just n
   _ → Nothing
+
+_Table ∷ Prism' EvalState TableR
+_Table = prism' Table case _ of
+  Table r → Just r
+  _ → Nothing
+
+_ResourceSize ∷ Traversal' EvalState Int
+_ResourceSize = wander \f s → case s of
+  Table r@{ size } → Table ∘ r { size = _ } <$> f size
+  _ → pure s

--- a/src/SlamData/Workspace/Card/Eval/Transition.purs
+++ b/src/SlamData/Workspace/Card/Eval/Transition.purs
@@ -21,30 +21,30 @@ import SlamData.Prelude
 import Quasar.Types (SQL)
 
 import SlamData.FileSystem.Resource as R
-import SlamData.Workspace.Card.Setups.Chart.Metric.Model as BuildMetric
-import SlamData.Workspace.Card.Setups.Chart.Sankey.Model as BuildSankey
+import SlamData.Workspace.Card.DownloadOptions.Component.State as Download
+import SlamData.Workspace.Card.FormInput.Model as FormInput
+import SlamData.Workspace.Card.Markdown.Model as Markdown
+import SlamData.Workspace.Card.Setups.Chart.Area.Model as BuildArea
+import SlamData.Workspace.Card.Setups.Chart.Bar.Model as BuildBar
+import SlamData.Workspace.Card.Setups.Chart.Boxplot.Model as BuildBoxplot
+import SlamData.Workspace.Card.Setups.Chart.Candlestick.Eval as BuildCandlestick
+import SlamData.Workspace.Card.Setups.Chart.Funnel.Model as BuildFunnel
 import SlamData.Workspace.Card.Setups.Chart.Gauge.Model as BuildGauge
 import SlamData.Workspace.Card.Setups.Chart.Graph.Model as BuildGraph
-import SlamData.Workspace.Card.Setups.Chart.Pie.Model as BuildPie
-import SlamData.Workspace.Card.Setups.Chart.Radar.Model as BuildRadar
-import SlamData.Workspace.Card.Setups.Chart.Area.Model as BuildArea
-import SlamData.Workspace.Card.Setups.Chart.Line.Model as BuildLine
-import SlamData.Workspace.Card.Setups.Chart.Bar.Model as BuildBar
-import SlamData.Workspace.Card.Setups.Chart.Scatter.Model as BuildScatter
-import SlamData.Workspace.Card.Setups.Chart.Funnel.Model as BuildFunnel
 import SlamData.Workspace.Card.Setups.Chart.Heatmap.Model as BuildHeatmap
-import SlamData.Workspace.Card.Setups.Chart.Boxplot.Model as BuildBoxplot
-import SlamData.Workspace.Card.Setups.Chart.PivotTable.Model as BuildPivotTable
-import SlamData.Workspace.Card.DownloadOptions.Component.State as Download
-import SlamData.Workspace.Card.Markdown.Model as Markdown
-import SlamData.Workspace.Card.Variables.Model as Variables
-import SlamData.Workspace.Card.Setups.Chart.PunchCard.Eval as BuildPunchCard
-import SlamData.Workspace.Card.Setups.Chart.Candlestick.Eval as BuildCandlestick
+import SlamData.Workspace.Card.Setups.Chart.Line.Model as BuildLine
+import SlamData.Workspace.Card.Setups.Chart.Metric.Model as BuildMetric
 import SlamData.Workspace.Card.Setups.Chart.Parallel.Eval as BuildParallel
+import SlamData.Workspace.Card.Setups.Chart.Pie.Model as BuildPie
+import SlamData.Workspace.Card.Setups.Chart.PivotTable.Model as BuildPivotTable
+import SlamData.Workspace.Card.Setups.Chart.PunchCard.Eval as BuildPunchCard
+import SlamData.Workspace.Card.Setups.Chart.Radar.Model as BuildRadar
+import SlamData.Workspace.Card.Setups.Chart.Sankey.Model as BuildSankey
+import SlamData.Workspace.Card.Setups.Chart.Scatter.Model as BuildScatter
 import SlamData.Workspace.Card.Setups.FormInput.Labeled.Model as SetupLabeled
-import SlamData.Workspace.Card.Setups.FormInput.TextLike.Model as SetupTextLike
 import SlamData.Workspace.Card.Setups.FormInput.Static.Model as SetupStatic
-import SlamData.Workspace.Card.FormInput.Model as FormInput
+import SlamData.Workspace.Card.Setups.FormInput.TextLike.Model as SetupTextLike
+import SlamData.Workspace.Card.Variables.Model as Variables
 
 data Eval
   = Pass
@@ -87,6 +87,7 @@ data Eval
   | SetupDatetime SetupTextLike.Model
   | SetupStatic SetupStatic.Model
   | FormInput FormInput.Model
+  | Table
 
 tagEval ∷ Eval → String
 tagEval = case _ of
@@ -130,3 +131,4 @@ tagEval = case _ of
   SetupDatetime _ → "SetupDatetime"
   SetupStatic _ → "SetupStatic"
   FormInput _ → "FormInput"
+  Table → "Table"

--- a/src/SlamData/Workspace/Card/Eval/Transition.purs
+++ b/src/SlamData/Workspace/Card/Eval/Transition.purs
@@ -45,6 +45,7 @@ import SlamData.Workspace.Card.Setups.FormInput.Labeled.Model as SetupLabeled
 import SlamData.Workspace.Card.Setups.FormInput.Static.Model as SetupStatic
 import SlamData.Workspace.Card.Setups.FormInput.TextLike.Model as SetupTextLike
 import SlamData.Workspace.Card.Variables.Model as Variables
+import SlamData.Workspace.Card.Table.Model as Table
 
 data Eval
   = Pass
@@ -87,7 +88,7 @@ data Eval
   | SetupDatetime SetupTextLike.Model
   | SetupStatic SetupStatic.Model
   | FormInput FormInput.Model
-  | Table
+  | Table Table.Model
 
 tagEval ∷ Eval → String
 tagEval = case _ of
@@ -131,4 +132,4 @@ tagEval = case _ of
   SetupDatetime _ → "SetupDatetime"
   SetupStatic _ → "SetupStatic"
   FormInput _ → "FormInput"
-  Table → "Table"
+  Table _ → "Table"

--- a/src/SlamData/Workspace/Card/Table/Component.purs
+++ b/src/SlamData/Workspace/Card/Table/Component.purs
@@ -22,25 +22,18 @@ module SlamData.Workspace.Card.Table.Component
 
 import SlamData.Prelude
 
-import Control.Monad.Error.Class as EC
-import Control.Monad.Except.Trans as ET
-
 import Data.Argonaut as JSON
 import Data.Int as Int
-import Data.Lens ((.~), (?~), (^.), (^?))
-import Data.Array as Arr
+import Data.Lens ((.~), (^?))
 
 import DOM.Classy.Event as DOM
 
 import Halogen as H
 
-import SlamData.Quasar.Error as QE
-import SlamData.Quasar.Query as Quasar
 import SlamData.Workspace.Card.CardType as CT
 import SlamData.Workspace.Card.Component as CC
 import SlamData.Workspace.Card.Eval.State as ES
 import SlamData.Workspace.Card.Model as Card
-import SlamData.Workspace.Card.Port as Port
 import SlamData.Workspace.Card.Table.Component.Query (PageStep(..), Query(..))
 import SlamData.Workspace.Card.Table.Component.Render (render)
 import SlamData.Workspace.Card.Table.Component.State as JTS
@@ -71,69 +64,34 @@ evalCard = case _ of
       Card.Table model → H.put $ JTS.fromModel model
       _ → pure unit
     pure next
-  CC.ReceiveInput _ varMap next → do
-    runTable varMap
+  CC.ReceiveInput _ _ next → do
     pure next
   CC.ReceiveOutput _ _ next →
     pure next
   CC.ReceiveState s next → do
-    for_ (s ^? ES._Table) \t → do
-      traceAnyA t
+    for_ (s ^? ES._Table) \t →
+      H.modify case t.result of
+        Left e →
+          _{ result = JTS.Errored e
+           }
+        Right _ | t.size ≡ 0 →
+          _{ result = JTS.Empty
+           }
+        Right a | otherwise →
+          _{ result = JTS.Ready
+               { json: JSON.fromArray a
+               , page: t.page
+               , pageSize: t.pageSize
+               }
+           , size = Just t.size
+           , isEnteringPageSize = false
+           }
     pure next
   CC.ReceiveDimensions dims reply → do
     pure $ reply
       if dims.width < 360.0 ∨ dims.height < 240.0
       then Low
       else High
-
-runTable
-  ∷ Port.DataMap
-  → DSL Unit
-runTable varMap = case Port.extractResource varMap of
-  Just resource → updateTable resource
-  _ → H.modify $ JTS._result .~ JTS.Errored "Expected a TaggedResource input"
-
-updateTable
-  ∷ Port.Resource
-  → DSL Unit
-updateTable resource = do
-  r ← ET.runExceptT do
-    oldInput ← lift $ H.gets _.input
-    when ((oldInput <#> _.resource) ≠ pure resource)
-      $ lift $ resetState
-
-    size ← liftQ $ Quasar.count $ resource ^. Port._filePath
-    lift $ H.modify $ JTS._input ?~ { resource, size }
-    p ← lift $ H.gets JTS.pendingPageInfo
-
-    items ←
-      liftQ $ Quasar.sample (resource ^. Port._filePath) ((p.page - 1) * p.pageSize) p.pageSize
-
-    let
-      result
-        | Arr.null items = JTS.Empty
-        | otherwise = JTS.Ready
-            { json: JSON.fromArray items
-            , page: p.page
-            , pageSize: p.pageSize
-            }
-
-    pure result
-  H.modify case r of
-    Left s → JTS._result .~ JTS.Errored (QE.printQError s)
-    Right result → (JTS._result .~ result) ∘ (JTS._isEnteringPageSize .~ false)
-
-
-liftQ
-  ∷ ∀ m a
-  . (EC.MonadError QE.QError m)
-  ⇒ m (Either QE.QError a)
-  → m a
-liftQ m = either EC.throwError pure =<< m
-
--- | Resets the state while preserving settings like page size.
-resetState ∷ DSL Unit
-resetState = H.modify (JTS._result .~ JTS.Loading)
 
 -- | Evaluates table-specific card queries.
 evalTable ∷ Query ~> DSL
@@ -146,20 +104,21 @@ evalTable = case _ of
     for_ (Int.fromString pageSize) (H.modify ∘ JTS.resizePage)
     refresh
     pure next
-  StartEnterCustomPageSize next →
-    H.modify (JTS._isEnteringPageSize .~ true) $> next
-  SetCustomPageSize size next →
-    H.modify (JTS.setPageSize size) $> next
-  SetCustomPage page next →
-    H.modify (JTS.setPage page) $> next
-  Update next →
-    refresh $> next
+  StartEnterCustomPageSize next → do
+    H.modify (JTS._isEnteringPageSize .~ true)
+    pure next
+  SetCustomPageSize size next → do
+    H.modify (JTS.setPageSize size)
+    refresh
+    pure next
+  SetCustomPage page next → do
+    H.modify (JTS.setPage page)
+    refresh
+    pure next
   PreventDefault ev next → do
     H.liftEff $ DOM.preventDefault ev
     pure next
 
 refresh ∷ DSL Unit
-refresh = do
-  input ← H.gets _.input
-  for_ input $ _.resource ⋙ updateTable
-  H.raise $ CC.modelUpdate
+refresh =
+  H.raise CC.modelUpdate

--- a/src/SlamData/Workspace/Card/Table/Component.purs
+++ b/src/SlamData/Workspace/Card/Table/Component.purs
@@ -25,9 +25,10 @@ import SlamData.Prelude
 import Control.Monad.Error.Class as EC
 import Control.Monad.Except.Trans as ET
 
-import Data.Argonaut.Core as JSON
+import Data.Argonaut as JSON
 import Data.Int as Int
 import Data.Lens ((.~), (?~))
+--import Data.Lens ((.~))
 
 import DOM.Classy.Event as DOM
 
@@ -102,7 +103,8 @@ updateTable resource tag varMap = do
   when (((oldInput <#> _.resource) ≠ pure resource) || ((oldInput >>= _.tag) ≠ tag))
     $ lift $ resetState
 
-  size ← liftQ $ Quasar.count resource
+  let size = 1000
+--  size ← liftQ $ Quasar.count resource
 
   lift $ H.modify $ JTS._input ?~ { resource, size, tag, varMap }
   p ← lift $ H.gets JTS.pendingPageInfo
@@ -113,7 +115,10 @@ updateTable resource tag varMap = do
   lift
     $ H.modify
     $ (JTS._isEnteringPageSize .~ false)
-    ∘ (JTS._result ?~
+--    ∘ (JTS._result .~ JTS.Empty)
+--    ∘ (JTS._result .~ JTS.Errored "Errored")
+--    ∘ (JTS._result .~ Nothing)
+    ∘ (JTS._result .~ JTS.Ready
          { json: JSON.fromArray items
          , page: p.page
          , pageSize: p.pageSize
@@ -128,7 +133,7 @@ liftQ m = either EC.throwError pure =<< m
 
 -- | Resets the state while preserving settings like page size.
 resetState ∷ DSL Unit
-resetState = H.modify (JTS._result .~ Nothing)
+resetState = H.modify (JTS._result .~ JTS.Loading)
 
 -- | Evaluates table-specific card queries.
 evalTable ∷ Query ~> DSL

--- a/src/SlamData/Workspace/Card/Table/Component/Query.purs
+++ b/src/SlamData/Workspace/Card/Table/Component/Query.purs
@@ -24,7 +24,6 @@ data Query a
   | SetCustomPage String a
   | SetCustomPageSize String a
   | StartEnterCustomPageSize a
-  | Update a
   | PreventDefault Event a
 
 data PageStep

--- a/src/SlamData/Workspace/Card/Table/Component/Render.purs
+++ b/src/SlamData/Workspace/Card/Table/Component/Render.purs
@@ -59,13 +59,11 @@ render st =
     Errored e → renderError e
     Ready result → renderResult result
   where
+  -- This is _loading_ but since we display semitransparent div with spinner on
+  -- top of loading deck there is no reason to display anything else
   renderLoading =
-    A.singleton
-    $ HH.div
-      [ HP.classes [ B.alert, B.alertInfo ] ]
-      [ HH.img [ HP.src "img/blue-spin.svg" ]
-      , HH.text "Loading"
-      ]
+    [ ]
+
   renderEmpty =
     A.singleton
     $ HH.div

--- a/src/SlamData/Workspace/Card/Table/Component/Render.purs
+++ b/src/SlamData/Workspace/Card/Table/Component/Render.purs
@@ -63,7 +63,6 @@ render st =
   -- top of loading deck there is no reason to display anything else
   renderLoading =
     [ ]
-
   renderEmpty =
     A.singleton
     $ HH.div

--- a/src/SlamData/Workspace/Card/Table/Component/State.purs
+++ b/src/SlamData/Workspace/Card/Table/Component/State.purs
@@ -18,25 +18,22 @@ module SlamData.Workspace.Card.Table.Component.State
   ( State
   , Result(..)
   , ResultR
-  , Input
   , initialState
-  , _input
   , _result
   , _Result
   , _page
   , _pageSize
   , _isEnteringPageSize
-  , _resource
   , _size
   , PageInfo
   , currentPageInfo
-  , pendingPageInfo
   , stepPage
   , setPage
   , resizePage
   , setPageSize
   , toModel
   , fromModel
+  , calcTotalPages
   ) where
 
 import SlamData.Prelude
@@ -48,11 +45,10 @@ import Data.Lens ((^?), (?~), Lens', lens, _Just, Prism', prism', Traversal')
 
 import SlamData.Workspace.Card.Table.Component.Query (PageStep(..))
 import SlamData.Workspace.Card.Table.Model (Model)
-import SlamData.Workspace.Card.Port as Port
 
 -- | The state for the Table card component.
 type State =
-  { input ∷ Maybe Input
+  { size ∷ Maybe Int
   , result ∷ Result
   , page ∷ Maybe (String ⊹ Int)
   , pageSize ∷ Maybe (Either String Int)
@@ -77,20 +73,14 @@ _ResultR = prism' Ready case _ of
   Ready r → Just r
   _ → Nothing
 
--- | An empty initial state for the Table card component.
 initialState ∷ State
 initialState =
-  { input: Nothing
+  { size: Nothing
   , result: Loading
   , page: Nothing
   , pageSize: Nothing
   , isEnteringPageSize: false
   }
-
--- | The current card input - a resource location for the results, and the size
--- | of the result set.
-_input ∷ ∀ a r. Lens' {input ∷ a|r} a
-_input = lens _.input (_ { input = _ })
 
 _result ∷ ∀ a r. Lens' {result ∷ a|r} a
 _result = lens _.result (_ { result = _ })
@@ -104,23 +94,12 @@ _page = lens _.page (_ { page = _ })
 _pageSize ∷ ∀ a r. Lens' {pageSize ∷ a|r} a
 _pageSize = lens _.pageSize (_ { pageSize = _ })
 
+_size ∷ ∀ a r. Lens' {size ∷ a|r} a
+_size = lens _.size _{ size = _ }
+
 -- | Specifies whether the custom page size entry is currently enabled.
 _isEnteringPageSize ∷ ∀ a r. Lens' {isEnteringPageSize ∷ a|r} a
 _isEnteringPageSize = lens _.isEnteringPageSize (_ { isEnteringPageSize = _ })
-
--- | The card input state.
-type Input =
-  { resource ∷ Port.Resource
-  , size ∷ Int
-  }
-
--- | The resource to load pages of data from.
-_resource ∷ ∀ a r. Lens' {resource ∷ a|r} a
-_resource = lens _.resource (_ { resource = _ })
-
--- | The total size of the resource's result set.
-_size ∷ ∀ a r. Lens' {size ∷ a|r} a
-_size = lens _.size (_ { size = _ })
 
 -- | A record with information about the current page number, page size, and
 -- | total number of pages.
@@ -128,26 +107,17 @@ type PageInfo = { page ∷ Int, pageSize ∷ Int, totalPages ∷ Int }
 
 currentPageInfo ∷ State → PageInfo
 currentPageInfo st =
-  let page = fromMaybe 1 $ _.page <$> st ^? _Result
-      pageSize = fromMaybe 0 $ _.pageSize <$> st ^? _Result
-      total = fromMaybe 0 $ st ^? _input ∘ _Just ∘ _size
-      totalPages = calcTotalPages pageSize total
-  in { page, pageSize, totalPages }
-
--- | Compute page info from the current state, preferring user-entered pending
--- | values if they are present and succesfully parseable.
-pendingPageInfo ∷ State → PageInfo
-pendingPageInfo st =
-  let customPage = either Int.fromString pure =<< st.page
-      actualPage = _.page <$> st ^? _Result
-      page = fromMaybe 1 $ customPage <|> actualPage
-      customPageSize = either Int.fromString pure =<< st.pageSize
-      actualPageSize = _.pageSize <$> st ^? _Result
-      pageSize = fromMaybe 10 $ customPageSize <|> actualPageSize
-      total = fromMaybe 0 $ st ^? _input ∘ _Just ∘ _size
-      totalPages = calcTotalPages pageSize total
-      page' = min page totalPages
-  in { page: page', pageSize, totalPages }
+  let
+    result = st ^? _Result
+    page = fromMaybe 1 $ map _.page result
+    pageSize = fromMaybe 0 $ map _.pageSize result
+    itemCount = fromMaybe 0 $ st ^? _size ∘ _Just
+    total = calcTotalPages {pageSize, itemCount}
+  in
+    { page
+    , pageSize
+    , totalPages: total
+    }
 
 -- | Changes the current page based on a PageStep increment.
 stepPage ∷ PageStep → State → State
@@ -168,28 +138,33 @@ pageStepValue step st = go step
   page =
     fromMaybe 1 $ _.page <$> st ^? _Result
 
-  totalPages =
-    fromMaybe 1
-      $ calcTotalPages
-      <$> (_.pageSize <$> st ^? _Result)
-      <*> (st ^? _input ∘ _Just ∘ _size)
+  total =
+    totalPages st
 
   go First = 1
-  go Last = totalPages
+  go Last = total
   go Prev
     | page <= 1 = 1
     | otherwise = page - 1
   go Next
-    | page >= totalPages = totalPages
+    | page >= total = total
     | otherwise = page + 1
+
+totalPages ∷ State → Int
+totalPages st =
+  fromMaybe 1
+    $ map calcTotalPages
+    $ { pageSize: _, itemCount: _}
+    <$> (_.pageSize <$> st ^? _Result)
+    <*> (st ^? _size ∘ _Just)
 
 -- | Calculates the total number of pages for a given page size and total
 -- | number of results.
-calcTotalPages ∷ Int → Int → Int
-calcTotalPages _ 0 = 1
-calcTotalPages 0 _ = 1
-calcTotalPages pageSize total =
-  fromMaybe 1 $ maximum [1, Int.ceil (Int.toNumber total / Int.toNumber pageSize)]
+calcTotalPages ∷ { pageSize ∷ Int, itemCount ∷ Int } → Int
+calcTotalPages { pageSize: 0} = 1
+calcTotalPages { itemCount: 0} = 1
+calcTotalPages { pageSize, itemCount} =
+  fromMaybe 1 $ maximum [1, Int.ceil (Int.toNumber itemCount / Int.toNumber pageSize)]
 
 -- | Sets the pending page size based on a concrete numeric value.
 resizePage ∷ Int → State → State
@@ -201,8 +176,8 @@ setPageSize size = _pageSize ?~ Left size
 
 toModel ∷ State → Model
 toModel st =
-  { page: (_.page <$> st ^? _Result) <|> (either (const Nothing) Just =<< st.page)
-  , pageSize: (_.pageSize <$> st ^? _Result) <|> (either (const Nothing) Just =<< st.pageSize)
+  { page: either Int.fromString Just =<< st.page
+  , pageSize: either Int.fromString Just =<< st.pageSize
   }
 
 fromModel ∷ Model → State

--- a/src/SlamData/Workspace/Card/Table/Component/State.purs
+++ b/src/SlamData/Workspace/Card/Table/Component/State.purs
@@ -28,7 +28,6 @@ module SlamData.Workspace.Card.Table.Component.State
   , _isEnteringPageSize
   , _resource
   , _size
-  , _levelOfDetails
   , PageInfo
   , currentPageInfo
   , pendingPageInfo
@@ -50,9 +49,6 @@ import Data.Lens ((^?), (?~), Lens', lens, _Just, Prism', prism', Traversal')
 import SlamData.Workspace.Card.Table.Component.Query (PageStep(..))
 import SlamData.Workspace.Card.Table.Model (Model)
 import SlamData.Workspace.Card.Port as Port
-import SlamData.Workspace.LevelOfDetails (LevelOfDetails(..))
-
-import Utils.Path (FilePath)
 
 -- | The state for the Table card component.
 type State =
@@ -61,9 +57,7 @@ type State =
   , page ∷ Maybe (String ⊹ Int)
   , pageSize ∷ Maybe (Either String Int)
   , isEnteringPageSize ∷ Boolean
-  , levelOfDetails ∷ LevelOfDetails
   }
-
 
 -- | The current result value being displayed.
 type ResultR =
@@ -91,7 +85,6 @@ initialState =
   , page: Nothing
   , pageSize: Nothing
   , isEnteringPageSize: false
-  , levelOfDetails: High
   }
 
 -- | The current card input - a resource location for the results, and the size
@@ -115,15 +108,10 @@ _pageSize = lens _.pageSize (_ { pageSize = _ })
 _isEnteringPageSize ∷ ∀ a r. Lens' {isEnteringPageSize ∷ a|r} a
 _isEnteringPageSize = lens _.isEnteringPageSize (_ { isEnteringPageSize = _ })
 
-_levelOfDetails ∷ ∀ a r. Lens' {levelOfDetails ∷ a|r} a
-_levelOfDetails = lens (_.levelOfDetails) (_{levelOfDetails = _})
-
 -- | The card input state.
 type Input =
-  { resource ∷ FilePath
-  , tag ∷ Maybe String
+  { resource ∷ Port.Resource
   , size ∷ Int
-  , varMap ∷ Maybe Port.VarMap
   }
 
 -- | The resource to load pages of data from.
@@ -133,12 +121,6 @@ _resource = lens _.resource (_ { resource = _ })
 -- | The total size of the resource's result set.
 _size ∷ ∀ a r. Lens' {size ∷ a|r} a
 _size = lens _.size (_ { size = _ })
-
--- | This is used to determine if query producing temporary resource has
--- | been changed. It holds sql query.
-_tag ∷ ∀ a r. Lens' {tag ∷ a|r} a
-_tag = lens _.tag _{tag = _}
-
 
 -- | A record with information about the current page number, page size, and
 -- | total number of pages.

--- a/src/SlamData/Workspace/Card/Table/Eval.purs
+++ b/src/SlamData/Workspace/Card/Table/Eval.purs
@@ -1,3 +1,19 @@
+{-
+Copyright 2016 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
 module SlamData.Workspace.Card.Table.Eval
   ( eval
   ) where
@@ -16,6 +32,7 @@ import SlamData.Quasar.Class (class QuasarDSL)
 import SlamData.Workspace.Card.Eval.Monad as CEM
 import SlamData.Workspace.Card.Port as Port
 import SlamData.Workspace.Card.Eval.State as ES
+import SlamData.Workspace.Card.Table.Model as M
 
 eval
   ∷ ∀ m
@@ -23,10 +40,11 @@ eval
     , MonadThrow CEM.CardError m
     , QuasarDSL m
     )
-  ⇒ Port.Port
+  ⇒ M.Model
+  → Port.Port
   → Port.DataMap
   → m Port.Out
-eval port varMap =
+eval model port varMap =
   Port.extractResource varMap
     # maybe (CEM.throw "Expected a TaggedResource input") \resource → do
       rawTableState ← map (_ ^? _Just ∘ ES._Table ) get
@@ -38,33 +56,47 @@ eval port varMap =
           , page: 1
           , pageSize: 10
           }
-        state = fromMaybe defaultState rawTableState
-      -- TODO: check if page/pageSize/resource hasn't been changed
-      resultAndSize ← runExceptT do
-        size ←
-          ExceptT
-          $ map (lmap QE.printQError)
-          $ Quasar.count
-          $ resource ^. Port._filePath
-        result ←
-          ExceptT
-          $ map (lmap QE.printQError)
-          $ Quasar.sample
-          (resource ^. Port._filePath)
-          ((state.page - 1) * state.pageSize)
-          state.pageSize
-        pure $ result × size
+        state =
+          fromMaybe defaultState rawTableState
+        pageSize =
+          fromMaybe state.pageSize model.pageSize
+        page =
+          fromMaybe state.page model.page
 
-      put $ Just $ ES.Table
-        { resource
-        , result: map fst resultAndSize
-        , size: either zero snd resultAndSize
-        , page: state.page
-        , pageSize: state.pageSize
-        }
-      either
-        CEM.throw
-        (const $ pure unit)
-        resultAndSize
+      unless (samePageAndResource rawTableState resource model) do
+        resultAndSize ← runExceptT do
+          size ←
+            case rawTableState of
+              Just t | t.resource ≡ resource → pure t.size
+              _ → liftET $ Quasar.count $ resource ^. Port._filePath
+
+          result ←
+            liftET
+            $ Quasar.sample
+            (resource ^. Port._filePath)
+            ((page - 1) * pageSize)
+            pageSize
+          pure $ result × size
+        put $ Just $ ES.Table
+          { resource
+          , result: map fst resultAndSize
+          , size: either zero snd resultAndSize
+          , page
+          , pageSize
+          }
+        either
+          CEM.throw
+          (const $ pure unit)
+          resultAndSize
 
       pure $ port × varMap
+  where
+  samePageAndResource ∷ Maybe ES.TableR → Port.Resource → M.Model → Boolean
+  samePageAndResource Nothing _ _ = false
+  samePageAndResource (Just t) resource {page, pageSize} =
+    t.resource ≡ resource
+    ∧ Just t.page ≡ page
+    ∧ Just t.pageSize ≡ pageSize
+
+  liftET ∷ ∀ a. m (CEM.CardError ⊹ a) → ExceptT String m a
+  liftET = ExceptT ∘ map (lmap QE.printQError)

--- a/src/SlamData/Workspace/Card/Table/Eval.purs
+++ b/src/SlamData/Workspace/Card/Table/Eval.purs
@@ -1,0 +1,70 @@
+module SlamData.Workspace.Card.Table.Eval
+  ( eval
+  ) where
+
+import SlamData.Prelude
+
+import Control.Monad.State (class MonadState, put, get)
+import Control.Monad.Throw (class MonadThrow)
+
+import Data.Lens ((^.), (^?), _Just)
+
+import SlamData.Quasar.Query as Quasar
+import SlamData.Quasar.Error as QE
+
+import SlamData.Quasar.Class (class QuasarDSL)
+import SlamData.Workspace.Card.Eval.Monad as CEM
+import SlamData.Workspace.Card.Port as Port
+import SlamData.Workspace.Card.Eval.State as ES
+
+eval
+  ∷ ∀ m
+  . ( MonadState CEM.CardState m
+    , MonadThrow CEM.CardError m
+    , QuasarDSL m
+    )
+  ⇒ Port.Port
+  → Port.DataMap
+  → m Port.Out
+eval port varMap =
+  Port.extractResource varMap
+    # maybe (CEM.throw "Expected a TaggedResource input") \resource → do
+      rawTableState ← map (_ ^? _Just ∘ ES._Table ) get
+      let
+        defaultState =
+          { resource
+          , result: Right [ ]
+          , size: 0
+          , page: 1
+          , pageSize: 10
+          }
+        state = fromMaybe defaultState rawTableState
+      -- TODO: check if page/pageSize/resource hasn't been changed
+      resultAndSize ← runExceptT do
+        size ←
+          ExceptT
+          $ map (lmap QE.printQError)
+          $ Quasar.count
+          $ resource ^. Port._filePath
+        result ←
+          ExceptT
+          $ map (lmap QE.printQError)
+          $ Quasar.sample
+          (resource ^. Port._filePath)
+          ((state.page - 1) * state.pageSize)
+          state.pageSize
+        pure $ result × size
+
+      put $ Just $ ES.Table
+        { resource
+        , result: map fst resultAndSize
+        , size: either zero snd resultAndSize
+        , page: state.page
+        , pageSize: state.pageSize
+        }
+      either
+        CEM.throw
+        (const $ pure unit)
+        resultAndSize
+
+      pure $ port × varMap


### PR DESCRIPTION
This and quasar-analytics/quasar#1931 fixes #1425 (This one is only show error messages and adds error card) 

+ Removed `StateOnlyChange` 
+ Added `stateAlter`. I thought about modifying eval state in component but finished up with this solution. So, technically `stateAlter` isn't necessary, but I think it can be useful in many situation. 
+ Moved querying from `Table.Component` to `Table.Eval`
+ If an error is occured table component presents alert and put error card on top. 

@garyb Please review