### PR TITLE
1760 reset deck changes

### DIFF
--- a/src/SlamData/Wiring.purs
+++ b/src/SlamData/Wiring.purs
@@ -131,6 +131,7 @@ type CacheWiring =
 
 type BusWiring =
   { decks ∷ Bus.BusRW DeckMessage
+  , consumerChanges :: Bus.BusRW Unit
   , workspace ∷ Bus.BusRW WorkspaceMessage
   , notify ∷ Bus.BusRW N.NotificationOptions
   , globalError ∷ Bus.BusRW GE.GlobalError
@@ -227,7 +228,8 @@ make path accessType vm permissionTokenHashes = liftAff do
     globalError ← Bus.make
     stepByStep ← Bus.make
     hintDismissals ← Bus.make
-    pure { decks, workspace, notify, globalError, stepByStep, hintDismissals }
+    consumerChanges <- Bus.make
+    pure { decks, workspace, notify, globalError, stepByStep, hintDismissals, consumerChanges }
 
 focusDeck
   ∷ ∀ m

--- a/src/SlamData/Workspace/Component/Query.purs
+++ b/src/SlamData/Workspace/Component/Query.purs
@@ -36,6 +36,7 @@ data Query a
   | Load (List DeckId) a
   | ExploreFile UP.FilePath a
   | PresentStepByStepGuide GuideType (H.SubscribeStatus → a)
+  | ResetToOriginal a
   | Resize (H.SubscribeStatus → a)
   | SignIn ProviderR a
   | HandleGuideMessage GuideType Guide.Message a

--- a/src/SlamData/Workspace/Component/Query.purs
+++ b/src/SlamData/Workspace/Component/Query.purs
@@ -44,3 +44,4 @@ data Query a
   | HandleSignInMessage SignInMessage a
   | HandleWorkspace Wiring.WorkspaceMessage a
   | HandleDialog Dialog.Message a
+  | HandleConsumerChange a

--- a/src/SlamData/Workspace/Component/State.purs
+++ b/src/SlamData/Workspace/Component/State.purs
@@ -31,6 +31,7 @@ type State =
   , stateMode ∷ StateMode
   , providers ∷ Array ProviderR
   , guide ∷ Maybe GuideType
+  , isModified ∷ Boolean
   }
 
 initialState ∷ State
@@ -39,4 +40,5 @@ initialState =
   , stateMode: Loading
   , providers: mempty
   , guide: Nothing
+  , isModified: false
   }


### PR DESCRIPTION
* Adds a "reset to original" button which appears in readOnly mode after a consumer has made changes. On clicking, it reverts back to the original values
* TODO styling of the button
* fixes #1760 