### PR TITLE
SqlSquare

### DIFF
--- a/src/SlamData/FileSystem/Dialog/Mount/SQL2/Component.purs
+++ b/src/SlamData/FileSystem/Dialog/Mount/SQL2/Component.purs
@@ -82,7 +82,7 @@ eval = case _ of
     let destPath = parent Pt.</> Pt.file name
         view = R.View $ destPath
         dest = R.Mount view
-    result ← API.viewQuery (Left parent) destPath sql vars
+    result ← API.viewQuery parent destPath sql vars
     pure $ k $ map (const view) result
 
 aceSetup ∷ Maybe String → Editor → Slam Unit

--- a/src/SlamData/FileSystem/Dialog/Mount/SQL2/Component.purs
+++ b/src/SlamData/FileSystem/Dialog/Mount/SQL2/Component.purs
@@ -82,7 +82,7 @@ eval = case _ of
     let destPath = parent Pt.</> Pt.file name
         view = R.View $ destPath
         dest = R.Mount view
-    result ← API.viewQuery parent destPath sql vars
+    result ← API.viewQuery' destPath sql vars
     pure $ k $ map (const view) result
 
 aceSetup ∷ Maybe String → Editor → Slam Unit

--- a/src/SlamData/Quasar/Query.purs
+++ b/src/SlamData/Quasar/Query.purs
@@ -15,126 +15,104 @@ limitations under the License.
 -}
 
 module SlamData.Quasar.Query
-  ( SQL
-  , templated
-  , compile
+  ( compile
   , queryEJson
   , queryEJsonVM
   , viewQuery
-  , fileQuery
   , all
   , sample
   , count
+  , fileQuery
   , fields
+  , jcursorToSql
   , module Quasar.Error
   ) where
 
 import SlamData.Prelude
 
-import Control.Apply (lift2)
-
 import Data.Argonaut as JS
 import Data.Array as Arr
 import Data.Int as Int
+import Data.Lens ((.~), (?~))
+import Data.List as L
 import Data.Json.Extended as EJS
 import Data.Path.Pathy as P
-import Data.String as S
+import Data.Set as Set
 import Data.StrMap as SM
+
+import Matryoshka (Coalgebra, ana)
 
 import Quasar.Advanced.QuasarAF as QF
 import Quasar.Data (JSONMode(..))
 import Quasar.Error (QError)
 import Quasar.Mount as QM
-import Quasar.Types (AnyPath, DirPath, FilePath, CompileResultR)
+import Quasar.Types (DirPath, FilePath, CompileResultR)
 
-import SlamData.Quasar.Error (throw)
 import SlamData.Quasar.Class (class QuasarDSL, liftQuasar)
 
--- | This is template string where actual path is encoded like {{path}}
-type SQL = String
+import SqlSquare (Sql, print)
+import SqlSquare as Sql
 
--- | Replaces `{{path}}` placeholders in an SQL template string with a file
--- | path.
-templated ∷ FilePath → SQL → SQL
-templated res = S.replace (S.Pattern "{{path}}") (S.Replacement $ "`" ⊕ P.printPath res ⊕ "`")
 
 -- | Compiles a query.
--- |
--- | If a file path is provided for the input path the query can use the
--- | {{path}} template syntax to have the file's path inserted, and the file's
--- | parent directory will be used to determine the backend to use in Quasar.
 compile
   ∷ ∀ m
   . QuasarDSL m
-  ⇒ AnyPath
-  → SQL
+  ⇒ DirPath
+  → Sql
   → SM.StrMap String
   → m (Either QError CompileResultR)
-compile path sql varMap =
-  let
-    backendPath = either id (fromMaybe P.rootDir ∘ P.parentDir) path
-    sql' = maybe sql (flip templated sql) $ either (const Nothing) Just path
-  in
-    liftQuasar $ QF.compileQuery backendPath sql' varMap
+compile backendPath sql varMap =
+  liftQuasar $ QF.compileQuery backendPath (print sql) varMap
 
 queryEJson
   ∷ ∀ m
   . QuasarDSL m
   ⇒ DirPath
-  → SQL
+  → Sql
   → m (Either QError (Array EJS.EJson))
 queryEJson path sql =
-  liftQuasar $ QF.readQueryEJson path sql SM.empty Nothing
+  liftQuasar $ QF.readQueryEJson path (print sql) SM.empty Nothing
 
 queryEJsonVM
   ∷ ∀ m
   . QuasarDSL m
   ⇒ DirPath
-  → SQL
+  → Sql
   → SM.StrMap String
   → m (Either QError (Array EJS.EJson))
 queryEJsonVM path sql vm =
-  liftQuasar $ QF.readQueryEJson path sql vm Nothing
+  liftQuasar $ QF.readQueryEJson path (print sql) vm Nothing
 
 -- | Runs a query creating a view mount for the query.
--- |
--- | If a file path is provided for the input path the query can use the
--- | {{path}} template syntax to have the file's path inserted.
 viewQuery
   ∷ ∀ m
   . (QuasarDSL m, Monad m)
-  ⇒ AnyPath
-  → FilePath
-  → SQL
+  ⇒ FilePath
+  → Sql
   → SM.StrMap String
   → m (Either QError Unit)
-viewQuery path dest sql vars = do
+viewQuery dest sql vars = do
   liftQuasar $
     QF.deleteMount (Right dest)
   liftQuasar $
     QF.updateMount (Right dest) (QM.ViewConfig
-      { query: maybe sql (flip templated sql) $ either (const Nothing) Just path
+      { query: print sql
       , vars
       })
 
--- | Runs a query for a particular file (the query can use the {{path}} template
--- | syntax to have the file's path inserted), writing the results to a file.
--- | The query backend will be determined by the input file path.
--- |
--- | The returned value is the output path returned by Quasar. For some queries
--- | this will be the input file rather than the specified destination.
 fileQuery
   ∷ ∀ m
   . QuasarDSL m
-  ⇒ FilePath
+  ⇒ DirPath
   → FilePath
-  → SQL
+  → Sql
   → SM.StrMap String
   → m (Either QError FilePath)
-fileQuery file dest sql vars =
-  let backendPath = fromMaybe P.rootDir (P.parentDir file)
-  in liftQuasar $ map _.out <$>
-    QF.writeQuery backendPath dest (templated file sql) vars
+fileQuery backendPath dest sql vars =
+  liftQuasar $ map _.out <$>
+    QF.writeQuery backendPath dest (print sql) vars
+
 
 all
   ∷ ∀ m
@@ -160,10 +138,22 @@ count
   ⇒ FilePath
   → m (Either QError Int)
 count file = runExceptT do
-  let backendPath = fromMaybe P.rootDir (P.parentDir file)
-      sql = templated file "SELECT COUNT(*) as total FROM {{path}}"
+  let
+    backendPath = fromMaybe P.rootDir (P.parentDir file)
+    sql =
+      Sql.buildSelect
+      $ (Sql._isDistinct .~ false)
+      ∘ (Sql._projections
+         .~ (L.singleton
+               $ Sql.projection
+                   (Sql.invokeFunction "COUNT" $ L.singleton $ Sql.splice Nothing)
+                   #  Sql.as "total"))
+      ∘ (Sql._relations ?~ Sql.TableRelation { alias: Nothing, path: Left file })
+      ∘ (Sql._filter .~ Nothing)
+      ∘ (Sql._groupBy .~ Nothing)
+      ∘ (Sql._orderBy .~ Nothing)
   result ← ExceptT $ liftQuasar $
-    QF.readQuery Readable backendPath sql SM.empty Nothing
+    QF.readQuery Readable backendPath (print sql) SM.empty Nothing
   pure $ fromMaybe 0 (readTotal result)
   where
   readTotal ∷ JS.JArray → Maybe Int
@@ -174,44 +164,32 @@ count file = runExceptT do
       <=< JS.toObject
       <=< Arr.head
 
+data UnfoldableJC = JC JS.JCursor | S String | I Int
+
+jcCoalgebra ∷ Coalgebra (Sql.SqlF EJS.EJsonF) UnfoldableJC
+jcCoalgebra = case _ of
+  S s → Sql.Ident s
+  I i → Sql.Literal (EJS.Integer i)
+  JC cursor → case cursor of
+    JS.JCursorTop → Sql.Splice Nothing
+    JS.JIndex i c → Sql.Binop { op: Sql.IndexDeref, lhs: JC c, rhs: I i }
+    JS.JField f c → Sql.Binop { op: Sql.FieldDeref, lhs: JC c, rhs: S f }
+
+jcursorToSql ∷ JS.JCursor → Sql
+jcursorToSql = ana jcCoalgebra ∘ JC ∘ JS.insideOut
+
+allFields ∷ JS.JArray → L.List Sql
+allFields =
+  map jcursorToSql
+  ∘ L.fromFoldable
+  ∘ foldMap (Set.fromFoldable ∘ map fst)
+  ∘ map JS.toPrims
+
 fields
   ∷ ∀ m
   . (Monad m, QuasarDSL m)
   ⇒ FilePath
-  → m (Either QError (Array String))
+  → m (QError ⊹ (L.List Sql))
 fields file = runExceptT do
   jarr ← ExceptT $ sample file 0 100
-  case jarr of
-    [] → throw "empty file"
-    _ → pure $ Arr.nub $ getFields =<< jarr
-
-  where
-  -- The output of this function is mysterious, but luckily is used in just one place.
-  --
-  -- TODO: Rather than accumulating a an array of formatted strings, this should be refactored
-  -- to return an array of *arrays* of unformatted strings, which can then be formatted by the
-  -- client (e.g. to intercalate with dots and add backticks).
-  getFields ∷ JS.Json → Array String
-  getFields = Arr.filter (_ /= "") ∘ Arr.nub ∘ go []
-    where
-    go ∷ Array String → JS.Json → Array String
-    go [] json = go [""] json
-    go acc json
-      | JS.isObject json = maybe acc (goObj acc) $ JS.toObject json
-      | JS.isArray json = maybe acc (goArr acc) $ JS.toArray json
-      | otherwise = acc
-
-    goArr ∷ Array String → JS.JArray → Array String
-    goArr acc arr =
-      Arr.concat $ go (lift2 append acc $ mkArrIxs arr) <$> arr
-      where
-      mkArrIxs ∷ JS.JArray → Array String
-      mkArrIxs jarr =
-        map (\x → "[" ⊕ show x ⊕ "]") $ Arr.range 0 $ Arr.length jarr - 1
-
-    goObj ∷ Array String → JS.JObject → Array String
-    goObj acc = Arr.concat ∘ map (goTuple acc) ∘ Arr.fromFoldable ∘ SM.toList
-
-    goTuple ∷ Array String → Tuple String JS.Json → Array String
-    goTuple acc (key × json) =
-      go (map (\x → x ⊕ ".`" ⊕ key ⊕ "`") acc) json
+  pure $ allFields jarr

--- a/src/SlamData/Workspace/Card/Ace/Component.purs
+++ b/src/SlamData/Workspace/Card/Ace/Component.purs
@@ -53,8 +53,9 @@ import SlamData.Workspace.Card.Ace.Component.State (State, initialState)
 import SlamData.Workspace.Card.CardType as CT
 import SlamData.Workspace.Card.Component as CC
 import SlamData.Workspace.Card.Model as Card
-import SlamData.Workspace.Card.Port as Port
 import SlamData.Workspace.LevelOfDetails (LevelOfDetails(..))
+
+import SqlSquare as Sql
 
 import Utils.Ace (getRangeRecs, readOnly)
 
@@ -133,7 +134,7 @@ evalCard mode = case _ of
       pure $ flip Array.mapMaybe vars \var → do
         guard $ Str.contains (Str.Pattern inp') (Str.toLower var)
         pure
-          { value: ":" <> Port.escapeIdentifier var
+          { value: ":" <> Sql.printIdent var
           , score: 200.0
           , caption: Just var
           , meta: "var"

--- a/src/SlamData/Workspace/Card/Cache/Eval.purs
+++ b/src/SlamData/Workspace/Card/Cache/Eval.purs
@@ -69,12 +69,13 @@ eval'
 eval' tmp resource = do
   let
     filePath = resource ^. Port._filePath
+    backendPath = fromMaybe Path.rootDir $ Path.parentDir filePath
     sql =
       Sql.buildSelect
         $ (Sql._projections .~ (pure $ Sql.projection $ Sql.splice Nothing))
         ∘ (Sql._relations ?~ (Sql.TableRelation {alias: Nothing, path: Left filePath}))
   outputResource ← CEM.liftQ $
-    QQ.fileQuery filePath tmp sql SM.empty
+    QQ.fileQuery backendPath tmp sql SM.empty
   CEM.liftQ $ QFS.messageIfFileNotFound
     outputResource
     "Error saving file, please try another location"

--- a/src/SlamData/Workspace/Card/Markdown/Eval.purs
+++ b/src/SlamData/Workspace/Card/Markdown/Eval.purs
@@ -195,6 +195,6 @@ evalEmbeddedQueries sm dir =
     ∷ String
     → m (Array EJSON.EJson)
   runQuery code = do
-    {inputs} ← CEM.liftQ $ Quasar.compile (Left dir) code sm
+    {inputs} ← CEM.liftQ $ Quasar.compile dir code sm
     CEM.addSources inputs
     CEM.liftQ $ Quasar.queryEJsonVM dir code sm

--- a/src/SlamData/Workspace/Card/Markdown/Eval.purs
+++ b/src/SlamData/Workspace/Card/Markdown/Eval.purs
@@ -23,6 +23,7 @@ import Control.Monad.Throw (class MonadThrow)
 import Control.Monad.Writer.Class (class MonadTell)
 
 import Data.Array as A
+import Data.Formatter.DateTime as Fd
 import Data.DateTime as DT
 import Data.Identity (Identity)
 import Data.Json.Extended as EJSON
@@ -30,7 +31,7 @@ import Data.List as L
 import Data.String as S
 import Data.StrMap as SM
 
-import Matryoshka (project, embed)
+import Matryoshka (project, transAna)
 
 import SlamData.Effects (SlamDataEffects)
 import SlamData.Quasar.Class (class QuasarDSL)
@@ -48,7 +49,6 @@ import Text.Markdown.SlamDown.Halogen.Component.State as SDH
 import Text.Markdown.SlamDown.Parser as SDP
 import Text.Markdown.SlamDown.Traverse as SDT
 
-import Utils (hush)
 import Utils.Path (DirPath)
 
 evalMarkdownForm
@@ -81,7 +81,7 @@ evalMarkdown str varMap = do
   case SDP.parseMd str of
     Left e → CEM.throw e
     Right sd → do
-      let sm = map Sql.print $ Port.flattenResources varMap
+      let sm = map (Sql.print ∘ unwrap) $ Port.flattenResources varMap
       doc ← evalEmbeddedQueries sm path sd
       pure (Port.SlamDown doc × varMap)
 
@@ -122,9 +122,9 @@ evalEmbeddedQueries sm dir =
     → m Port.VarMapValue
   evalCode mid code
     | languageIsSql mid =
-        embed ∘ Sql.Literal ∘ extractCodeValue <$> runQuery code
+        Port.VarMapValue ∘ transAna Sql.Literal ∘ extractCodeValue <$> runQuery code
     | otherwise =
-        hush $ Sql.parse code
+        pure $ Port.VarMapValue $ Sql.null
 
   extractCodeValue ∷ Array EJSON.EJson → EJSON.EJson
   extractCodeValue [ej] = extractSingletonObject ej
@@ -134,9 +134,7 @@ evalEmbeddedQueries sm dir =
     ∷ Maybe SDE.LanguageId
     → Boolean
   languageIsSql =
-    maybe
-      true
-      ((_ ≡ "sql") ∘ S.toLower)
+    maybe true $ eq "sql" ∘ S.toLower
 
   extractSingletonObject
     ∷ EJSON.EJson
@@ -150,7 +148,9 @@ evalEmbeddedQueries sm dir =
     ∷ String
     → m Port.VarMapValue
   evalValue code = do
-    maybe (Port.Literal EJSON.null) (Port.Literal ∘ extractSingletonObject)
+    maybe
+      (Port.VarMapValue Sql.null)
+      (Port.VarMapValue ∘ transAna Sql.Literal ∘ extractSingletonObject)
       ∘ A.head
       <$> runQuery code
 
@@ -167,37 +167,42 @@ evalEmbeddedQueries sm dir =
         pure ∘ SD.PlainText $ pure str
       (SD.Numeric _), (EJSON.Decimal a) →
         pure ∘ SD.Numeric $ pure a
-      (SD.Time prec _), (EJSON.Time time) →
-        pure ∘ SD.Time prec $ pure time
-      (SD.Time prec _), (EJSON.Timestamp dt) →
-        pure ∘ SD.Time prec $ pure $ DT.time dt
-      (SD.Date _), (EJSON.Date d) →
-        pure ∘ SD.Date $ pure d
-      (SD.Date _), (EJSON.Timestamp dt) →
-        pure ∘ SD.Date $ pure $ DT.date dt
-      (SD.DateTime prec _), (EJSON.Timestamp dt) →
-        pure ∘ SD.DateTime prec $ pure dt
+      (SD.Time prec _), (EJSON.String time) →
+        case Fd.unformatDateTime "HH:mm:ss" time of
+          Left _ → CEM.throw $ "Incorrect time value: " ⊕ show time
+          Right r → pure ∘ SD.Time prec $ pure $ DT.time r
+      (SD.Date _), (EJSON.String d) →
+        case Fd.unformatDateTime "YYYY-MM-DD" d of
+          Left _ → CEM.throw $ "Incorrect date value: " ⊕ show d
+          Right r → pure ∘ SD.Date $ pure $ DT.date r
+      (SD.DateTime prec _), (EJSON.String dt) →
+        case Fd.unformatDateTime "YYYY-MM-DDTHH:mm:ssZ" dt of
+          Left _ → CEM.throw $ "Incorrect datetime value: " ⊕ show dt
+          Right r → pure ∘ SD.DateTime prec $ pure r
       _, _ → CEM.throw $ "Type error: " ⊕ show result ⊕ " does not match " ⊕ show tb
 
   evalList
     ∷ String
     → m (L.List Port.VarMapValue)
   evalList code = do
-    items ← map extractSingletonObject <$> runQuery code
+    jitems ← map extractSingletonObject <$> runQuery code
     let limit = 500
     pure ∘ L.fromFoldable
-      $ if A.length items > limit
+      $ if A.length jitems > limit
           then
-          map Port.Literal
-            (A.take limit items)
+            ( map (Port.VarMapValue ∘ transAna Sql.Literal) $ A.take limit jitems )
             ⊕ [ SD.stringValue $ "<" ⊕ show limit ⊕ "item limit reached>" ]
           else
-          Port.Literal <$> items
+          map (Port.VarMapValue ∘ transAna Sql.Literal) jitems
 
   runQuery
     ∷ String
     → m (Array EJSON.EJson)
-  runQuery code = do
-    {inputs} ← CEM.liftQ $ Quasar.compile dir code sm
-    CEM.addSources inputs
-    CEM.liftQ $ Quasar.queryEJsonVM dir code sm
+  runQuery code =
+    let esql = Sql.parse code
+    in case esql of
+      Left e → CEM.throw "Error parsing sql query"
+      Right sql → do
+        {inputs} ← CEM.liftQ $ Quasar.compile dir sql sm
+        CEM.addSources inputs
+        CEM.liftQ $ Quasar.queryEJsonVM dir sql sm

--- a/src/SlamData/Workspace/Card/Markdown/Interpret.purs
+++ b/src/SlamData/Workspace/Card/Markdown/Interpret.purs
@@ -18,16 +18,22 @@ module SlamData.Workspace.Card.Markdown.Interpret
 
 import SlamData.Prelude
 
-import Data.Array as A
+import Data.DateTime as DT
 import Data.Identity (Identity(..))
-import Data.Json.Extended as EJSON
 import Data.List as L
+import Data.Formatter.DateTime as FD
 import Data.Maybe as M
+
+import Matryoshka (embed, project)
+
+import SqlSquare as Sql
 
 import SlamData.Workspace.Card.Port.VarMap as VM
 
 import Text.Markdown.SlamDown as SD
 import Text.Markdown.SlamDown.Halogen.Component.State as SDS
+
+import Utils (hush)
 
 -- The use of this function in formFieldValueToVarMapValue is suspicious, and
 -- lead me to think that we have not arranged our data structures properly. In
@@ -42,56 +48,79 @@ getLiteral
   ∷ ∀ m
   . (Plus m, Applicative m)
   ⇒ VM.VarMapValue
-  → m EJSON.EJson
-getLiteral (VM.Literal l) = pure l
-getLiteral _ = empty
+  → m Sql.Sql
+getLiteral (VM.VarMapValue s) = project s # case _ of
+  Sql.Literal e → pure s
+  _ → empty
 
 formFieldEmptyValue
   ∷ ∀ f a
   . SD.FormFieldP f a
   → VM.VarMapValue
 formFieldEmptyValue field =
-  case field of
-    SD.TextBox tb → VM.Literal
+  VM.VarMapValue case field of
+    SD.TextBox tb →
       case tb of
-        SD.PlainText _ → EJSON.string ""
-        SD.Numeric _ → EJSON.integer 0
-        SD.Date _ → EJSON.null
-        SD.Time _ _ → EJSON.null
-        SD.DateTime _ _ → EJSON.null
-    SD.CheckBoxes _ _ → VM.SetLiteral []
-    SD.RadioButtons _ _ → VM.Literal EJSON.null
-    SD.DropDown _ _ → VM.Literal EJSON.null
+        SD.PlainText _ → Sql.string ""
+        SD.Numeric _ → Sql.int 0
+        SD.Date _ → Sql.null
+        SD.Time _ _ → Sql.null
+        SD.DateTime _ _ → Sql.null
+    SD.CheckBoxes _ _ → Sql.set []
+    SD.RadioButtons _ _ → Sql.null
+    SD.DropDown _ _ → Sql.null
 
 formFieldValueToVarMapValue
   ∷ ∀ m
   . Monad m
   ⇒ SDS.FormFieldValue VM.VarMapValue
   → m (M.Maybe VM.VarMapValue)
-formFieldValueToVarMapValue v =
-  runMaybeT $
-    case v of
-      SD.TextBox tb → VM.Literal <$> do
-        tb' ← liftMaybe $ SD.traverseTextBox unwrap tb
-        case tb' of
-          SD.PlainText (Identity x) → pure $ EJSON.string x
-          SD.Numeric (Identity x) → pure $ EJSON.decimal x
-          SD.Date (Identity x) → pure $ EJSON.date x
-          SD.Time _ (Identity x) → pure $ EJSON.time x
-          SD.DateTime _ (Identity x) → pure $ EJSON.timestamp x
-      SD.CheckBoxes (Identity sel) _ →
-        pure ∘ VM.SetLiteral ∘ A.fromFoldable $ L.mapMaybe (map VM.Literal ∘ getLiteral) sel
-      SD.RadioButtons (Identity x) _ →
-        VM.Literal <$> getLiteral x
-      SD.DropDown mx _ → VM.Literal <$> do
-        Identity x ← liftMaybe mx
-        getLiteral x
+formFieldValueToVarMapValue v = runMaybeT case v of
+  SD.TextBox tb → map VM.VarMapValue do
+    tb' ←
+      liftMaybe $ SD.traverseTextBox unwrap tb
+    case tb' of
+      SD.PlainText (Identity x) →
+        pure $ Sql.string x
+      SD.Numeric (Identity x) →
+        pure $ Sql.hugeNum x
+      SD.Date (Identity x) →
+        liftMaybe
+        $ hush
+        $ FD.formatDateTime "YYYY-MM-DD" (DT.DateTime x bottom) <#> \s →
+          Sql.invokeFunction "DATE" $ pure $ Sql.string s
+      SD.Time _ (Identity x) →
+        liftMaybe
+        $ hush
+        $ FD.formatDateTime "HH:mm:ss" (DT.DateTime bottom x) <#> \s →
+          Sql.invokeFunction "TIME" $ pure $ Sql.string s
+      SD.DateTime _ (Identity x) →
+        liftMaybe
+        $ hush
+        $ FD.formatDateTime "YYYY-MM-DDTHH:mm:ssZ" x <#> \s →
+          Sql.invokeFunction "TIMESTAMP" $ pure $ Sql.string s
+  SD.CheckBoxes (Identity sel) _ →
+      pure
+      $ VM.VarMapValue
+      $ embed
+      $ Sql.SetLiteral
+      $ L.mapMaybe (getLiteral) sel
+--    pure
+--    $ embed
+--    $ Sql.SetLiteral
+--    ?foo sel
+--    $ L.mapMaybe (map Sql.Literal ∘ getLiteral) sel
+  SD.RadioButtons (Identity x) _ →
+    map VM.VarMapValue $ getLiteral x
+  SD.DropDown mx _ → map VM.VarMapValue do
+    Identity x ← liftMaybe mx
+    getLiteral x
 
   where
-    liftMaybe
-      ∷ ∀ n a
-      . (Applicative n)
-      ⇒ Maybe a
-      → MaybeT n a
-    liftMaybe =
-      MaybeT ∘ pure
+  liftMaybe
+    ∷ ∀ n a
+    . (Applicative n)
+    ⇒ Maybe a
+    → MaybeT n a
+  liftMaybe =
+    MaybeT ∘ pure

--- a/src/SlamData/Workspace/Card/Markdown/Interpret.purs
+++ b/src/SlamData/Workspace/Card/Markdown/Interpret.purs
@@ -105,11 +105,6 @@ formFieldValueToVarMapValue v = runMaybeT case v of
       $ embed
       $ Sql.SetLiteral
       $ L.mapMaybe (getLiteral) sel
---    pure
---    $ embed
---    $ Sql.SetLiteral
---    ?foo sel
---    $ L.mapMaybe (map Sql.Literal ∘ getLiteral) sel
   SD.RadioButtons (Identity x) _ →
     map VM.VarMapValue $ getLiteral x
   SD.DropDown mx _ → map VM.VarMapValue do

--- a/src/SlamData/Workspace/Card/Open/Eval.purs
+++ b/src/SlamData/Workspace/Card/Open/Eval.purs
@@ -23,7 +23,7 @@ import SlamData.Prelude
 import Control.Monad.Throw (class MonadThrow)
 import Control.Monad.Writer.Class (class MonadTell)
 
-import Data.Lens ((^?))
+import Data.Lens ((^?), (.~), (?~))
 import Data.Path.Pathy as Path
 
 import SlamData.FileSystem.Resource as R
@@ -34,6 +34,8 @@ import SlamData.Workspace.Card.Eval.Monad as CEM
 import SlamData.Workspace.Card.Open.Model as Open
 import SlamData.Workspace.Card.Port as Port
 import SlamData.Workspace.Card.Port.VarMap as VM
+
+import SqlSquare as Sql
 
 import Utils.Path (FilePath)
 
@@ -59,11 +61,19 @@ evalOpen model varMap = case model of
   Just (Open.Variable (VM.Var var)) → do
     res ← CEM.temporaryOutputResource
     let
-      sql = "SELECT * FROM :" <> VM.escapeIdentifier var
-      varMap' = Port.renderVarMapValue <$> Port.flattenResources varMap
-      backendPath = fromMaybe Path.rootDir (Path.parentDir res)
-    CEM.liftQ $ QQ.viewQuery backendPath res sql varMap'
-    pure (Port.resourceOut (Port.View res sql varMap))
+      sql =
+        Sql.buildSelect
+          $ (Sql._projections
+             .~ (pure $ Sql.projection $ Sql.splice Nothing))
+          ∘ (Sql._relations
+             ?~ (Sql.VariRelation { vari: var, alias: Nothing }))
+      varMap' =
+        map (Sql.print ∘ unwrap) $ Port.flattenResources varMap
+      backendPath =
+        fromMaybe Path.rootDir $ Path.parentDir res
+
+    CEM.liftQ $ QQ.viewQuery res sql varMap'
+    pure $ Port.resourceOut $ Port.View res (Sql.print sql) varMap
 
   where
   noResource ∷ ∀ a. m a

--- a/src/SlamData/Workspace/Card/Open/Eval.purs
+++ b/src/SlamData/Workspace/Card/Open/Eval.purs
@@ -61,7 +61,7 @@ evalOpen model varMap = case model of
     let
       sql = "SELECT * FROM :" <> VM.escapeIdentifier var
       varMap' = Port.renderVarMapValue <$> Port.flattenResources varMap
-      backendPath = Left $ fromMaybe Path.rootDir (Path.parentDir res)
+      backendPath = fromMaybe Path.rootDir (Path.parentDir res)
     CEM.liftQ $ QQ.viewQuery backendPath res sql varMap'
     pure (Port.resourceOut (Port.View res sql varMap))
 

--- a/src/SlamData/Workspace/Card/Open/Eval.purs
+++ b/src/SlamData/Workspace/Card/Open/Eval.purs
@@ -73,7 +73,7 @@ evalOpen model varMap = case model of
         fromMaybe Path.rootDir $ Path.parentDir res
 
     CEM.liftQ $ QQ.viewQuery res sql varMap'
-    pure $ Port.resourceOut $ Port.View res (Sql.print sql) varMap
+    pure $ Port.resourceOut $ Port.View res (Sql.print $ sql) varMap
 
   where
   noResource ∷ ∀ a. m a

--- a/src/SlamData/Workspace/Card/Port.purs
+++ b/src/SlamData/Workspace/Card/Port.purs
@@ -67,7 +67,7 @@ import SlamData.Workspace.Card.Setups.Chart.PivotTable.Model as PTM
 import SlamData.Workspace.Card.Setups.Semantics as Sem
 import SlamData.Workspace.Card.CardType.ChartType (ChartType)
 import SlamData.Workspace.Card.CardType.FormInputType (FormInputType)
-import SlamData.Workspace.Card.Port.VarMap (VarMap, URLVarMap, VarMapValue(..), emptyVarMap)
+import SlamData.Workspace.Card.Port.VarMap (VarMap, URLVarMap, VarMapValue(..), emptyVarMap, _VarMapValue)
 
 import SqlSquare as Sql
 

--- a/src/SlamData/Workspace/Card/Port.purs
+++ b/src/SlamData/Workspace/Card/Port.purs
@@ -53,11 +53,12 @@ module SlamData.Workspace.Card.Port
 import SlamData.Prelude
 
 import Data.Argonaut (JCursor)
-import Data.Lens (Prism', prism', Traversal', wander, Lens', lens, (^.), view, (.~), (?~))
+import Data.Lens (Prism', prism', Traversal', wander, Lens', lens, (^.), view)
 import Data.List as List
 import Data.Map as Map
 import Data.Set as Set
 import Data.StrMap as SM
+import Data.Path.Pathy as Path
 
 import ECharts.Monad (DSL)
 import ECharts.Types.Phantom (OptionI)
@@ -172,12 +173,7 @@ flattenResources = map go
 
 resourceToVarMapValue ∷ Resource → VarMapValue
 resourceToVarMapValue r =
-  VarMapValue
-    $ Sql.buildSelect
-    $ (Sql._projections
-       .~ (pure $ Sql.projection (Sql.splice Nothing)))
-    ∘ (Sql._relations
-       ?~ (Sql.TableRelation { path: Left $ r ^. _filePath, alias: Nothing }))
+  VarMapValue $ Sql.ident $ Path.printPath $ r ^. _filePath
 
 defaultResourceVar ∷ String
 defaultResourceVar = "results"

--- a/src/SlamData/Workspace/Card/Port/VarMap.purs
+++ b/src/SlamData/Workspace/Card/Port/VarMap.purs
@@ -16,6 +16,7 @@ module SlamData.Workspace.Card.Port.VarMap
   , VarMap
   , URLVarMap
   , VarMapValue(..)
+  , _VarMapValue
   , emptyVarMap
   , variables
   ) where
@@ -25,6 +26,8 @@ import SlamData.Prelude
 import Data.Array as A
 import Data.Json.Extended as EJSON
 import Data.List as L
+import Data.Lens.Iso.Newtype (_Newtype)
+import Data.Lens.Types (Iso')
 import Data.StrMap as SM
 
 import Data.Argonaut ((.?), Json)
@@ -51,6 +54,10 @@ derive newtype instance arbitraryVar ∷ SC.Arbitrary Var
 derive instance newtypeVar :: Newtype Var _
 
 newtype VarMapValue = VarMapValue Sql
+
+_VarMapValue ∷ Iso' VarMapValue Sql
+_VarMapValue = _Newtype
+
 
 derive instance newtypeVarMapValue ∷ Newtype VarMapValue _
 

--- a/src/SlamData/Workspace/Card/Port/VarMap.purs
+++ b/src/SlamData/Workspace/Card/Port/VarMap.purs
@@ -28,6 +28,7 @@ import Data.Json.Extended as EJSON
 import Data.List as L
 import Data.Lens.Iso.Newtype (_Newtype)
 import Data.Lens.Types (Iso')
+import Data.String as S
 import Data.StrMap as SM
 
 import Data.Argonaut ((.?), Json)
@@ -99,8 +100,13 @@ instance decodeJsonVarMapValue :: DecodeJson VarMapValue where
       lmap show $ SqlP.parse queryStr
 
 instance valueVarMapValue ∷ SDV.Value VarMapValue where
-  stringValue = VarMapValue ∘ embed ∘ Sql.Literal ∘ EJSON.String
-  renderValue = Sql.print ∘ unwrap
+  stringValue = VarMapValue ∘ Sql.string
+  renderValue v =
+    let p = Sql.print $ unwrap v
+    in
+     fromMaybe p
+     $ S.stripSuffix (S.Pattern "\"") p
+     >>= S.stripPrefix (S.Pattern "\"")
 
 instance arbitraryVarMapValue ∷ SC.Arbitrary VarMapValue where
   arbitrary = map VarMapValue $ Sql.arbitrarySqlOfSize 2

--- a/src/SlamData/Workspace/Card/Port/VarMap.purs
+++ b/src/SlamData/Workspace/Card/Port/VarMap.purs
@@ -16,35 +16,29 @@ module SlamData.Workspace.Card.Port.VarMap
   , VarMap
   , URLVarMap
   , VarMapValue(..)
-  , renderVarMapValue
   , emptyVarMap
-  , escapeIdentifier
   , variables
   ) where
 
 import SlamData.Prelude
 
 import Data.Array as A
-import Data.Foldable as F
-import Data.HugeNum as HN
 import Data.Json.Extended as EJSON
-import Data.Json.Extended.Signature.Render as EJR
 import Data.List as L
-import Data.String.Regex (test, replace) as Regex
-import Data.String.Regex.Flags (ignoreCase, global) as Regex
-import Data.String.Regex.Unsafe (unsafeRegex) as Regex
 import Data.StrMap as SM
 
-import Data.Argonaut ((.?))
-import Data.Argonaut.Core (jsonSingletonObject)
+import Data.Argonaut ((.?), Json)
 import Data.Argonaut.Decode (class DecodeJson, decodeJson)
-import Data.Argonaut.Encode (class EncodeJson, encodeJson)
+import Data.Argonaut.Encode (class EncodeJson)
 
-import Matryoshka (Algebra, cata)
+import Matryoshka (embed, transAna)
+
+import SqlSquare (Sql)
+import SqlSquare as Sql
+import SqlSquare.Parser as SqlP
 
 import Text.Markdown.SlamDown.Syntax.Value as SDV
 
-import Test.StrongCheck.Gen as Gen
 import Test.StrongCheck.Arbitrary as SC
 
 newtype Var = Var String
@@ -56,104 +50,53 @@ derive newtype instance encodeVar ∷ EncodeJson Var
 derive newtype instance arbitraryVar ∷ SC.Arbitrary Var
 derive instance newtypeVar :: Newtype Var _
 
-data VarMapValue
-  = Literal EJSON.EJson
-  | SetLiteral (Array VarMapValue)
-  | QueryExpr String -- TODO: syntax of SQL^2 queries
+newtype VarMapValue = VarMapValue Sql
 
-derive instance eqVarMapValue ∷ Eq VarMapValue
-derive instance ordVarMapValue ∷ Ord VarMapValue
+derive instance newtypeVarMapValue ∷ Newtype VarMapValue _
 
+derive newtype instance eqVarMapValue ∷ Eq VarMapValue
+derive newtype instance ordVarMapValue ∷ Ord VarMapValue
 instance showVarMapValue ∷ Show VarMapValue where
-  show = renderVarMapValue
+  show (VarMapValue sql) = "(VarMapValue " ⊕ Sql.print sql ⊕ ")"
 
 instance encodeJsonVarMapValue ∷ EncodeJson VarMapValue where
-  encodeJson v =
-    case v of
-      Literal ejson →
-        jsonSingletonObject "literal" $
-          EJSON.encodeEJson ejson
-      SetLiteral as →
-        jsonSingletonObject "set" $
-          encodeJson as
-      QueryExpr str →
-        jsonSingletonObject "query" $
-          encodeJson str
+  encodeJson = Sql.encodeJson ∘ unwrap
+
 
 instance decodeJsonVarMapValue :: DecodeJson VarMapValue where
-  decodeJson json = do
-    obj <- decodeJson json
-    decodeLiteral obj
+  decodeJson json =
+    (map VarMapValue $ Sql.decodeJson json)
+    <|> (decodeLegacy json)
+    where
+    decodeLegacy = decodeJson >=> \obj →
+      map VarMapValue
+      $ decodeLiteral obj
       <|> decodeSetLiteral obj
       <|> decodeQueryExpr obj
 
-    where
-      decodeLiteral =
-        (_ .? "literal")
-          >=> EJSON.decodeEJson
-          >>> map Literal
+    decodeLiteral obj = do
+      (js ∷ Json) ← obj .? "literal"
+      (ejs ∷ EJSON.EJson) ←
+        EJSON.decodeEJson js
+      pure $ transAna Sql.Literal ejs
 
-      decodeSetLiteral =
-        (_ .? "set")
-          >=> decodeJson
-          >>> map SetLiteral
+    decodeSetLiteral obj = do
+      (arr ∷ Array Json) ← obj .? "set"
+      lst ←
+        map (L.fromFoldable ∘ map unwrap)
+        $ traverse decodeLegacy arr
+      pure $ embed $ Sql.SetLiteral lst
 
-      decodeQueryExpr  =
-        (_ .? "query")
-          >>> map QueryExpr
-
-renderVarMapValue
-  ∷ VarMapValue
-  → String
-renderVarMapValue val =
-  case val of
-    Literal lit → EJSON.renderEJson lit
-    SetLiteral as → "(" <> F.intercalate "," (renderVarMapValue <$> as) <> ")"
-    QueryExpr str → str
-
-displayVarMapValue
-  ∷ VarMapValue
-  → String
-displayVarMapValue val =
-  case val of
-    Literal lit → displayEJson lit
-    SetLiteral as → "(" <> F.intercalate ", " (displayVarMapValue <$> as) <> ")"
-    QueryExpr str → str
-
-displayEJsonF ∷ Algebra EJSON.EJsonF String
-displayEJsonF =
-  case _ of
-    EJSON.Null → "null"
-    EJSON.Boolean b → if b then "true" else "false"
-    EJSON.Integer i → show i
-    EJSON.Decimal a → HN.toString a
-    EJSON.String str → str
-    EJSON.Timestamp dt → EJR.renderTimestamp dt
-    EJSON.Time t → EJR.renderTime t
-    EJSON.Date d → EJR.renderDate d
-    EJSON.Interval str → str
-    EJSON.ObjectId str → str
-    EJSON.Array ds → "[" <> commaSep ds <> "]"
-    EJSON.Map (EJSON.EJsonMap ds) → "{ " <> commaSep (map renderPair ds) <> " }"
-  where
-  commaSep ∷ Array String → String
-  commaSep = F.intercalate ","
-  renderPair ∷ Tuple String String → String
-  renderPair (Tuple k v) = k <> ": " <> v
-
--- | A more readable, but forgetful renderer
-displayEJson ∷ EJSON.EJson → String
-displayEJson = cata displayEJsonF
+    decodeQueryExpr obj  = do
+      queryStr ← obj .? "query"
+      lmap show $ SqlP.parse queryStr
 
 instance valueVarMapValue ∷ SDV.Value VarMapValue where
-  stringValue = Literal <<< EJSON.string
-  renderValue = displayVarMapValue
+  stringValue = VarMapValue ∘ embed ∘ Sql.Literal ∘ EJSON.String
+  renderValue = Sql.print ∘ unwrap
 
 instance arbitraryVarMapValue ∷ SC.Arbitrary VarMapValue where
-  arbitrary =
-    Literal <$> EJSON.arbitraryJsonEncodableEJsonOfSize 1
-      <|> SetLiteral <$> Gen.arrayOf (Literal <$> EJSON.arbitraryJsonEncodableEJsonOfSize 1)
-      <|> QueryExpr <$> SC.arbitrary
+  arbitrary = map VarMapValue $ Sql.arbitrarySqlOfSize 2
 
 type VarMap = SM.StrMap VarMapValue
 
@@ -167,12 +110,3 @@ emptyVarMap = SM.empty
 
 variables ∷ VarMap → L.List Var
 variables = L.fromFoldable ∘ map Var ∘ A.sort ∘ SM.keys
-
-escapeIdentifier ∷ String → String
-escapeIdentifier str =
-  if Regex.test identifier str
-    then str
-    else "`" <> Regex.replace tick "\\`" str <> "`"
-  where
-    identifier = Regex.unsafeRegex "^[_a-z][_a-z0-9]*$" Regex.ignoreCase
-    tick = Regex.unsafeRegex "`" Regex.global

--- a/src/SlamData/Workspace/Card/Query/Eval.purs
+++ b/src/SlamData/Workspace/Card/Query/Eval.purs
@@ -54,7 +54,7 @@ evalQuery sql varMap = do
   let
     varMap' = Port.renderVarMapValue <$> Port.flattenResources varMap
     backendPath =
-      Left $ fromMaybe Path.rootDir (Path.parentDir resource)
+      fromMaybe Path.rootDir (Path.parentDir resource)
   { inputs } ←
     CEM.liftQ $ lmap (QE.prefixMessage "Error compiling query") <$>
       QQ.compile backendPath sql varMap'

--- a/src/SlamData/Workspace/Card/Query/Model.purs
+++ b/src/SlamData/Workspace/Card/Query/Model.purs
@@ -23,10 +23,12 @@ import SlamData.Prelude
 import SlamData.Workspace.Card.Ace.Model as Ace
 import SlamData.Workspace.Card.Port as Port
 
+import SqlSquare as Sql
+
 initialModel ∷ Port.Port → Ace.Model
 initialModel = case _ of
   Port.ResourceKey var →
-    { text: "SELECT * FROM :" <> Port.escapeIdentifier var
+    { text: "SELECT * FROM :" <> Sql.printIdent var
     , ranges: []
     }
   _ →

--- a/src/SlamData/Workspace/Card/Search/Interpret.purs
+++ b/src/SlamData/Workspace/Card/Search/Interpret.purs
@@ -22,27 +22,31 @@ import SlamData.Prelude
 
 import Data.Array (filter, catMaybes, head, nub, fromFoldable)
 import Data.Int as Int
-import Data.List (List)
+import Data.List as L
 import Data.String as S
 import Data.String.Regex as RX
 import Data.String.Regex.Flags as RXF
-
 import Data.Json.Extended as EJSON
 import Data.Json.Extended.Signature.Parse as EJP
 
 import Text.Parsing.Parser as P
 import Text.SlamSearch.Types as SS
 
+import SqlSquare (Sql)
+import SqlSquare as Sql
+
 import Utils as Utils
+
+
 
 -- TODO: We need to really obliterate this module and replace these regular
 -- expressions and ad hoc renderers with something that targets a SQL^2 A(S/B)T,
 -- which is then serialized separately. Blocked by SD-1391.
 
 queryToSQL
-  ∷ Array String
+  ∷ L.List Sql String
   → SS.SearchQuery
-  → String
+  → S.Sql
 queryToSQL fields query =
      "SELECT"
   <> (if needDistinct whereClause then " DISTINCT " else " ")

--- a/src/SlamData/Workspace/Card/Search/Interpret.purs
+++ b/src/SlamData/Workspace/Card/Search/Interpret.purs
@@ -86,7 +86,6 @@ ssValueString = case _ of
   SS.Text v → v
   SS.Tag v → v
 
-
 topFieldF ∷ Algebra (SqlF Ej.EJsonF) (Maybe Sql)
 topFieldF = case _ of
   Splice Nothing → Just $ embed $ Splice Nothing
@@ -100,7 +99,7 @@ topFieldF = case _ of
 
 projections ∷ L.List Sql → L.List (Sql.Projection Sql)
 projections =
-  map Sql.projection --(Sql.Projection ∘ { expr: _, alias: Nothing})
+  map Sql.projection
   ∘ L.nub
   ∘ L.catMaybes
   ∘ map (cata topFieldF)
@@ -110,7 +109,7 @@ filter fs =
   ands
   ∘ map ors
   ∘ unwrap
-  ∘ map (termToSql $ map flattenIndex fs)
+  ∘ map (termToSql $ L.nub $ map flattenIndex fs)
 
 ands ∷ L.List Sql → Sql
 ands = case _ of
@@ -130,6 +129,7 @@ flattenIndex = transAna flattenIndexT
 flattenIndexT ∷ ∀ t. Transform t (SqlF Ej.EJsonF) (SqlF Ej.EJsonF)
 flattenIndexT = case _ of
   Binop { op: Sql.IndexDeref, lhs } → Unop { op: Sql.FlattenArrayValues, expr: lhs }
+  Binop { op: Sql.FieldDeref, lhs } → Unop { op: Sql.FlattenMapValues, expr: lhs }
   s → s
 
 termToSql ∷ L.List Sql → SS.Term → Sql

--- a/src/SlamData/Workspace/Card/Search/Interpret.purs
+++ b/src/SlamData/Workspace/Card/Search/Interpret.purs
@@ -15,7 +15,7 @@ limitations under the License.
 -}
 
 module SlamData.Workspace.Card.Search.Interpret
-  ( queryToSQL
+  ( queryToSql
   ) where
 
 import SlamData.Prelude
@@ -43,13 +43,12 @@ import SqlSquare as Sql
 import Utils as Utils
 
 
-
-queryToSQL
+queryToSql
   ∷ L.List Sql
   → SS.SearchQuery
   → FilePath
   → Sql
-queryToSQL fields searchQuery path =
+queryToSql fields searchQuery path =
   Sql.buildSelect
     $ (Sql._isDistinct .~ isDistinct searchQuery)
     ∘ (Sql._projections .~ projections fields)

--- a/src/SlamData/Workspace/Card/Setups/Chart/PivotTable/Eval.purs
+++ b/src/SlamData/Workspace/Card/Setups/Chart/PivotTable/Eval.purs
@@ -42,6 +42,8 @@ import SlamData.Workspace.Card.Setups.Dimension as D
 import SlamData.Workspace.Card.Setups.Transform as T
 import SlamData.Workspace.Card.Setups.Axis (buildAxes)
 
+import SqlSquare (Sql)
+
 import Utils.Path (FilePath)
 
 eval
@@ -70,14 +72,14 @@ eval options varMap resource = do
     state' = { axes, records: [], resource }
     view = Port.View r (snd query) varMap
     output = Port.PivotTable (fst query) × SM.singleton Port.defaultResourceVar (Left view)
-    backendPath = Left $ fromMaybe Path.rootDir (Path.parentDir r)
+    backendPath = fromMaybe Path.rootDir (Path.parentDir r)
   put (Just (CEM.Analysis state'))
   when (Array.null options.columns) do
     CEM.throw "Please select a column to display"
   CEM.liftQ $ QQ.viewQuery backendPath r (snd query) SM.empty
   pure output
 
-mkSql ∷ PTM.Model → FilePath → Port.PivotTablePort × String
+mkSql ∷ PTM.Model → FilePath → Port.PivotTablePort × Sql
 mkSql options resource =
   let
     isSimple = PTM.isSimple options

--- a/src/SlamData/Workspace/Card/Setups/Chart/PivotTable/Eval.purs
+++ b/src/SlamData/Workspace/Card/Setups/Chart/PivotTable/Eval.purs
@@ -24,17 +24,18 @@ import Control.Monad.Throw (class MonadThrow, throw)
 
 import Data.Argonaut as J
 import Data.Array as Array
-import Data.Lens ((^.))
+import Data.Lens ((^.), (.~), (?~), (<>~))
+import Data.List ((:))
+import Data.List as L
+import Data.NonEmpty as NE
 import Data.Map as Map
 import Data.Path.Pathy as Path
-import Data.String as String
 import Data.Set as Set
 import Data.StrMap as SM
 
 import SlamData.Prelude
 import SlamData.Quasar.Class (class QuasarDSL)
 import SlamData.Quasar.Query as QQ
-import SlamData.Workspace.Card.Eval.Common as CEC
 import SlamData.Workspace.Card.Eval.Monad as CEM
 import SlamData.Workspace.Card.Port as Port
 import SlamData.Workspace.Card.Setups.Chart.PivotTable.Model as PTM
@@ -43,6 +44,7 @@ import SlamData.Workspace.Card.Setups.Transform as T
 import SlamData.Workspace.Card.Setups.Axis (buildAxes)
 
 import SqlSquare (Sql)
+import SqlSquare as Sql
 
 import Utils.Path (FilePath)
 
@@ -70,13 +72,13 @@ eval options varMap resource = do
       _ → either throw (pure ∘ buildAxes) =<< QQ.sample filePath 0 300
   let
     state' = { axes, records: [], resource }
-    view = Port.View r (snd query) varMap
+    view = Port.View r (Sql.print $ snd query) varMap
     output = Port.PivotTable (fst query) × SM.singleton Port.defaultResourceVar (Left view)
     backendPath = fromMaybe Path.rootDir (Path.parentDir r)
   put (Just (CEM.Analysis state'))
   when (Array.null options.columns) do
     CEM.throw "Please select a column to display"
-  CEM.liftQ $ QQ.viewQuery backendPath r (snd query) SM.empty
+  CEM.liftQ $ QQ.viewQuery r (snd query) SM.empty
   pure output
 
 mkSql ∷ PTM.Model → FilePath → Port.PivotTablePort × Sql
@@ -84,31 +86,48 @@ mkSql options resource =
   let
     isSimple = PTM.isSimple options
     port = genPort isSimple options
-    dimLen = Array.length port.dimensions
-    dimVals = map escapeDimension <$> port.dimensions
-    colVals = map escapeColumn <$> port.columns
-    groupBy = map (\(_ × tr × val) → maybe val (flip T.printTransform val) tr) dimVals
-    dims = map (\(n × tr × val) → groupByTransform tr val <> " AS " <> Port.escapeIdentifier n) dimVals
-    cols =
-      map
-        case _ of
-          n × Nothing × val | isSimple → val <> " AS " <> Port.escapeIdentifier n
-          n × tr × val → columnTransform tr val <> " AS " <> Port.escapeIdentifier n
-        colVals
-    head =
-      [ "SELECT " <> String.joinWith ", " (dims <> cols)
-      , "FROM {{path}} AS row"
-      ]
-    tail =
-      [ "GROUP BY " <> String.joinWith ", " groupBy
-      , "ORDER BY " <> String.joinWith ", " groupBy
-      ]
+
+    dimVals = L.fromFoldable $ map escapeDimension <$> port.dimensions
+    colVals = L.fromFoldable $ map escapeColumn <$> port.columns
+
+    dimProjections ∷ L.List (Sql.Projection Sql)
+    dimProjections = dimVals <#> \(n × tr × prj) →
+      groupByTransform tr prj # Sql.as (Sql.printIdent n)
+
+    colProjections ∷ L.List (Sql.Projection Sql)
+    colProjections = colVals <#> case _ of
+      n × Nothing × val | isSimple → val # Sql.as (Sql.printIdent n)
+      n × tr × val → columnTransform tr val # Sql.as (Sql.printIdent n)
+
+    projectionExpr ∷ ∀ a. Sql.Projection a → a
+    projectionExpr (Sql.Projection { expr }) = expr
+
+    groupByFields ∷ L.List Sql
+    groupByFields = dimVals <#> \(_ × tr × val) →
+      projectionExpr $ maybe val (flip T.applyTransform val) tr
+
+
+    groupBy ∷ Maybe (Sql.GroupBy Sql)
+    groupBy = case groupByFields of
+      L.Nil → Nothing
+      xs → Just $ Sql.groupBy xs
+
+    orderBy ∷ Maybe (Sql.OrderBy Sql)
+    orderBy = case groupByFields of
+      L.Nil → Nothing
+      h:tl → Just $ Sql.OrderBy $ (Sql.ASC × h) NE.:| map (Sql.ASC × _) tl
+
+    projections ∷ L.List (Sql.Projection Sql)
+    projections = dimProjections <> colProjections
+
+    sql ∷ Sql
     sql =
-      QQ.templated resource $
-        String.joinWith " "
-          if dimLen == 0
-            then head
-            else head <> tail
+      Sql.buildSelect
+        $ ( Sql._projections <>~ projections)
+        ∘ ( Sql._relations
+              ?~ ( Sql.TableRelation { alias: Just "row", path: Left resource }))
+        ∘ ( Sql._groupBy .~ groupBy )
+        ∘ ( Sql._orderBy .~ orderBy )
   in
     port × sql
 
@@ -154,24 +173,24 @@ topName = case _ of
   J.JIndex _ cs → topName cs
   J.JCursorTop → "value"
 
-groupByTransform ∷ Maybe T.Transform → String → String
-groupByTransform (Just tr) b = T.printTransform tr b
+groupByTransform ∷ Maybe T.Transform → Sql.Projection Sql → Sql.Projection Sql
+groupByTransform (Just tr) b = T.applyTransform tr b
 groupByTransform Nothing b   = b
 
-columnTransform ∷ Maybe T.Transform → String → String
-columnTransform (Just tr) b = T.printTransform tr b
-columnTransform Nothing b   = "[" <> b <> " ...]"
+columnTransform ∷ Maybe T.Transform → Sql.Projection Sql → Sql.Projection Sql
+columnTransform (Just tr) b = T.applyTransform tr b
+columnTransform Nothing (Sql.Projection {alias, expr}) =
+  Sql.Projection { alias, expr: Sql.unop Sql.UnshiftArray expr }
 
-escapeString ∷ String → String
-escapeString = J.printJson <<< J.encodeJson
-
-escapeDimension ∷ ∀ a. D.Dimension a J.JCursor → Maybe T.Transform × String
+escapeDimension ∷ ∀ a. D.Dimension a J.JCursor → Maybe T.Transform × Sql.Projection Sql
 escapeDimension = case _ of
-  D.Dimension _ (D.Static str) → Nothing × escapeString str
-  D.Dimension _ (D.Projection tr cur) → tr × "row" <> CEC.escapeCursor cur
+  D.Dimension _ (D.Static str) → Nothing × (Sql.projection $ Sql.ident str)
+  D.Dimension _ (D.Projection tr cur) →
+    tr × (Sql.projection $ Sql.binop Sql.FieldDeref (Sql.ident "row") $ QQ.jcursorToSql cur)
 
-escapeColumn ∷ ∀ a. D.Dimension a PTM.Column → Maybe T.Transform × String
+escapeColumn ∷ ∀ a. D.Dimension a PTM.Column → Maybe T.Transform × Sql.Projection Sql
 escapeColumn = case _ of
-  D.Dimension _ (D.Static str) → Nothing × escapeString str
-  D.Dimension _ (D.Projection tr PTM.All) → tr × "row"
-  D.Dimension _ (D.Projection tr (PTM.Column cur)) → tr × "row" <> CEC.escapeCursor cur
+  D.Dimension _ (D.Static str) → Nothing × (Sql.projection $ Sql.ident str)
+  D.Dimension _ (D.Projection tr PTM.All) → tr × (Sql.projection $ Sql.ident "row")
+  D.Dimension _ (D.Projection tr (PTM.Column cur)) →
+    tr × (Sql.projection $ Sql.binop Sql.FieldDeref (Sql.ident "row") $ QQ.jcursorToSql cur)

--- a/src/SlamData/Workspace/Card/Setups/Semantics.purs
+++ b/src/SlamData/Workspace/Card/Setups/Semantics.purs
@@ -276,16 +276,6 @@ semanticsToSql = case _ of
       (pure ∘ Sql.invokeFunction "TIMESTAMP" ∘ pure ∘ Sql.string)
       $ Fd.formatDateTime "YYYY-MM-DDTHH:mm:ssZ" dt
 
-semanticsToSQLStrings ∷ Semantics → Array String
-semanticsToSQLStrings (Value v) = [ show v ]
-semanticsToSQLStrings (Percent v) = [ "\"" <> show v <> "%\"", show (v/100.0) ]
-semanticsToSQLStrings (Money v m) = [ "\"" <> show v <> show m <> "\"" ]
-semanticsToSQLStrings (Category s) = [ show s ]
-semanticsToSQLStrings (Bool b) = [ show b ]
-semanticsToSQLStrings (Time t) = [ show $ printTime t ]
-semanticsToSQLStrings (Date d) = [ show $ printDate d ]
-semanticsToSQLStrings (DateTime (DT.DateTime d t)) = [ show $ printDate d <> " " <> printTime t ]
-
 semanticsToNumber ∷ Semantics → Maybe Number
 semanticsToNumber (Value v) = pure v
 semanticsToNumber (Money v _) = pure v

--- a/src/SlamData/Workspace/Card/Setups/Transform.purs
+++ b/src/SlamData/Workspace/Card/Setups/Transform.purs
@@ -28,6 +28,9 @@ import SlamData.Workspace.Card.Setups.Transform.DatePart as DP
 import SlamData.Workspace.Card.Setups.Transform.Numeric as N
 import SlamData.Workspace.Card.Setups.Transform.String as S
 
+import SqlSquare (Sql)
+import SqlSquare as Sql
+
 import Test.StrongCheck.Arbitrary (class Arbitrary, arbitrary)
 import Test.StrongCheck.Gen as Gen
 
@@ -66,6 +69,8 @@ foldTransform a b c d e f = case _ of
   String z → d z
   Numeric z → e z
   Count → f unit
+
+
 
 prettyPrintTransform ∷ Transform → String
 prettyPrintTransform =

--- a/src/SlamData/Workspace/Card/Setups/Transform.purs
+++ b/src/SlamData/Workspace/Card/Setups/Transform.purs
@@ -105,25 +105,6 @@ applyTransform =
     in Sql.Projection { alias, expr: Sql.invokeFunction funcName $ L.singleton expr }
 
 
-printTransform ∷ Transform → String → String
-printTransform =
-  foldTransform
-    (datePart ∘ DP.printDate)
-    (datePart ∘ DP.printTime)
-    aggregation
-    stringOp
-    N.printNumericOperation
-    (const count)
-  where
-  count value = "COUNT(" <> value <> ")"
-  datePart part value = "DATE_PART(\"" <> part <> "\", " <> value <> ")"
-  stringOp op value = S.prettyPrintStringOperation op <> "(" <> value <> ")"
-  aggregation ag value = case ag of
-    Ag.Minimum → "MIN(" <> value <> ")"
-    Ag.Maximum → "MAX(" <> value <> ")"
-    Ag.Average → "AVG(" <> value <> ")"
-    Ag.Sum     → "SUM(" <> value <> ")"
-
 dateTransforms ∷ Array Transform
 dateTransforms = DatePart <$> DP.dateParts
 

--- a/src/SlamData/Workspace/Card/Setups/Transform/DatePart.purs
+++ b/src/SlamData/Workspace/Card/Setups/Transform/DatePart.purs
@@ -17,6 +17,8 @@ limitations under the License.
 module SlamData.Workspace.Card.Setups.Transform.DatePart where
 
 import SlamData.Prelude
+import SqlSquare as Sql
+import Data.List as L
 import Data.Argonaut as J
 import Test.StrongCheck.Arbitrary (class Arbitrary)
 import Test.StrongCheck.Gen as Gen
@@ -87,6 +89,27 @@ printTime = case _ of
   Second → "second"
   Minute → "minute"
   Hour → "hour"
+
+applyDateTransform ∷ DatePart → Sql.Projection Sql.Sql → Sql.Projection Sql.Sql
+applyDateTransform dp (Sql.Projection { alias, expr }) =
+  Sql.Projection
+    { alias
+    , expr:
+        Sql.invokeFunction "DATE_PART"
+        $ L.fromFoldable
+        [ Sql.string $ printDate dp, expr ]
+    }
+
+applyTimeTransform ∷ TimePart → Sql.Projection Sql.Sql → Sql.Projection Sql.Sql
+applyTimeTransform tp (Sql.Projection { alias, expr }) =
+  Sql.Projection
+    { alias
+    , expr:
+        Sql.invokeFunction "DATE_PART"
+        $ L.fromFoldable
+        [ Sql.string $ printTime tp, expr ]
+    }
+
 
 printDateTime ∷ DateTimePart → String
 printDateTime = either printDate printTime

--- a/src/SlamData/Workspace/Card/Setups/Transform/String.purs
+++ b/src/SlamData/Workspace/Card/Setups/Transform/String.purs
@@ -17,6 +17,7 @@ limitations under the License.
 module SlamData.Workspace.Card.Setups.Transform.String where
 
 import SlamData.Prelude
+import SqlSquare as Sql
 import Data.Argonaut as J
 import Test.StrongCheck.Arbitrary (class Arbitrary)
 import Test.StrongCheck.Gen as Gen
@@ -25,6 +26,14 @@ data StringOperation
   = Lower
   | Upper
   | Length
+
+applyStringOperation ∷ StringOperation → Sql.Projection Sql.Sql → Sql.Projection Sql.Sql
+applyStringOperation op (Sql.Projection { expr, alias }) =
+  Sql.Projection
+  { alias
+  , expr: Sql.invokeFunction (printStringOperation op) $ pure expr
+  }
+
 
 stringOperations ∷ Array StringOperation
 stringOperations =

--- a/src/SlamData/Workspace/Card/Troubleshoot/Component.purs
+++ b/src/SlamData/Workspace/Card/Troubleshoot/Component.purs
@@ -33,6 +33,8 @@ import SlamData.Workspace.Card.Troubleshoot.Component.Query (Query)
 import SlamData.Workspace.Card.Troubleshoot.Component.State (State, initialState)
 import SlamData.Workspace.LevelOfDetails as LOD
 
+import SqlSquare as Sql
+
 type DSL = CC.InnerCardDSL State Query
 type HTML = CC.InnerCardHTML Query
 
@@ -68,7 +70,7 @@ render { varMap } =
     renderItem name val =
       [ HH.tr_
           [ HH.td_ [ HH.text name ]
-          , HH.td_ [ HH.code_ [ HH.text $ Port.renderVarMapValue val ] ]
+          , HH.td_ [ HH.code_ [ HH.text $ Sql.print $ unwrap val ] ]
           ]
       ]
 

--- a/src/SlamData/Workspace/Routing.purs
+++ b/src/SlamData/Workspace/Routing.purs
@@ -28,21 +28,16 @@ import SlamData.Prelude
 
 import Data.Argonaut as J
 import Data.Foldable as F
-import Data.Json.Extended as EJSON
-import Data.Json.Extended.Signature.Render as EJR
 import Data.List as L
 import Data.Map as Map
 import Data.Maybe as M
 import Data.Path.Pathy ((</>))
 import Data.Path.Pathy as P
-import Data.String as Str
 import Data.String.Regex as R
 import Data.String.Regex.Flags as RXF
 import Data.StrMap as SM
 
 import Global (encodeURIComponent)
-
-import Matryoshka (project)
 
 import Routing.Match (Match)
 import Routing.Match (eitherMatch, list) as Match
@@ -54,6 +49,8 @@ import SlamData.Workspace.Action as WA
 import SlamData.Workspace.Card.CardId as CID
 import SlamData.Workspace.Card.Port.VarMap as Port
 import SlamData.Workspace.Deck.DeckId as DID
+
+import SqlSquare as Sql
 
 import Utils.Path as UP
 
@@ -163,24 +160,11 @@ mkWorkspaceHash path action varMap =
     <> maybe "" ("/" <> _) (renderVarMapQueryString varMap)
 
 varMapsForURL ∷ Map.Map CID.CardId Port.VarMap → SM.StrMap Port.URLVarMap
-varMapsForURL = SM.fromFoldable ∘ map (bimap CID.toString (map go)) ∘ Map.toList
-  where
-  go (Port.Literal ej) = goEJson ej
-  go (Port.SetLiteral as) = "(" <> F.intercalate "," (go <$> as) <> ")"
-  go (Port.QueryExpr q) =
-    -- | This is not entirely legit as it will strip backticks from SQL²
-    -- | expressions as well as identifiers, as we have no information about
-    -- | the field type here... -gb
-    fromMaybe q $ Str.stripPrefix (Str.Pattern "`") =<< Str.stripSuffix (Str.Pattern "`") q
-
-  goEJson ej = case project ej of
-    EJSON.String str → str
-    EJSON.Timestamp dt → EJR.renderTimestamp dt
-    EJSON.Date d → EJR.renderDate d
-    EJSON.Time t → EJR.renderTime t
-    EJSON.Interval str → str
-    EJSON.ObjectId str → str
-    _ → EJSON.renderEJson ej
+varMapsForURL =
+  SM.fromFoldable
+  -- I'm not very sure why there was stripping of backtics, just removed it @cryogenian
+  ∘ map (bimap CID.toString (map $ Sql.print ∘ unwrap))
+  ∘ Map.toList
 
 decodeVarMaps ∷ String → Either String (SM.StrMap Port.URLVarMap)
 decodeVarMaps = J.jsonParser >=> J.decodeJson

--- a/src/Utils.purs
+++ b/src/Utils.purs
@@ -33,6 +33,11 @@ stringToNumber s =
   where
   n = readFloat s
 
+stringToBoolean ∷ String → Maybe Boolean
+stringToBoolean "true" = Just true
+stringToBoolean "false" = Just false
+stringToBoolean _ = Nothing
+
 stringToInt ∷ String → Maybe Int
 stringToInt = map Int.floor ∘ stringToNumber
 

--- a/test/src/Test/SlamData/Feature/Test/Markdown.purs
+++ b/test/src/Test/SlamData/Feature/Test/Markdown.purs
@@ -63,7 +63,7 @@ test = do
     Expect.fieldInLastMdCard "startTime" "time" ""
     Expect.fieldInLastMdCard "finishTime" "time" "20:39"
     Expect.labelInLastMdCard "event"
-    Expect.dropdownInLastMdCard "1500m" ["1000m", "1500m", "3000m"]
+    Expect.dropdownInLastMdCard "1500m" ["1500m", "1000m", "3000m"]
     Expect.labelInLastMdCard "gender"
     Expect.checkableFieldInLastMdCard "X" "checkbox" false
     Expect.checkableFieldInLastMdCard "W" "checkbox" false
@@ -267,7 +267,7 @@ test = do
     Interact.runQuery
     Interact.accessNextCardInLastDeck
     Interact.insertDisplayMarkdownCardInLastDeck
-    Expect.fieldInLastMdCard "city" "text" "AGAWAM"
+    Expect.fieldInLastMdCard "city" "text" "ABINGTON"
     Interact.accessPreviousCardInLastDeck
     Interact.accessPreviousCardInLastDeck
     Interact.selectFromDropdownInLastDeck "state" "RI"


### PR DESCRIPTION
Integration purescript-sqlsquare. 

Depends on slamdata/purescript-sqlsquare#3

Fixes #1515 

@garyb @natefaubion Please review

+ Most `Quasar.Query` things use `Sql` as an input.
+ Replaced `VarMapValue` with `newtype VarMapValue = VarMapValue Sql` 
+ Fields analysis, search interpretation, pivot table eval -- all use sqlsquare ast. 
+ Since __purescript-ejson__ lost it's date|time parsers I parse/print dates using __purescript-formatters__ here

I believe that `Port` can be `Sql` too 😛 