### PR TITLE
FS tooltips

### DIFF
--- a/less/filesystem.less
+++ b/less/filesystem.less
@@ -1,7 +1,3 @@
-.file-action {
-  margin-left: 0.25rem;
-  width: 1rem;
-}
 
 @import "filesystem/search";
 @import "filesystem/toolbar";

--- a/less/filesystem/toolbar.less
+++ b/less/filesystem/toolbar.less
@@ -26,9 +26,13 @@
     margin-bottom: 0;
   }
 
+  button, label {
+    padding: 0 .75rem;
+    cursor: pointer;
+  }
+
   .sd-icon {
-    padding-left: 10px;
-    font-size: 16px;
+    font-size: 20px;
     line-height: 40px;
     position: relative;
     overflow: hidden;

--- a/less/main.less
+++ b/less/main.less
@@ -155,15 +155,22 @@ ol.breadcrumb {
     }
 }
 
-.toolbar-menu button, .item-toolbar button {
-    background: none;
-    border: 0;
+.toolbar-menu,
+.item-toolbar {
+  .list-inline > li {
     padding: 0;
-    color: #337ab7;
+  }
 
-    &:hover {
-        color: #23527c
-    }
+  button, label {
+      background: none;
+      border: 0;
+      padding: 0 .5rem;
+      color: #337ab7;
+
+      &:hover {
+          color: #23527c
+      }
+  }
 }
 
 .new-card-menu {
@@ -405,3 +412,4 @@ button {
 @import "workspace";
 @import "button";
 @import "icon";
+@import "tooltip";

--- a/less/tooltip.less
+++ b/less/tooltip.less
@@ -1,0 +1,55 @@
+.sd-tooltip {
+  position: relative;
+
+  // Toolip label
+  &::before {
+    transform: translateX(50%);
+    background-color: rgba(225,225,225,.8);
+    color: #fff;
+    content: attr(aria-label);
+    padding: 0 .5rem;
+    line-height: 1.5rem;
+    text-transform: none;
+    font-weight: normal;
+    white-space: nowrap;
+    font-size: 11px;
+    margin-bottom: 5px;
+  }
+
+  // Tooltip arrow
+  &::after {
+    transform: translateX(50%);
+    border-left: 5px solid transparent;
+    border-right: 5px solid transparent;
+    border-top: 5px solid rgba(225,225,225,.8);
+    content: " ";
+    font-size: 0;
+    line-height: 0;
+    width: 0;
+  }
+
+  &.sd-tooltip-r {
+    &::before {
+      right: 0;
+      transform: translateX(0);
+    }
+  }
+
+  &::before,
+  &::after {
+    position: absolute;
+    right: 50%;
+    bottom: 100%;
+    color: #666;
+    opacity: 0;
+    pointer-events: none;
+  }
+
+  &:focus::before,
+  &:focus::after,
+  &:hover::before,
+  &:hover::after {
+    opacity: 1;
+    transition: all 0.2s ease;
+  }
+}

--- a/src/SlamData/FileSystem/Component/Render.purs
+++ b/src/SlamData/FileSystem/Component/Render.purs
@@ -71,7 +71,7 @@ toolbar state =
       )
     <> [ H.ul
          [ P.classes [ B.listInline, B.pullRight ] ]
-         $ [ workspace, folder, showHide, download, file, mount ] <> configure
+         $ configure <> [ mount, workspace, folder, showHide, download, file ]
        ]
   where
   configure ∷ Array (HTML p (Query Unit))
@@ -104,8 +104,11 @@ toolbar state =
           ]
       , H.label
           [ P.for "upload"
-          , P.title "Upload file"
-          , P.class_ $ H.ClassName "tool-item"
+          , P.classes
+              [ H.ClassName "tool-item"
+              , H.ClassName "sd-tooltip"
+              , H.ClassName "sd-tooltip-r"
+              ]
           , ARIA.label "Upload file"
           ]
           [ I.uploadSm ]
@@ -119,8 +122,10 @@ toolItem func title icon =
   H.li_
     [ H.button
         [ ARIA.label title
-        , P.title title
-        , P.class_ $ H.ClassName "tool-item"
+        , P.classes
+            [ H.ClassName "tool-item"
+            , H.ClassName "sd-tooltip"
+            ]
         , E.onClick (E.input_ func)
         ]
         [ icon ]

--- a/src/SlamData/FileSystem/Listing/Item/Component.purs
+++ b/src/SlamData/FileSystem/Listing/Item/Component.purs
@@ -235,7 +235,7 @@ itemActions presentActions item | otherwise =
           [ HE.onClick $ HE.input $ HandleAction $ act (itemResource item)
           , HP.title label
           , ARIA.label label
-          , HP.class_ CSS.fileAction
+          , HP.classes [ CSS.fileAction, HH.ClassName "sd-tooltip" ]
           ]
           [ icon ]
       ]


### PR DESCRIPTION
I've added custom tooltips that appear instantly on the mystery icons in the file system. A fairly small UX change, but I think it helps quite a bit with the FS that we have now.

<img width="758" alt="screen shot 2017-04-20 at 4 45 03 pm" src="https://cloud.githubusercontent.com/assets/144058/25253884/87b899c0-25e8-11e7-9fd4-b102b5f50b5d.png">
<img width="794" alt="screen shot 2017-04-20 at 4 44 52 pm" src="https://cloud.githubusercontent.com/assets/144058/25253885/87db6bbc-25e8-11e7-9a5e-50a2cf5c5939.png">
