### PR TITLE
Adds an error type for Search card errors

### DIFF
--- a/src/SlamData/Workspace/Card/Error/Component.purs
+++ b/src/SlamData/Workspace/Card/Error/Component.purs
@@ -36,10 +36,11 @@ import SlamData.Wiring as Wiring
 import SlamData.Workspace.AccessType (AccessType(..))
 import SlamData.Workspace.Card.CardType (CardType(..), AceMode(..), cardName)
 import SlamData.Workspace.Card.CardType.FormInputType as FIT
-import SlamData.Workspace.Card.Error as CE
 import SlamData.Workspace.Card.Error (CardError(..), cardToGlobalError)
+import SlamData.Workspace.Card.Error as CE
 import SlamData.Workspace.Card.Error.Component.Query (Query(..))
 import SlamData.Workspace.Card.Error.Component.State (State, initialState)
+import Text.Parsing.Parser (parseErrorMessage)
 import Utils (prettyJson)
 
 type DSL = H.ComponentDSL State Query Void Slam
@@ -115,6 +116,7 @@ prettyPrintCardError state ce = case cardToGlobalError ce of
     TableCardError tce → tableErrorMessage state tce
     FormInputStaticCardError fise → formInputStaticErrorMessage state fise
     FormInputLabeledCardError file → formInputLabeledErrorMessage state file
+    SearchCardError sce → searchErrorMessage state sce
 
 collapsible ∷ String → HTML → Boolean → HTML
 collapsible title content expanded =
@@ -490,4 +492,36 @@ formInputLabeledErrorMessage { accessType, expanded } err =
           , pure $ HH.p_
               [ HH.text "Labels must be unique. Please, use other axis." ]
           , guard (accessType == Editable) $> HH.p_ [ HH.text "Go back to the previous card and select an axis to fix this error." ]
+          ]
+
+searchErrorMessage ∷ State → CE.SearchError → HTML
+searchErrorMessage { accessType, expanded } err =
+  case accessType of
+    Editable → renderDetails err
+    ReadOnly →
+      HH.div_
+        [ HH.p_ [ HH.text $ "A problem occurred in the " <> cardName Search <> " card, please notify the author of this workspace." ]
+        , collapsible "Error details" (renderDetails err) expanded
+        ]
+  where
+  renderDetails = case _ of
+    CE.SearchQueryParseError { query, error } →
+      HH.div_
+        $ join
+          [ pure $ errorTitle [ HH.text $ "Failed to parse the query when setting up the " <> cardName Search <> " card." ]
+          , pure $ HH.p_
+              [ HH.text "Failed with the following parse error: "
+              , HH.code_ [HH.text (parseErrorMessage error)]
+              ]
+          , guard (accessType == Editable) $> HH.p_ [ HH.text "Go back to the previous card and correct your query to fix this error." ]
+          ]
+    CE.SearchQueryCompilationError error →
+      HH.div_
+        $ join
+          [ pure $ errorTitle [ HH.text $ "Failed to compile the query when setting up the " <> cardName Search <> " card." ]
+          , pure $ HH.p_
+              [ HH.text "Failed with the following compilation error: "
+              , printQErrorWithDetails error
+              ]
+          , guard (accessType == Editable) $> HH.p_ [ HH.text "Go back to the previous card and correct your query to fix this error." ]
           ]

--- a/src/SlamData/Workspace/Card/Search/Error.purs
+++ b/src/SlamData/Workspace/Card/Search/Error.purs
@@ -1,0 +1,40 @@
+{-
+Copyright 2017 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
+module SlamData.Workspace.Card.Search.Error where
+
+import SlamData.Prelude
+
+import Quasar.Advanced.QuasarAF (QError)
+import SlamData.GlobalError as GE
+import Text.Parsing.Parser (ParseError)
+import Utils (hush)
+
+data SearchError
+  = SearchQueryParseError { query ∷ String, error ∷ ParseError }
+  | SearchQueryCompilationError QError
+
+instance showSearchError ∷ Show SearchError where
+  show = case _ of
+    SearchQueryParseError { query, error } →
+      "(SearchQueryParseError { query: " <> show query <> ", error: " <> show error <> " })"
+    SearchQueryCompilationError error →
+      "(SearchQueryCompilationError " <> show error <> ")"
+
+searchToGlobalError ∷ SearchError → Maybe GE.GlobalError
+searchToGlobalError = case _ of
+  SearchQueryCompilationError error → hush (GE.fromQError error)
+  _ → Nothing


### PR DESCRIPTION
Some noise in this PR, because I sorted the declarations in `SlamData.Workspace.Card.Error`. I can totally move that out into its own PR if that's preferred.