### PR TITLE
Silent model updates

### DIFF
--- a/src/SlamData/Workspace/Card/Common/EvalQuery.purs
+++ b/src/SlamData/Workspace/Card/Common/EvalQuery.purs
@@ -18,8 +18,11 @@ module SlamData.Workspace.Card.Common.EvalQuery
   ( CardEvalQuery(..)
   , CardEvalMessage(..)
   , ModelUpdateType(..)
+  , ModelUpdateOption(..)
   , modelUpdate
+  , modelUpdateSilently
   , stateUpdate
+  , shouldTriggerEval
   ) where
 
 import SlamData.Prelude
@@ -67,14 +70,26 @@ data CardEvalMessage
 -- | the model changes in a way that will affect the evaluated output of the
 -- | card.
 data ModelUpdateType
-  = EvalModelUpdate
+  = EvalModelUpdate ModelUpdateOption
   | EvalStateUpdate (Maybe EvalState → Maybe EvalState)
 
+data ModelUpdateOption
+  = TriggerEval
+  | Silent
+
 modelUpdate ∷ CardEvalMessage
-modelUpdate = ModelUpdated EvalModelUpdate
+modelUpdate = ModelUpdated (EvalModelUpdate TriggerEval)
+
+modelUpdateSilently ∷ CardEvalMessage
+modelUpdateSilently = ModelUpdated (EvalModelUpdate Silent)
 
 stateUpdate ∷ EvalState → CardEvalMessage
 stateUpdate = ModelUpdated ∘ EvalStateUpdate ∘ const ∘ Just
 
 stateAlter ∷ (Maybe EvalState → Maybe EvalState) → CardEvalMessage
 stateAlter = ModelUpdated ∘ EvalStateUpdate
+
+shouldTriggerEval ∷ ModelUpdateOption → Boolean
+shouldTriggerEval = case _ of
+  TriggerEval → true
+  _ → false

--- a/src/SlamData/Workspace/Card/Component.purs
+++ b/src/SlamData/Workspace/Card/Component.purs
@@ -209,9 +209,9 @@ makeCardComponent cardType component options =
       pure next
     CQ.HandleCardMessage msg next → do
       case msg of
-        EQ.ModelUpdated EQ.EvalModelUpdate → do
+        EQ.ModelUpdated (EQ.EvalModelUpdate evalOpts) → do
           model ← H.query unit (left (H.request EQ.Save))
-          for_ model (H.lift ∘ P.publishCardChange displayCoord)
+          for_ model (H.lift ∘ P.publishCardChange evalOpts displayCoord)
         EQ.ModelUpdated (EQ.EvalStateUpdate fn) → do
           H.lift $ P.publishCardStateChange displayCoord fn
       pure next

--- a/src/SlamData/Workspace/Card/Draftboard/Component.purs
+++ b/src/SlamData/Workspace/Card/Draftboard/Component.purs
@@ -162,7 +162,7 @@ evalBoard opts = case _ of
           $ updateLayout (fromMaybe st.layout result)
           ∘ _ { splitOpts = Nothing, splitLocation = Nothing }
         H.queryAll $ H.action DCQ.UpdateCardSize
-        H.raise CC.modelUpdate
+        H.raise CC.modelUpdateSilently
     pure next
   ResizeStart edge ev next → do
     let
@@ -231,7 +231,7 @@ evalBoard opts = case _ of
           $ updateLayout (fromMaybe st.layout result)
           ∘ _ { resizeLocation = Nothing }
         H.queryAll $ H.action DCQ.UpdateCardSize
-        H.raise CC.modelUpdate
+        H.raise CC.modelUpdateSilently
     pure next
   DeleteCell cursor next → do
     st ← H.get
@@ -239,7 +239,7 @@ evalBoard opts = case _ of
       result = Layout.deleteCell cursor st.layout
     H.modify (updateLayout (fromMaybe st.layout result))
     H.queryAll $ H.action DCQ.UpdateCardSize
-    H.raise CC.modelUpdate
+    H.raise CC.modelUpdateSilently
     pure next
   GrabStart deckId ev next → do
     st ← H.get
@@ -281,6 +281,7 @@ evalBoard opts = case _ of
             for_ cell.value \deckId' → do
               H.modify _ { moveLocation = Nothing }
               groupDeck orn bias deckId deckId'
+              H.raise CC.modelUpdate
           Move cell → do
             let
               result =
@@ -291,7 +292,7 @@ evalBoard opts = case _ of
               $ updateLayout (fromMaybe st.layout result)
               ∘ _ { moveLocation = Nothing }
             void $ H.query deckId $ H.action DCQ.UpdateCardSize
-        H.raise CC.modelUpdate
+            H.raise CC.modelUpdateSilently
     pure next
   AddDeck cursor next → do
     H.lift $ P.addDeckToDraftboard opts.cardId cursor >>= Wiring.focusDeck

--- a/src/SlamData/Workspace/Card/Tabs/Component.purs
+++ b/src/SlamData/Workspace/Card/Tabs/Component.purs
@@ -229,7 +229,7 @@ evalTabs cardOpts = case _ of
                 , activeTab = Just ix'
                 , tabs = reorder ix ix' st.tabs
                 }
-              H.raise CC.modelUpdate
+              H.raise CC.modelUpdateSilently
               H.raise $ CC.stateUpdate $ ES.ActiveTab ix'
             Nothing →
               H.modify _ { ordering = Nothing }

--- a/src/SlamData/Workspace/Eval/Card.purs
+++ b/src/SlamData/Workspace/Eval/Card.purs
@@ -24,6 +24,7 @@ module SlamData.Workspace.Eval.Card
   , DisplayCoord
   , toAll
   , module SlamData.Workspace.Card.CardId
+  , module SlamData.Workspace.Card.Common.EvalQuery
   , module SlamData.Workspace.Card.Eval
   , module SlamData.Workspace.Card.Eval.Monad
   , module SlamData.Workspace.Card.Eval.State
@@ -39,6 +40,7 @@ import Data.List (List)
 import Data.Set (Set)
 
 import SlamData.Workspace.Card.CardId (CardId)
+import SlamData.Workspace.Card.Common.EvalQuery (ModelUpdateOption(..), shouldTriggerEval)
 import SlamData.Workspace.Card.Eval (Eval, runCard, modelToEval)
 import SlamData.Workspace.Card.Eval.Monad (CardEnv(..), ChildOut, AdditionalSource(..))
 import SlamData.Workspace.Card.Eval.State (initialEvalState, EvalState)


### PR DESCRIPTION
Fixes #929 

I also uncovered a bug where deleting a card did not trigger evaluation of a parent, and left stale graph state around.