### PR TITLE
Add "versionify" build step for production builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ script:
   - npm run build:icons
   - npm run build:less
   - npm run build:psa
-  - if test $TRAVIS_TAG; then npm run build:lite; else npm run test:property && npm run build:lite && npm test; fi
+  - if test $TRAVIS_TAG; then npm run build:lite && npm run versionify; else npm run test:property && npm run build:lite && npm test; fi
 before_deploy:
 - mkdir -p slamdata
 - cp -r public slamdata/

--- a/html/index.html
+++ b/html/index.html
@@ -5,9 +5,13 @@
     <meta charset="UTF-8">
     <script type="text/javascript" src="js/ace.js"></script>
     <script type="text/javascript" src="js/ace/ext-language_tools.js"></script>
+    <!-- filesystem-js -->
     <script type="text/javascript" src="js/filesystem.js"></script>
+    <!-- /filesystem-js -->
     <link rel="stylesheet" href="css/bootstrap.min.css">
+    <!-- styles -->
     <link rel="stylesheet" href="css/main.css">
+    <!-- /styles -->
     <link rel="icon" type="image/png" href="img/favicon.png">
   </head>
   <body>

--- a/html/workspace.html
+++ b/html/workspace.html
@@ -6,9 +6,13 @@
     <script type="text/javascript" src="js/keyboard.js"></script>
     <script type="text/javascript" src="js/ace.js"></script>
     <script type="text/javascript" src="js/ace/ext-language_tools.js"></script>
+    <!-- workspace-js -->
     <script type="text/javascript" src="js/workspace.js"></script>
+    <!-- /workspace-js -->
     <link rel="stylesheet" href="css/bootstrap.min.css">
+    <!-- styles -->
     <link rel="stylesheet" href="css/main.css">
+    <!-- /styles -->
     <link rel="icon" type="image/png" href="img/favicon.png">
   </head>
   <body class="sd-workspace-page">

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "test:local": "npm run build:psa && webpack --progress --config webpack.config.dev.js && npm test",
     "test:property": "gulp bundle-property-tests && node tmp/js/property-tests",
     "watch:less": "less-watch-compiler less/ public/css/ main.less",
-    "ide": "purs ide server"
+    "ide": "purs ide server",
+    "versionify": "gulp versionify"
   },
   "license": "Apache-2.0",
   "bugs": {
@@ -47,14 +48,17 @@
     "chalk": "^1.1.1",
     "change-case": "^3.0.1",
     "chromedriver": "^2.28.0",
+    "del": "^2.2.2",
     "expose-loader": "^0.7.1",
     "glob": "^7.1.1",
     "gulp": "^3.9.0",
     "gulp-cheerio": "^0.6.2",
     "gulp-content-filter": "0.0.0",
+    "gulp-file": "^0.3.0",
     "gulp-footer": "^1.0.5",
     "gulp-header": "^1.7.1",
     "gulp-inject": "^4.2.0",
+    "gulp-rename": "^1.2.2",
     "gulp-replace": "^0.5.4",
     "gulp-svg-sprite": "^1.3.6",
     "gulp-trimlines": "^1.0.0",
@@ -69,6 +73,7 @@
     "purs-loader": "^2.4.2",
     "rimraf": "^2.4.3",
     "selenium-webdriver": "2.53.2",
+    "vinyl-paths": "^2.1.0",
     "webpack": "^2.3.2",
     "webpack-stream": "^2.1.0"
   },


### PR DESCRIPTION
Resolves #1695

This renames the CSS & JS bundles with the SlamData release version, and injects the appropriate tags into HTML too.