### PR TITLE
Line area item tooltip

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
   },
   "dependencies": {
     "clipboard": "1.6.1",
-    "echarts": "^3.2.2",
+    "echarts": "^3.5.4",
     "fs": "^0.0.2",
     "jsrsasign": "^5.0.5",
     "minimatch": "^3.0.0"

--- a/src/SlamData/Workspace/Card/Setups/Chart/Area/Component/Query.purs
+++ b/src/SlamData/Workspace/Card/Setups/Chart/Area/Component/Query.purs
@@ -23,3 +23,4 @@ data Query a
   | SetAxisLabelAngle String a
   | ToggleStacked a
   | HandleDims Q.Message a
+  | SetSize String a

--- a/src/SlamData/Workspace/Card/Setups/Chart/Area/Component/State.purs
+++ b/src/SlamData/Workspace/Card/Setups/Chart/Area/Component/State.purs
@@ -22,6 +22,7 @@ type State =
   { isSmooth ∷ Boolean
   , isStacked ∷ Boolean
   , axisLabelAngle ∷ Number
+  , size ∷ Number
   }
 
 initialState ∷ State
@@ -29,6 +30,7 @@ initialState =
   { isSmooth: false
   , isStacked: false
   , axisLabelAngle: 0.0
+  , size: 10.0
   }
 
 _isSmooth ∷ Lens' State Boolean

--- a/src/SlamData/Workspace/Card/Setups/Chart/Area/Eval.purs
+++ b/src/SlamData/Workspace/Card/Setups/Chart/Area/Eval.purs
@@ -24,6 +24,7 @@ import SlamData.Prelude
 import Data.Argonaut (Json, decodeJson, (.?))
 import Data.Array ((!!))
 import Data.Array as A
+import Data.Int as Int
 import Data.Lens ((^?))
 import Data.List as L
 import Data.Map as M
@@ -119,11 +120,12 @@ areaOptions axes r areaData = do
       , { label: D.jcursorLabel r.value, value: CCT.formatValueIx 1 }
       ]
     opts = flip foldMap r.series \dim →
-      [ { label: D.jcursorLabel dim, value: _.seriesName } ]
+      [ { label: D.jcursorLabel dim, value: _.seriesName
+        } ]
 
   E.tooltip do
-    E.formatterAxis (CCT.tableFormatter (pure ∘ _.color) (cols <> opts))
-    E.triggerAxis
+    E.formatterItem (CCT.tableFormatter (pure ∘ _.color) (cols <> opts) ∘ pure)
+    E.triggerItem
     E.textStyle do
       E.fontFamily "Ubuntu, sans"
       E.fontSize 12
@@ -208,12 +210,12 @@ areaOptions axes r areaData = do
           E.buildValues do
             E.addStringValue key
             E.addValue v
+          E.symbolSize $ Int.floor r.size
     for_ serie.name E.name
     for_ (colors !! ix) \color → do
       E.itemStyle $ E.normal $ E.color color
       E.areaStyle $ E.normal $ E.color $ getShadeColor color (if r.isStacked then 1.0 else 0.5)
     E.lineStyle $ E.normal $ E.width 2
     E.symbol ET.Circle
-    E.symbolSize 0
     E.smooth r.isSmooth
     when r.isStacked $ E.stack "stack"

--- a/src/SlamData/Workspace/Card/Setups/Chart/Area/Model.purs
+++ b/src/SlamData/Workspace/Card/Setups/Chart/Area/Model.purs
@@ -36,6 +36,7 @@ type ModelR =
   , isStacked ∷ Boolean
   , isSmooth ∷ Boolean
   , axisLabelAngle ∷ Number
+  , size ∷ Number
   }
 
 type Model = Maybe ModelR
@@ -51,6 +52,7 @@ eqR r1 r2 =
   ∧ r1.isSmooth ≡ r2.isSmooth
   ∧ r1.series ≡ r2.series
   ∧ r1.axisLabelAngle ≡ r2.axisLabelAngle
+  ∧ r1.size ≡ r2.size
 
 eqModel ∷ Model → Model → Boolean
 eqModel Nothing Nothing = true
@@ -66,6 +68,7 @@ genModel = do
     dimension ← map (map (un ArbJCursor) ∘ un D.DimensionWithStaticCategory) arbitrary
     value ← map (map (un ArbJCursor) ∘ un D.DimensionWithStaticCategory) arbitrary
     series ← map (map (un ArbJCursor) ∘ un D.DimensionWithStaticCategory) <$> arbitrary
+    size ← arbitrary
     isStacked ← arbitrary
     isSmooth ← arbitrary
 
@@ -76,6 +79,7 @@ genModel = do
          , isSmooth
          , series
          , axisLabelAngle
+         , size
          }
 
 encode ∷ Model → J.Json
@@ -88,6 +92,7 @@ encode (Just r) =
   ~> "isSmooth" := r.isSmooth
   ~> "series" := r.series
   ~> "axisLabelAngle" := r.axisLabelAngle
+  ~> "size" := r.size
   ~> J.jsonEmptyObject
 
 decode ∷ J.Json → String ⊹ Model
@@ -111,6 +116,7 @@ decode js
     isStacked ← obj .? "isStacked"
     isSmooth ← obj .? "isSmooth"
     axisLabelAngle ← obj .? "axisLabelAngle"
+    size ← (obj .? "size" <|> pure 10.0)
 
     pure { dimension
          , value
@@ -118,6 +124,7 @@ decode js
          , isSmooth
          , series
          , axisLabelAngle
+         , size
          }
   decodeLegacyR ∷ J.JObject → String ⊹ ModelR
   decodeLegacyR obj = do
@@ -137,4 +144,5 @@ decode js
          , isSmooth
          , series
          , axisLabelAngle
+         , size: 10.0
          }

--- a/src/SlamData/Workspace/Card/Setups/Chart/Legacy.purs
+++ b/src/SlamData/Workspace/Card/Setups/Chart/Legacy.purs
@@ -145,6 +145,8 @@ decode cturs js = do
         bo.smooth
       axisLabelAngle =
         Int.toNumber bo.axisLabelAngle
+      size =
+        10.0
 
       areaR =
         { dimension: _
@@ -153,6 +155,7 @@ decode cturs js = do
         , isStacked
         , isSmooth
         , axisLabelAngle
+        , size
         }
         <$> dimension
         <*> value

--- a/src/SlamData/Workspace/Card/Setups/Chart/Legacy.purs
+++ b/src/SlamData/Workspace/Card/Setups/Chart/Legacy.purs
@@ -328,7 +328,7 @@ decode cturs js = do
       size =
         Nothing
       minSize =
-        2.0
+        10.0
       maxSize =
         20.0
       axisLabelAngle =

--- a/src/SlamData/Workspace/Card/Setups/Chart/Line/Component/State.purs
+++ b/src/SlamData/Workspace/Card/Setups/Chart/Line/Component/State.purs
@@ -26,7 +26,7 @@ type State =
 initialState ∷ State
 initialState =
   { axisLabelAngle: 0.0
-  , minSize: 1.0
+  , minSize: 10.0
   , maxSize: 50.0
   , optionalMarkers: false
   }

--- a/src/SlamData/Workspace/Card/Setups/Chart/Line/Eval.purs
+++ b/src/SlamData/Workspace/Card/Setups/Chart/Line/Eval.purs
@@ -175,7 +175,7 @@ lineOptions axes r lineData = do
     cols =
       [ { label: D.jcursorLabel r.dimension, value: CCT.formatValueIx 0 }
       , { label: D.jcursorLabel r.value, value: \x →
-           if x.seriesIndex `mod` 2 ≡ 0
+           if isNothing r.secondValue ∨ x.seriesIndex `mod` 2 ≡ 0
            then CCT.formatValueIx 1 x
            else ""
         }

--- a/src/SlamData/Workspace/Card/Setups/Chart/Line/Eval.purs
+++ b/src/SlamData/Workspace/Card/Setups/Chart/Line/Eval.purs
@@ -43,6 +43,7 @@ import SlamData.Workspace.Card.Setups.Axis as Ax
 import SlamData.Workspace.Card.Setups.Chart.ColorScheme (colors)
 import SlamData.Workspace.Card.Setups.Chart.Common as SCC
 import SlamData.Workspace.Card.Setups.Chart.Common.Positioning as BCP
+import SlamData.Workspace.Card.Setups.Chart.Common.Tooltip as CCT
 import SlamData.Workspace.Card.Setups.Chart.Line.Model (Model, ModelR)
 import SlamData.Workspace.Card.Setups.Common.Eval (type (>>))
 import SlamData.Workspace.Card.Setups.Common.Eval as BCE
@@ -170,8 +171,27 @@ buildLineData r =
 
 lineOptions ∷ Axes → ModelR → Array LineSerie → DSL OptionI
 lineOptions axes r lineData = do
+  let
+    cols =
+      [ { label: D.jcursorLabel r.dimension, value: CCT.formatValueIx 0 }
+      , { label: D.jcursorLabel r.value, value: \x →
+           if x.seriesIndex `mod` 2 ≡ 0
+           then CCT.formatValueIx 1 x
+           else ""
+        }
+      ]
+    opts = A.catMaybes
+      [ r.secondValue <#> \dim → { label: D.jcursorLabel dim, value: \x →
+                                    if x.seriesIndex `mod` 2 ≡ 0
+                                    then ""
+                                    else CCT.formatValueIx 1 x
+                                 }
+      , r.size <#> \dim → { label: D.jcursorLabel dim, value: CCT.formatSymbolSize }
+      , r.series <#> \dim → { label: D.jcursorLabel dim, value: _.seriesName }
+      ]
   E.tooltip do
-    if isJust r.size then E.triggerItem else E.triggerAxis
+    E.triggerItem
+    E.formatterItem (CCT.tableFormatter (pure ∘ _.color) (cols <> opts) ∘ pure)
     E.textStyle $ E.fontSize 12
 
   E.colors colors


### PR DESCRIPTION
Fixes #1683 

+ Added `size` field for area chart and 
+ Switched to table formatter for line chart 
+ Both line and area now use only item triggered tooltips.

For _right_ solution of #1683 I'm going to create an issue in June milestone. 
@natefaubion Please take a look 