### PR TITLE
fixes #1536 nub misbehaving in z-index

### DIFF
--- a/less/workspace.less
+++ b/less/workspace.less
@@ -6,7 +6,7 @@
   bottom: 0;
 
   .sd-nav {
-    z-index: 999;
+    z-index: 1;
   }
 
   .sd-nav.open {


### PR DESCRIPTION
So I talked with @beckyconning and it would seem that it needs to be a `z-index` below 12 of the cards. This number put it above 0 indexed stuff, but unless it needs to be a mysterious `z-index` above something else, as we know those numbers are always seemingly arbitrary, then we should bump it (or the card) appropriately.