### PR TITLE
fixed mount form action

### DIFF
--- a/src/SlamData/FileSystem/Dialog/Mount/Component.purs
+++ b/src/SlamData/FileSystem/Dialog/Mount/Component.purs
@@ -142,6 +142,7 @@ btnCancel state@{ unMounting, saving } =
   HH.button
     [ HP.classes [CN.btn]
     , HP.enabled $ not saving && not unMounting
+    , HP.type_ HP.ButtonButton
     , HE.onClick (HE.input_ RaiseDismiss)
     ]
     [ HH.text "Cancel" ]


### PR DESCRIPTION
Was causing the form to be dismissed when form submitted (e.g. by pressing the enter key) whilst invalid.