### PR TITLE
Update formatting/parsing of date/time variable values

### DIFF
--- a/src/SlamData/Workspace/FormBuilder/Item/Component.purs
+++ b/src/SlamData/Workspace/FormBuilder/Item/Component.purs
@@ -126,8 +126,8 @@ render model =
       _ →
           HH.input
             $ fieldType
-            <> [ HP.value (fromMaybe "" model.defaultValue)
-               , HE.onValueInput (HE.input UpdateDefaultValue)
+            <> [ HP.value (maybe "" (State.sanitiseValueForForm model.fieldType) model.defaultValue)
+               , HE.onValueInput (HE.input UpdateDefaultValue ∘ State.sanitiseValueFromForm model.fieldType)
                , ARIA.label lbl
                , HP.placeholder lbl
                ]


### PR DESCRIPTION
Instead of doing stuff during eval, this moves all the string munging formatting/unformatting into the component instead, to keep the weirdness local to one place.

Currently needs a case in `Eval` so that existing workspaces behave nicely, since they'll have the "invalid" format values stored in their model still.