### PR TITLE
Bump jtable dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -41,7 +41,7 @@
     "purescript-halogen-menu": "5.0.0",
     "purescript-halogen-vdom-string-renderer": "^0.2.0",
     "purescript-js-timers": "^3.0.0",
-    "purescript-jtable": "^5.0.0",
+    "purescript-jtable": "^5.1.0",
     "purescript-maps": "^3.0.0",
     "purescript-markdown": "^10.0.0",
     "purescript-markdown-halogen": "^6.0.0",


### PR DESCRIPTION
Fixes #1610 

Note that zip codes like "90210" will still be parsed as numbers. This only affects leading zeros. I'm not really sure why we are parsing strings as numbers though. /cc @damonLL 