### PR TITLE
Extract `load` from `ColumnOptions` for more flexibility & sanity

### DIFF
--- a/src/Halogen/Component/Proxy.purs
+++ b/src/Halogen/Component/Proxy.purs
@@ -17,6 +17,7 @@ limitations under the License.
 module Halogen.Component.Proxy
   ( ProxyQ
   , ProxyComponent
+  , queryQ
   , proxy
   , proxyQI
   , proxyQL
@@ -28,7 +29,7 @@ module Halogen.Component.Proxy
 import Prelude
 
 import Data.Const (Const)
-import Data.Coyoneda (Coyoneda, unCoyoneda)
+import Data.Coyoneda (Coyoneda, liftCoyoneda, unCoyoneda)
 import Data.Functor.Coproduct (Coproduct, left, right)
 import Data.Maybe (Maybe(..))
 import Data.Newtype (unwrap)
@@ -42,6 +43,9 @@ data ProxyQ f i o a
   = Query (Coyoneda f a)
   | Receive i a
   | Raise o a
+
+queryQ ∷ ∀ f i o. f ~> ProxyQ f i o
+queryQ = Query <<< liftCoyoneda
 
 type ProxyComponent f i o m = H.Component HH.HTML (ProxyQ f i o) i o m
 

--- a/src/SlamData/Workspace/Card/Open/Component.purs
+++ b/src/SlamData/Workspace/Card/Open/Component.purs
@@ -21,7 +21,7 @@ module SlamData.Workspace.Card.Open.Component
 
 import SlamData.Prelude
 
-import Control.Monad.Eff.Ref as Ref
+import Control.Monad.State as CMS
 
 import Data.Array as A
 import Data.Lens (view)
@@ -39,7 +39,6 @@ import Halogen.Themes.Bootstrap3 as B
 import SlamData.FileSystem.Resource as R
 import SlamData.GlobalError as GE
 import SlamData.GlobalMenu.Bus as GMB
-import SlamData.Monad (Slam)
 import SlamData.Notification as N
 import SlamData.Quasar.Error as QE
 import SlamData.Quasar.FS as Quasar
@@ -48,9 +47,10 @@ import SlamData.Wiring as Wiring
 import SlamData.Workspace.Card.CardType as CT
 import SlamData.Workspace.Card.Component as CC
 import SlamData.Workspace.Card.Model as Card
-import SlamData.Workspace.Card.Open.Component.Query (Query(..))
+import SlamData.Workspace.Card.Open.Component.Query (Query)
 import SlamData.Workspace.Card.Open.Component.Query as Q
 import SlamData.Workspace.Card.Open.Component.State (State, initialState)
+import SlamData.Workspace.Card.Open.Item (AnyItem(..), AnyItem', AnyPath', anyItemToOpen)
 import SlamData.Workspace.Card.Open.Model as Open
 import SlamData.Workspace.Card.Port as Port
 import SlamData.Workspace.Card.Port.VarMap as VM
@@ -58,28 +58,10 @@ import SlamData.Workspace.LevelOfDetails as LOD
 import SlamData.Workspace.MillerColumns.BasicItem.Component as MCI
 import SlamData.Workspace.MillerColumns.Column.BasicFilter as MCF
 import SlamData.Workspace.MillerColumns.Column.Component as MCC
+import SlamData.Workspace.MillerColumns.Column.Component.Request as MCR
 import SlamData.Workspace.MillerColumns.Component as MC
 
 import Utils.Path (AnyPath)
-
-data AnyItem a
-  = Root
-  | Variables
-  | Variable VM.Var
-  | Resource a
-
-anyItemToOpen ∷ AnyItem' → Maybe Open.Open
-anyItemToOpen = case _ of
-  Variable v → Just (Open.Variable v)
-  Resource r → Just (Open.Resource r)
-  _ → Nothing
-
-derive instance eqAnyItem ∷ Eq a ⇒ Eq (AnyItem a)
-derive instance ordAnyItem ∷ Ord a ⇒ Ord (AnyItem a)
-derive instance functorAnyItem ∷ Functor AnyItem
-
-type AnyPath' = AnyItem AnyPath
-type AnyItem' = AnyItem R.Resource
 
 type ColumnsQuery = MC.Query AnyItem' AnyPath' Void
 type DSL = CC.InnerCardParentDSL State Query ColumnsQuery Unit
@@ -92,24 +74,23 @@ openComponent =
     , eval: evalCard ⨁ evalOpen
     , initialState: const initialState
     , receiver: const Nothing
-    , initializer: Just $ right $ H.action Init
+    , initializer: Just $ right $ H.action Q.Init
     , finalizer: Nothing
     }
 
 render ∷ State → HTML
-render state =
-  case state.currentVars of
-    Just ref → HH.slot unit (MC.component $ columnOptions ref) (pathToColumnData Root) handleMessage
-    Nothing → HH.text ""
+render _ = HH.slot unit columnsComponent (pathToColumnData Root) handleMessage
 
 handleMessage ∷ MC.Message' AnyItem' AnyPath' Void → Maybe (CC.InnerCardQuery Query Unit)
 handleMessage = either handleSelection absurd
   where
   runInput ∷ Maybe Open.Open → Maybe (CC.InnerCardQuery Query Unit)
-  runInput sel = Just $ H.action $ right ∘ UpdateSelection sel
+  runInput sel = Just $ H.action $ right ∘ Q.UpdateSelection sel
 
   handleSelection ∷ MC.Message AnyItem' AnyPath' → Maybe (CC.InnerCardQuery Query Unit)
-  handleSelection (MC.SelectionChanged _ sel) = runInput (anyItemToOpen =<< sel)
+  handleSelection = case _ of
+    MC.SelectionChanged _ sel → runInput (anyItemToOpen =<< sel)
+    MC.LoadRequest req → Just $ right $ H.action $ Q.HandleLoadRequest req
 
 renderItem ∷ AnyItem' → MCI.BasicItemHTML
 renderItem r =
@@ -164,8 +145,6 @@ evalOpen = case _ of
     { auth } ← Wiring.expose
     H.subscribe
       $ busEventSource (\msg -> right (Q.HandleSignInMessage msg H.Listening)) auth.signIn
-    currentVars ← H.liftEff $ Ref.newRef mempty
-    H.modify _ { currentVars = Just currentVars }
     pure next
   Q.HandleSignInMessage message next → do
     when (message ≡ GMB.SignInSuccess) do
@@ -174,6 +153,10 @@ evalOpen = case _ of
   Q.UpdateSelection selection next → do
     H.modify _ { selection = selection }
     H.raise CC.modelUpdate
+    pure next
+  Q.HandleLoadRequest req@(path × _) next → do
+    res ← load req
+    H.query unit $ H.action $ MC.FulfilLoadRequest (path × res)
     pure next
 
 evalCard ∷ CC.CardEvalQuery ~> DSL
@@ -192,11 +175,10 @@ evalCard = case _ of
     pure next
   CC.ReceiveInput _ varMap next → do
     let vars = VM.variables $ Port.flattenResources varMap
-    st ← H.get
-    for_ st.currentVars (H.liftEff ∘ flip Ref.writeRef vars)
+    selection ← CMS.state \st -> st.selection × (st { currentVars = vars })
     -- We need to reload the variables column in response to a new varMap,
     -- but only if it might be visible.
-    case st.selection of
+    case selection of
       Just (Open.Resource _) → pure unit
       _ → void $ H.query unit $ H.action $ MC.Reload
     pure next
@@ -218,27 +200,27 @@ queryPopulate = case _ of
   where
   query = void ∘ H.query unit ∘ H.action ∘ MC.Populate ∘ pathToColumnData
 
-columnOptions ∷ Ref.Ref (L.List VM.Var) → MCI.BasicColumnOptions AnyItem' AnyPath'
-columnOptions varsRef =
-  MC.ColumnOptions
+columnsComponent ∷ MC.MillerColumnsComponent AnyItem' AnyPath' Void
+columnsComponent =
+  MC.component $ MC.ColumnOptions
     { renderColumn: MCC.component
     , renderItem: MCI.component { label: itemName, render: renderItem }
     , label: itemName
-    , load
     , isLeaf: isLeaf isRight
     , id: map R.getPath
     }
 
-  where
-  load ∷ MC.LoadParams AnyPath' → Slam { items ∷ L.List AnyItem', nextOffset ∷ Maybe Int }
-  load { filter, path } = case path of
+load ∷ AnyPath' × MCR.LoadRequest → DSL (MCR.LoadResponse AnyItem')
+load (path × { filter, requestId }) =
+  case path of
     Root →
       pure
-        { items: L.fromFoldable [ rootDirectory, Variables ]
+        { requestId
+        , items: L.fromFoldable [ rootDirectory, Variables ]
         , nextOffset: Nothing
         }
     Variables → do
-      vars ← H.liftEff $ Ref.readRef varsRef
+      vars ← H.gets _.currentVars
       let
         filter' = S.toLower filter
         filterFn (VM.Var v) = S.contains (S.Pattern filter') $ S.toLower v
@@ -246,7 +228,8 @@ columnOptions varsRef =
           | filter ≡ "" = vars
           | otherwise   = L.filter filterFn vars
       pure
-        { items: Variable <$> vars'
+        { requestId
+        , items: Variable <$> vars'
         , nextOffset: Nothing
         }
     Resource (Left r) → do
@@ -255,16 +238,17 @@ columnOptions varsRef =
         Right rs → do
           let filenameFilter = MCF.mkFilter filter
           pure
-            { items: L.fromFoldable (Resource <$> A.filter (filenameFilter ∘ view R._name) rs)
+            { requestId
+            , items: L.fromFoldable (Resource <$> A.filter (filenameFilter ∘ view R._name) rs)
             , nextOffset: Nothing
             }
     Resource _ → pure noResult
     Variable v → pure noResult
+  where
+  noResult ∷ MCR.LoadResponse AnyItem'
+  noResult = { requestId, items: L.Nil, nextOffset: Nothing }
 
-  noResult ∷ { items ∷ L.List AnyItem', nextOffset ∷ Maybe Int }
-  noResult = { items: L.Nil, nextOffset: Nothing }
-
-handleError ∷ QE.QError → Slam Unit
+handleError ∷ QE.QError → DSL Unit
 handleError err =
   case GE.fromQError err of
     Left msg →

--- a/src/SlamData/Workspace/Card/Open/Component/Query.purs
+++ b/src/SlamData/Workspace/Card/Open/Component/Query.purs
@@ -20,8 +20,11 @@ import SlamData.Prelude
 
 import SlamData.GlobalMenu.Bus as GMB
 import SlamData.Workspace.Card.Open.Model (Open)
+import SlamData.Workspace.MillerColumns.Column.Component.Request (LoadRequest)
+import SlamData.Workspace.Card.Open.Item (AnyPath')
 
 data Query a
   = Init a
   | HandleSignInMessage GMB.SignInMessage a
   | UpdateSelection (Maybe Open) a
+  | HandleLoadRequest (AnyPath' × LoadRequest) a

--- a/src/SlamData/Workspace/Card/Open/Component/State.purs
+++ b/src/SlamData/Workspace/Card/Open/Component/State.purs
@@ -18,8 +18,6 @@ module SlamData.Workspace.Card.Open.Component.State where
 
 import SlamData.Prelude
 
-import Control.Monad.Eff.Ref (Ref)
-
 import Data.List as L
 
 import SlamData.Workspace.Card.Open.Model (Open)
@@ -27,11 +25,11 @@ import SlamData.Workspace.Card.Port.VarMap as VM
 
 type State =
   { selection ∷ Maybe Open
-  , currentVars ∷ Maybe (Ref (L.List VM.Var))
+  , currentVars ∷ L.List VM.Var
   }
 
 initialState ∷ State
 initialState =
   { selection: Nothing
-  , currentVars: Nothing
+  , currentVars: L.Nil
   }

--- a/src/SlamData/Workspace/Card/Open/Item.purs
+++ b/src/SlamData/Workspace/Card/Open/Item.purs
@@ -1,0 +1,43 @@
+{-
+Copyright 2016 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
+module SlamData.Workspace.Card.Open.Item where
+
+import SlamData.Prelude
+import SlamData.FileSystem.Resource as R
+import SlamData.Workspace.Card.Open.Model as Open
+import SlamData.Workspace.Card.Port.VarMap as VM
+
+import Utils.Path (AnyPath)
+
+data AnyItem a
+  = Root
+  | Variables
+  | Variable VM.Var
+  | Resource a
+
+anyItemToOpen ∷ AnyItem' → Maybe Open.Open
+anyItemToOpen = case _ of
+  Variable v → Just (Open.Variable v)
+  Resource r → Just (Open.Resource r)
+  _ → Nothing
+
+derive instance eqAnyItem ∷ Eq a ⇒ Eq (AnyItem a)
+derive instance ordAnyItem ∷ Ord a ⇒ Ord (AnyItem a)
+derive instance functorAnyItem ∷ Functor AnyItem
+
+type AnyPath' = AnyItem AnyPath
+type AnyItem' = AnyItem R.Resource

--- a/src/SlamData/Workspace/MillerColumns/Column/Component/Query.purs
+++ b/src/SlamData/Workspace/MillerColumns/Column/Component/Query.purs
@@ -19,6 +19,7 @@ module SlamData.Workspace.MillerColumns.Column.Component.Query
   , Query'
   , Message(..)
   , Message'
+  , module SlamData.Workspace.MillerColumns.Column.Component.Request
   ) where
 
 import SlamData.Prelude
@@ -28,6 +29,7 @@ import DOM.Node.Types (Element)
 import Halogen.Component.Proxy (ProxyQ)
 
 import SlamData.Workspace.MillerColumns.Column.Component.Item as Item
+import SlamData.Workspace.MillerColumns.Column.Component.Request (LoadRequest, LoadResponse)
 
 data Query a i o b
   = Init b
@@ -38,6 +40,7 @@ data Query a i o b
   | UpdateFilter String b
   | HandleScroll Element b
   | HandleMessage i (Item.Message' a o) b
+  | FulfilLoadRequest (LoadResponse a) b
 
 type Query' a i o = ProxyQ (Query a i o) (Maybe a) (Message' a i o)
 
@@ -45,5 +48,6 @@ data Message a i
   = Initialized
   | Selected i a
   | Deselected
+  | LoadRequest LoadRequest
 
 type Message' a i o = Either (Message a i) o

--- a/src/SlamData/Workspace/MillerColumns/Column/Component/Request.purs
+++ b/src/SlamData/Workspace/MillerColumns/Column/Component/Request.purs
@@ -1,0 +1,45 @@
+{-
+Copyright 2016 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
+module SlamData.Workspace.MillerColumns.Column.Component.Request where
+
+import SlamData.Prelude
+
+import Data.List as L
+import Data.Newtype (over)
+
+-- | An ID used to annotate a load request or response that is specific to a
+-- | particular column.
+newtype RequestId = RequestId Int
+
+derive instance newtypeRequestId ∷ Newtype RequestId _
+derive newtype instance eqRequestId ∷ Eq RequestId
+derive newtype instance ordRequestId ∷ Ord RequestId
+
+succ ∷ RequestId → RequestId
+succ = over RequestId (_ + 1)
+
+type LoadRequest =
+  { requestId ∷ RequestId
+  , filter ∷ String
+  , offset ∷ Maybe Int
+  }
+
+type LoadResponse a =
+  { requestId ∷ RequestId
+  , items ∷ L.List a
+  , nextOffset ∷ Maybe Int
+  }

--- a/src/SlamData/Workspace/MillerColumns/Column/Component/State.purs
+++ b/src/SlamData/Workspace/MillerColumns/Column/Component/State.purs
@@ -21,8 +21,8 @@ import SlamData.Prelude
 import Data.List (List(..))
 
 import SlamData.Monad (Slam)
-import SlamData.Workspace.MillerColumns.Column.Options (LoadParams)
 import SlamData.Workspace.MillerColumns.Column.Component.Query (Query)
+import SlamData.Workspace.MillerColumns.Column.Component.Request (RequestId(..), LoadRequest)
 
 import Halogen.Component.Utils.Debounced (DebounceTrigger(..))
 
@@ -42,8 +42,8 @@ type State a i o =
   , selected ∷ Maybe a
   , filterText ∷ String
   , nextOffset ∷ Maybe Int
-  , lastLoadParams ∷ Maybe (LoadParams i)
-  , tick ∷ Int
+  , lastLoadRequest ∷ Maybe LoadRequest
+  , lastRequestId ∷ RequestId
   , filterTrigger ∷ DebounceTrigger (Query a i o) Slam
   }
 
@@ -54,7 +54,7 @@ initialState =
   , selected: _
   , filterText: ""
   , nextOffset: Nothing
-  , lastLoadParams: Nothing
-  , tick: 0
+  , lastLoadRequest: Nothing
+  , lastRequestId: RequestId 0
   , filterTrigger: DebounceTrigger (const (pure unit))
   }

--- a/src/SlamData/Workspace/MillerColumns/Column/Options.purs
+++ b/src/SlamData/Workspace/MillerColumns/Column/Options.purs
@@ -18,16 +18,12 @@ module SlamData.Workspace.MillerColumns.Column.Options where
 
 import SlamData.Prelude
 
-import Data.List as L
-
 import Halogen as H
 import Halogen.HTML as HH
 
 import SlamData.Monad (Slam)
 import SlamData.Workspace.MillerColumns.Column.Component.Query as Column
 import SlamData.Workspace.MillerColumns.Column.Component.Item as Item
-
-type LoadParams i = { path ∷ i, filter ∷ String, offset ∷ Maybe Int }
 
 type ColumnComponent a i o =
   H.Component HH.HTML (Column.Query' a i o) (Maybe a) (Column.Message' a i o) Slam
@@ -40,7 +36,6 @@ newtype ColumnOptions a i o =
     { renderColumn ∷ ColumnOptions a i o → i → ColumnComponent a i o
     , renderItem ∷ i → a → ItemComponent a o
     , label ∷ a → String
-    , load ∷ LoadParams i → Slam { items ∷ L.List a, nextOffset ∷ Maybe Int }
     , isLeaf ∷ i → Boolean
     , id ∷ a → i
     }

--- a/src/SlamData/Workspace/MillerColumns/Component/Query.purs
+++ b/src/SlamData/Workspace/MillerColumns/Component/Query.purs
@@ -19,6 +19,7 @@ module SlamData.Workspace.MillerColumns.Component.Query where
 import SlamData.Prelude
 
 import SlamData.Workspace.MillerColumns.Column.Component as Column
+import SlamData.Workspace.MillerColumns.Column.Component.Request (LoadRequest, LoadResponse)
 import SlamData.Workspace.MillerColumns.Component.State (ColumnsData)
 
 data Query a i o b
@@ -26,8 +27,10 @@ data Query a i o b
   | ChangeRoot (ColumnsData a i) b
   | HandleMessage Int i (Column.Message' a i o) b
   | Reload b
+  | FulfilLoadRequest (i × LoadResponse a) b
 
 data Message a i
   = SelectionChanged i (Maybe a)
+  | LoadRequest (i × LoadRequest)
 
 type Message' a i o = Either (Message a i) o

--- a/src/SlamData/Workspace/MillerColumns/TreeData.purs
+++ b/src/SlamData/Workspace/MillerColumns/TreeData.purs
@@ -28,6 +28,7 @@ import Data.Set as S
 import Data.Unfoldable (unfoldr)
 
 import SlamData.Workspace.MillerColumns.Column.BasicFilter (mkFilter)
+import SlamData.Workspace.MillerColumns.Column.Component.Request (LoadRequest, LoadResponse)
 import SlamData.Workspace.MillerColumns.Component.State (ColumnsData)
 
 type Tree a = CF.Cofree L.List a
@@ -44,18 +45,18 @@ constructTree unfold root as =
 
 -- | This is only suitable for use when every `a` in the tree is unique.
 loadFromTree
-  ∷ ∀ m a r
-  . (Eq a, Applicative m)
+  ∷ ∀ a
+  . Eq a
   ⇒ (a → String)
   → Tree a
-  → { path ∷ a, filter ∷ String | r }
-  → m { items ∷ L.List a, nextOffset ∷ Maybe Int }
-loadFromTree label tree { path, filter } =
+  → a × LoadRequest
+  → a × LoadResponse a
+loadFromTree label tree (path × { requestId, filter }) =
   let
     labelFilter = mkFilter filter ∘ label
     items = L.filter labelFilter $ go $ pure tree
   in
-    pure { items, nextOffset: Nothing }
+    path × { requestId, items, nextOffset: Nothing }
   where
   go ∷ L.List (Tree a) → L.List a
   go branches =


### PR DESCRIPTION
@natefaubion I don't really know what I was thinking with the previous approach... this is way better in terms of not restricting us to `Slam` in `load`, avoiding the need for `Ref` hacks etc.