### PR TITLE
Fix ordering of backside dismissal

### DIFF
--- a/src/SlamData/Workspace/Deck/Component.purs
+++ b/src/SlamData/Workspace/Deck/Component.purs
@@ -347,8 +347,8 @@ handleBackSide opts = case _ of
         deck ← H.lift $ P.getDeck opts.deckId
         case deck >>= _.parent, mirrorCard <#> _.cardId of
           Just parentId, Just cardId | not (L.null opts.displayCursor) → do
-            _ ← H.lift $ P.mirrorDeck parentId cardId opts.deckId
             switchToFrontside
+            void $ H.lift $ P.mirrorDeck parentId cardId opts.deckId
           _, Just cardId → do
             parentId ← H.lift $ P.wrapAndMirrorDeck cardId opts.deckId
             navigateToDeck (parentId L.: opts.cursor)
@@ -368,10 +368,10 @@ handleBackSide opts = case _ of
   where
   wrapDeck ∷ (DeckId → Card.AnyCardModel) → DeckDSL Unit
   wrapDeck wrapper = do
+    switchToFrontside
     parentId ← H.lift $ P.wrapDeck opts.deckId (wrapper opts.deckId)
-    if L.null opts.displayCursor
-      then navigateToDeck (parentId L.: opts.cursor)
-      else switchToFrontside
+    when (L.null opts.displayCursor) do
+      navigateToDeck (parentId L.: opts.cursor)
 
 handleBackSideFilter ∷ ActionFilter.Message → DeckDSL Unit
 handleBackSideFilter = case _ of


### PR DESCRIPTION
Fixes #1589 

When mirroring, the action was performed before dismissing the backside options. When the backside is open, the cards are hidden with `display: none`. So the dashboard updates, tells the child decks to update dimensions, and the decks tell the cards to update dimensions. Except that the currently active card still has it's backside up, and the cards all report as 0 width and height. 😭 

A better solution is #1351 which will prevent these ordering issues like this from happening when it comes dimensions.