### PR TITLE
Topology changes should go through Persistence

### DIFF
--- a/src/SlamData/Workspace/Card/Draftboard/Component/State.purs
+++ b/src/SlamData/Workspace/Card/Draftboard/Component/State.purs
@@ -58,7 +58,6 @@ type State =
   , cellLayout ∷ List.List (Cell (Maybe DeckId) Number)
   , edgeLayout ∷ List.List (Edge Number)
   , cursors ∷ Map.Map DeckId Cursor
-  , inserting ∷ Boolean
   }
 
 type SplitOpts =
@@ -98,7 +97,6 @@ initialState =
   , cellLayout: mempty
   , edgeLayout: mempty
   , cursors: mempty
-  , inserting: false
   }
 
 initialRect ∷ Rect Number


### PR DESCRIPTION
Pointer fiddling in the components is brittle. Anything that changes the
topology of the graph should go through Persistence, and the graph
should be rebuilt appropriately.

Fixes #1531 