### PR TITLE
Allow dots in workspace names

### DIFF
--- a/src/SlamData/FileSystem/Resource.purs
+++ b/src/SlamData/FileSystem/Resource.purs
@@ -188,7 +188,7 @@ root = Directory P.rootDir
 
 mkWorkspace ∷ PU.AnyPath → Resource
 mkWorkspace ap =
-  either (Workspace ∘ (_ <./> Config.workspaceExtension)) go ap
+  either (Workspace ∘ PU.addDirExt Config.workspaceExtension) go ap
   where
   go ∷ PU.FilePath → Resource
   go p = maybe newWorkspace id do

--- a/src/Utils/Path.purs
+++ b/src/Utils/Path.purs
@@ -49,6 +49,9 @@ infixl 6 renameDirExt as <./>
 renameDirExt :: forall a s. Path a Dir s -> String -> Path a Dir s
 renameDirExt p ext = renameDir (changeDirExt $ const ext) p
 
+addDirExt :: forall a s. String -> Path a Dir s -> Path a Dir s
+addDirExt ext = renameDir (\(DirName d) -> DirName $ d <> "." <> ext)
+
 rootify :: DirPath -> Path Rel Dir Sandboxed
 rootify p = fromMaybe (dir "/") $ relativeTo p rootDir
 


### PR DESCRIPTION
Fixes #1720 

"Extensions" were getting stripped twice due to the usage of `<./>` to add the extension back.