### PR TITLE
Fix parse format for DateTime coming from HTML inputs

### DIFF
--- a/src/SlamData/Workspace/FormBuilder/Item/FieldType.purs
+++ b/src/SlamData/Workspace/FormBuilder/Item/FieldType.purs
@@ -79,7 +79,7 @@ _FieldTypeDisplayName ∷ Lens.Prism' String FieldType
 _FieldTypeDisplayName = Lens.prism inj proj
   where
     inj StringFieldType = "Text"
-    inj DateTimeFieldType = "DateTime"
+    inj DateTimeFieldType = "Timestamp"
     inj DateFieldType = "Date"
     inj TimeFieldType = "Time"
     inj IntervalFieldType = "Interval"
@@ -92,7 +92,7 @@ _FieldTypeDisplayName = Lens.prism inj proj
     inj SqlIdentifierFieldType = "SQL² Identifier"
 
     proj "Text" = Right StringFieldType
-    proj "DateTime" = Right DateTimeFieldType
+    proj "Timestamp" = Right DateTimeFieldType
     proj "Date" = Right DateFieldType
     proj "Time" = Right TimeFieldType
     proj "Interval" = Right IntervalFieldType


### PR DESCRIPTION
Also use "Timestamp" rather than "DateTime" in the front-end, since that's the SQL^2 term for it.

Resolves #1785, resolves #1786.

@cryogenian please review :)