### PR TITLE
Update JTable version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -41,7 +41,7 @@
     "purescript-halogen-menu": "5.0.0",
     "purescript-halogen-vdom-string-renderer": "^0.2.0",
     "purescript-js-timers": "^3.0.0",
-    "purescript-jtable": "^5.1.0",
+    "purescript-jtable": "^6.0.0",
     "purescript-maps": "^3.0.0",
     "purescript-markdown": "^10.0.0",
     "purescript-markdown-halogen": "^6.0.0",

--- a/src/SlamData/Workspace/Card/Table/Component/Render.purs
+++ b/src/SlamData/Workspace/Card/Table/Component/Render.purs
@@ -18,6 +18,7 @@ module SlamData.Workspace.Card.Table.Component.Render (HTML, render) where
 
 import SlamData.Prelude
 
+import Data.Argonaut.JCursor (runJsonPrim)
 import Data.Array as A
 import Data.Char (fromCharCode)
 import Data.Int as Int
@@ -34,6 +35,8 @@ import SlamData.Render.Icon as I
 import SlamData.Workspace.Card.Component as CC
 import SlamData.Workspace.Card.Table.Component.Query (PageStep(..), Query(..))
 import SlamData.Workspace.Card.Table.Component.State (State, currentPageInfo)
+
+import Utils (showPrettyNumber)
 
 type HTML = CC.InnerCardHTML Query
 
@@ -79,9 +82,12 @@ render st =
      ]
 jTableOpts ∷ JT.JTableOpts
 jTableOpts = JT.jTableOptsDefault
-  { style = JT.noStyle
+  { style = JT.noStyle renderJson
   , columnOrdering = JT.alphaOrdering
   }
+  where
+  renderJson j =
+    runJsonPrim j (const "") show showPrettyNumber id
 
 prevButtons ∷ Boolean → HTML
 prevButtons enabled =


### PR DESCRIPTION
Fixes #1744 

The `JSemantic` stuff has been removed from JTable, so it now makes no assumptions about your data, and just prints it as is.