### PR TITLE
Remove error handling from Preview Table card

### DIFF
--- a/src/SlamData/Workspace/Card/Eval/State.purs
+++ b/src/SlamData/Workspace/Card/Eval/State.purs
@@ -59,7 +59,7 @@ type AutoSelectR =
 
 type TableR =
   { resource ∷ Resource
-  , result ∷ String ⊹ Array Json
+  , result ∷ Array Json
   , page ∷ Int
   , pageSize ∷ Int
   , size ∷ Int

--- a/src/SlamData/Workspace/Card/Table/Component.purs
+++ b/src/SlamData/Workspace/Card/Table/Component.purs
@@ -70,22 +70,18 @@ evalCard = case _ of
     pure next
   CC.ReceiveState s next → do
     for_ (s ^? ES._Table) \t →
-      H.modify case t.result of
-        Left e →
-          _{ result = JTS.Errored e
-           }
-        Right _ | t.size ≡ 0 →
-          _{ result = JTS.Empty
-           }
-        Right a | otherwise →
-          _{ result = JTS.Ready
-               { json: JSON.fromArray a
-               , page: t.page
-               , pageSize: t.pageSize
-               }
-           , size = Just t.size
-           , isEnteringPageSize = false
-           }
+      H.modify
+        if t.size == 0
+          then _{ result = Nothing }
+          else
+            _{ result = Just
+                 { json: JSON.fromArray t.result
+                 , page: t.page
+                 , pageSize: t.pageSize
+                 }
+             , size = Just t.size
+             , isEnteringPageSize = false
+             }
     pure next
   CC.ReceiveDimensions dims reply → do
     pure $ reply

--- a/src/SlamData/Workspace/Card/Table/Component/Render.purs
+++ b/src/SlamData/Workspace/Card/Table/Component/Render.purs
@@ -33,7 +33,7 @@ import SlamData.Render.CSS.New as CSS
 import SlamData.Render.Icon as I
 import SlamData.Workspace.Card.Component as CC
 import SlamData.Workspace.Card.Table.Component.Query (PageStep(..), Query(..))
-import SlamData.Workspace.Card.Table.Component.State (State, currentPageInfo, Result(..))
+import SlamData.Workspace.Card.Table.Component.State (State, currentPageInfo)
 
 type HTML = CC.InnerCardHTML Query
 
@@ -54,25 +54,14 @@ fromInputValue { current, pending } =
 render ∷ State → HTML
 render st =
   HH.div_ $ case st.result of
-    Loading → renderLoading
-    Empty → renderEmpty
-    Errored e → renderError e
-    Ready result → renderResult result
+    Nothing → renderEmpty
+    Just result → renderResult result
   where
-  -- This is _loading_ but since we display semitransparent div with spinner on
-  -- top of loading deck there is no reason to display anything else
-  renderLoading =
-    [ ]
   renderEmpty =
     A.singleton
     $ HH.div
       [ HP.classes [ B.alert, B.alertWarning ] ]
       [ HH.text "Selected resource is empty" ]
-  renderError e =
-    A.singleton
-    $ HH.pre
-      [ HP.classes [ B.alert, B.alertDanger ] ]
-      [ HH.text e ]
   renderResult result =
     let
       p = currentPageInfo st

--- a/src/SlamData/Workspace/Card/Table/Component/State.purs
+++ b/src/SlamData/Workspace/Card/Table/Component/State.purs
@@ -16,7 +16,6 @@ limitations under the License.
 
 module SlamData.Workspace.Card.Table.Component.State
   ( State
-  , Result(..)
   , ResultR
   , initialState
   , _result
@@ -41,15 +40,14 @@ import SlamData.Prelude
 import Data.Argonaut (Json)
 import Data.Foldable (maximum)
 import Data.Int as Int
-import Data.Lens ((^?), (?~), Lens', lens, _Just, Prism', prism', Traversal')
-
+import Data.Lens (Lens', Traversal', _Just, lens, (?~), (^?))
 import SlamData.Workspace.Card.Table.Component.Query (PageStep(..))
 import SlamData.Workspace.Card.Table.Model (Model)
 
 -- | The state for the Table card component.
 type State =
   { size ∷ Maybe Int
-  , result ∷ Result
+  , result ∷ Maybe ResultR
   , page ∷ Maybe (String ⊹ Int)
   , pageSize ∷ Maybe (Either String Int)
   , isEnteringPageSize ∷ Boolean
@@ -62,21 +60,10 @@ type ResultR =
   , pageSize ∷ Int
   }
 
-data Result
-  = Loading
-  | Errored String
-  | Empty
-  | Ready ResultR
-
-_ResultR ∷ Prism' Result ResultR
-_ResultR = prism' Ready case _ of
-  Ready r → Just r
-  _ → Nothing
-
 initialState ∷ State
 initialState =
   { size: Nothing
-  , result: Loading
+  , result: Nothing
   , page: Nothing
   , pageSize: Nothing
   , isEnteringPageSize: false
@@ -86,7 +73,7 @@ _result ∷ ∀ a r. Lens' {result ∷ a|r} a
 _result = lens _.result (_ { result = _ })
 
 _Result ∷ Traversal' State ResultR
-_Result = _result ∘ _ResultR
+_Result = _result ∘ _Just
 
 _page ∷ ∀ a r. Lens' {page ∷ a |r} a
 _page = lens _.page (_ { page = _ })


### PR DESCRIPTION
Handling these states in the table card isn't necessary since now it is populated via the eval machinery (previously it populated itself). Thanks to `eval`, now if an error arises, an error card is inserted instead. Likewise the loading state does not occur the way it used to, so the whole state sum can be simplified to `Maybe` now: either there is content to display, or there is not.