### PR TITLE
Update mount code for changes in purescript-quasar

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -53,7 +53,7 @@
     "purescript-parallel": "^3.0.0",
     "purescript-pathy": "^4.0.0",
     "purescript-profunctor-lenses": "^3.2.0",
-    "purescript-quasar": "^27.0.0",
+    "purescript-quasar": "6c5c623aa8c8a570b9d1cd9d7708da8efe0b43fb",
     "purescript-rationals": "^3.1.1",
     "purescript-routing": "^5.1.0",
     "purescript-search": "^3.0.0",

--- a/src/SlamData/FileSystem/Dialog/Mount/MarkLogic/Component.purs
+++ b/src/SlamData/FileSystem/Dialog/Mount/MarkLogic/Component.purs
@@ -18,35 +18,33 @@ module SlamData.FileSystem.Dialog.Mount.MarkLogic.Component
   ( comp
   , Query
   , module SlamData.FileSystem.Dialog.Mount.Common.SettingsQuery
-  , module MCS
+  , module S
   ) where
 
 import SlamData.Prelude
 
 import Data.Path.Pathy (dir, (</>))
-
 import Halogen as H
 import Halogen.HTML as HH
 import Halogen.HTML.Events as HE
 import Halogen.HTML.Properties as HP
-
 import Quasar.Mount as QM
 import Quasar.Mount.MarkLogic (Format(..))
-
 import SlamData.FileSystem.Dialog.Mount.Common.Render as MCR
 import SlamData.FileSystem.Dialog.Mount.Common.SettingsQuery (SettingsQuery(..), SettingsMessage(..))
-import SlamData.FileSystem.Dialog.Mount.MarkLogic.Component.State as MCS
+import SlamData.FileSystem.Dialog.Mount.Common.State as MCS
+import SlamData.FileSystem.Dialog.Mount.MarkLogic.Component.State as S
 import SlamData.FileSystem.Resource (Mount(..))
 import SlamData.Monad (Slam)
 import SlamData.Quasar.Error as QE
 import SlamData.Quasar.Mount as API
 import SlamData.Render.ClassName as CN
 
-type Query = SettingsQuery MCS.State
+type Query = SettingsQuery S.State
 
 type HTML = H.ComponentHTML Query
 
-comp ∷ MCS.State → H.Component HH.HTML Query Unit SettingsMessage Slam
+comp ∷ S.State → H.Component HH.HTML Query Unit SettingsMessage Slam
 comp initialState =
   H.component
     { initialState: const initialState
@@ -55,22 +53,22 @@ comp initialState =
     , receiver: const Nothing
     }
 
-render ∷ MCS.State → HTML
+render ∷ S.State → HTML
 render state =
   HH.div
     [ HP.class_ CN.mountMarkLogic ]
-    [ MCR.section "Server" [ MCR.host state MCS._host' ]
+    [ MCR.section "Server" [ MCR.host state S._host' ]
     , MCR.section "Authentication"
         [ HH.div
             [ HP.class_ CN.mountUserInfo ]
-            [ MCR.label "Username" [ MCR.input state MCS._user [] ]
-            , MCR.label "Password" [ MCR.input state MCS._password [ HP.type_ HP.InputPassword ] ]
+            [ MCR.label "Username" [ MCR.input state S._user [] ]
+            , MCR.label "Password" [ MCR.input state S._password [ HP.type_ HP.InputPassword ] ]
             ]
         ]
     , MCR.section "Root"
         [ HH.div
             [ HP.classes [CN.formGroup, CN.mountPath] ]
-            [ MCR.label "Database" [ MCR.input state MCS._path [] ] ]
+            [ MCR.label "Database" [ MCR.input state S._path [] ] ]
         , HH.div
             [ HP.class_ CN.mountFormat ]
             [ HH.label_ [ HH.span_ [ HH.text "Format" ] ]
@@ -93,18 +91,18 @@ render state =
       ]
 
 
-eval ∷ Query ~> H.ComponentDSL MCS.State Query SettingsMessage Slam
+eval ∷ Query ~> H.ComponentDSL S.State Query SettingsMessage Slam
 eval = case _ of
   ModifyState f next → do
     H.modify f
     H.raise Modified
     pure next
   Validate k →
-    k <<< either Just (const Nothing) <<< MCS.toConfig <$> H.get
+    k <<< either Just (const Nothing) <<< MCS.vToE <<< S.toConfig <$> H.get
   Submit parent name k →
     k <$> runExceptT do
       st ← lift H.get
-      config ← except $ lmap QE.msgToQError $ MCS.toConfig st
+      config ← except $ lmap QE.msgToQError $ MCS.vToE $ S.toConfig st
       let path = parent </> dir name
       ExceptT $ API.saveMount (Left path) (QM.MarkLogicConfig config)
       pure $ Database path

--- a/src/SlamData/FileSystem/Dialog/Mount/MarkLogic/Component/State.purs
+++ b/src/SlamData/FileSystem/Dialog/Mount/MarkLogic/Component/State.purs
@@ -16,6 +16,7 @@ limitations under the License.
 
 module SlamData.FileSystem.Dialog.Mount.MarkLogic.Component.State
   ( State
+  , Field(..)
   , initialState
   , fromConfig
   , toConfig
@@ -24,13 +25,11 @@ module SlamData.FileSystem.Dialog.Mount.MarkLogic.Component.State
 
 import SlamData.Prelude
 
-import Data.URI.Path (printPath) as URI
 import Data.URI.Host (printHost) as URI
-
+import Data.URI.Path (printPath) as URI
+import Data.Validation.Semigroup as V
 import Global as Global
-
 import Quasar.Mount.MarkLogic (Config, Format(..))
-
 import SlamData.FileSystem.Dialog.Mount.Common.State as MCS
 
 type State =
@@ -40,6 +39,8 @@ type State =
   , path ∷ String
   , format ∷ Format
   }
+
+data Field = Host | Auth | Path
 
 initialState ∷ State
 initialState =
@@ -51,26 +52,30 @@ initialState =
   }
 
 fromConfig ∷ Config → State
-fromConfig { host, user, password, path, format } =
+fromConfig { host, credentials, path, format } =
   { host: bimap URI.printHost (maybe "" show) host
-  , user: maybe "" Global.decodeURIComponent user
-  , password: maybe "" Global.decodeURIComponent password
+  , user: maybe "" (Global.decodeURIComponent <<< _.user <<< unwrap) credentials
+  , password: maybe "" (Global.decodeURIComponent <<< _.password <<< unwrap) credentials
   , path: maybe "" URI.printPath path
   , format
   }
 
-toConfig ∷ State → Either String Config
-toConfig { host, user, password, path, format } = do
-  when (MCS.isEmpty (fst host)) $ Left "Please enter host"
-  host' ← lmap ("Host: " <> _) $ MCS.parseHost host
-  when (isNothing (snd host')) $ Left "Please enter port"
-  when (not MCS.isEmpty user || not MCS.isEmpty password) do
-    when (MCS.isEmpty user) $ Left "Please enter user name"
-    when (MCS.isEmpty password) $ Left "Please enter password"
-  pure
-    { host: host'
-    , user: Global.encodeURIComponent <$> MCS.nonEmptyString user
-    , password: Global.encodeURIComponent <$> MCS.nonEmptyString password
-    , path: MCS.parsePath' =<< MCS.nonEmptyString path
-    , format
-    }
+toConfig ∷ State → V.V (MCS.ValidationError Field) Config
+toConfig { host, user, password, path, format } =
+  { host: _
+  , credentials: _
+  , path: _
+  , format
+  } <$> host' <*> credentials <*> path'
+  where
+    host' = either (MCS.invalid Host) pure do
+      when (MCS.isEmpty (fst host)) $ Left "Please enter host"
+      h ← lmap ("Host: " <> _) $ MCS.parseHost host
+      when (isNothing (snd h)) $ Left "Please enter port"
+      pure h
+    credentials = either (MCS.invalid Auth) pure do
+      when (not MCS.isEmpty user || not MCS.isEmpty password) do
+        when (MCS.isEmpty user) $ Left "Please enter user name"
+        when (MCS.isEmpty password) $ Left "Please enter password"
+      pure $ MCS.parseCredentials { user, password }
+    path' = pure $ MCS.parsePath' =<< MCS.nonEmptyString path

--- a/src/SlamData/FileSystem/Dialog/Mount/MongoDB/Component.purs
+++ b/src/SlamData/FileSystem/Dialog/Mount/MongoDB/Component.purs
@@ -18,31 +18,29 @@ module SlamData.FileSystem.Dialog.Mount.MongoDB.Component
   ( comp
   , Query
   , module SlamData.FileSystem.Dialog.Mount.Common.SettingsQuery
-  , module MCS
+  , module S
   ) where
 
 import SlamData.Prelude
 
 import Data.Path.Pathy (dir, (</>))
-
 import Halogen as H
 import Halogen.HTML as HH
 import Halogen.HTML.Properties as HP
-
 import Quasar.Mount as QM
-
 import SlamData.FileSystem.Dialog.Mount.Common.Render as MCR
 import SlamData.FileSystem.Dialog.Mount.Common.SettingsQuery (SettingsQuery(..), SettingsMessage(..))
-import SlamData.FileSystem.Dialog.Mount.MongoDB.Component.State as MCS
+import SlamData.FileSystem.Dialog.Mount.Common.State as MCS
+import SlamData.FileSystem.Dialog.Mount.MongoDB.Component.State as S
 import SlamData.FileSystem.Resource (Mount(..))
 import SlamData.Monad (Slam)
 import SlamData.Quasar.Error as QE
 import SlamData.Quasar.Mount as API
 import SlamData.Render.ClassName as CN
 
-type Query = SettingsQuery MCS.State
+type Query = SettingsQuery S.State
 
-comp ∷ MCS.State → H.Component HH.HTML Query Unit SettingsMessage Slam
+comp ∷ S.State → H.Component HH.HTML Query Unit SettingsMessage Slam
 comp initialState =
   H.component
     { initialState: const initialState
@@ -51,37 +49,37 @@ comp initialState =
     , receiver: const Nothing
     }
 
-render ∷ MCS.State → H.ComponentHTML Query
+render ∷ S.State → H.ComponentHTML Query
 render state =
   HH.div
     [ HP.class_ CN.mountMongoDB ]
-    [ MCR.section "Server(s)" [ MCR.hosts state MCS._hosts ]
+    [ MCR.section "Server(s)" [ MCR.hosts state S._hosts ]
     , MCR.section "Authentication"
         [ HH.div
             [ HP.classes [CN.formGroup, CN.mountUserInfo] ]
-            [ MCR.label "Username" [ MCR.input state MCS._user [] ]
-            , MCR.label "Password" [ MCR.input state MCS._password [ HP.type_ HP.InputPassword ] ]
+            [ MCR.label "Username" [ MCR.input state S._user [] ]
+            , MCR.label "Password" [ MCR.input state S._password [ HP.type_ HP.InputPassword ] ]
             ]
         , HH.div
             [ HP.class_ CN.mountPath ]
-            [ MCR.label "Database" [ MCR.input state MCS._path [] ] ]
+            [ MCR.label "Database" [ MCR.input state S._path [] ] ]
         ]
-    , MCR.section "Settings" [ MCR.propList MCS._props state ]
+    , MCR.section "Settings" [ MCR.propList S._props state ]
     ]
 
-eval ∷ Query ~> H.ComponentDSL MCS.State Query SettingsMessage Slam
+eval ∷ Query ~> H.ComponentDSL S.State Query SettingsMessage Slam
 eval = case _ of
   ModifyState f next → do
-    H.modify (MCS.processState <<< f)
+    H.modify (S.processState <<< f)
     H.raise Modified
     pure next
   Validate k →
-    k ∘ either Just (const Nothing) ∘ MCS.toConfig <$> H.get
+    k ∘ either Just (const Nothing) ∘ MCS.vToE ∘ S.toConfig <$> H.get
   Submit parent name k →
     k <$> runExceptT do
       let
         path = parent </> dir name
       st ← lift H.get
-      config ← except $ lmap QE.msgToQError $ MCS.toConfig st
+      config ← except $ lmap QE.msgToQError $ MCS.vToE $ S.toConfig st
       ExceptT $ API.saveMount (Left path) (QM.MongoDBConfig config)
       pure $ Database path

--- a/src/SlamData/FileSystem/Dialog/Mount/SparkHDFS/Component.purs
+++ b/src/SlamData/FileSystem/Dialog/Mount/SparkHDFS/Component.purs
@@ -18,33 +18,31 @@ module SlamData.FileSystem.Dialog.Mount.SparkHDFS.Component
   ( comp
   , Query
   , module SlamData.FileSystem.Dialog.Mount.Common.SettingsQuery
-  , module MCS
+  , module S
   ) where
 
 import SlamData.Prelude
 
 import Data.Array as Array
 import Data.Path.Pathy (dir, (</>))
-
 import Halogen as H
 import Halogen.HTML as HH
 import Halogen.HTML.Events as HE
 import Halogen.HTML.Properties as HP
-
 import Quasar.Mount as QM
-
-import SlamData.Monad (Slam)
 import SlamData.FileSystem.Dialog.Mount.Common.Render as MCR
 import SlamData.FileSystem.Dialog.Mount.Common.SettingsQuery (SettingsQuery(..), SettingsMessage(..))
-import SlamData.FileSystem.Dialog.Mount.SparkHDFS.Component.State as MCS
+import SlamData.FileSystem.Dialog.Mount.Common.State as MCS
+import SlamData.FileSystem.Dialog.Mount.SparkHDFS.Component.State as S
 import SlamData.FileSystem.Resource (Mount(..))
-import SlamData.Quasar.Mount as API
+import SlamData.Monad (Slam)
 import SlamData.Quasar.Error as QE
+import SlamData.Quasar.Mount as API
 import SlamData.Render.ClassName as CN
 
-type Query = SettingsQuery MCS.State
+type Query = SettingsQuery S.State
 
-comp ∷ MCS.State → H.Component HH.HTML Query Unit SettingsMessage Slam
+comp ∷ S.State → H.Component HH.HTML Query Unit SettingsMessage Slam
 comp initialState =
   H.component
     { initialState: const initialState
@@ -53,16 +51,16 @@ comp initialState =
     , receiver: const Nothing
     }
 
-render ∷ MCS.State → H.ComponentHTML Query
+render ∷ S.State → H.ComponentHTML Query
 render state =
   HH.div
     [ HP.class_ CN.mountSpark ]
-    [ MCR.section "Spark Server" [ MCR.host state MCS._sparkHost ]
-    , MCR.section "HDFS Server" [ MCR.host state MCS._hdfsHost ]
+    [ MCR.section "Spark Server" [ MCR.host state S._sparkHost ]
+    , MCR.section "HDFS Server" [ MCR.host state S._hdfsHost ]
     , MCR.section "Root"
         [ HH.div
             [ HP.class_ CN.mountPath ]
-            [ MCR.label "Path" [ MCR.input state MCS._path [] ] ]
+            [ MCR.label "Path" [ MCR.input state S._path [] ] ]
         ]
     , MCR.section "Advanced Settings"
         [ MCR.propListTable (Array.mapWithIndex renderPropRow (state.props <> [ "" × "" ])) ]
@@ -75,8 +73,8 @@ render state =
         (guard (key ≠ "") $> "")
           <> [ key ]
           <> state.availableProps
-      updateFnKey = MCS.updatePropAt ix ∘ flip Tuple value
-      updateFnVal = MCS.updatePropAt ix ∘ Tuple key
+      updateFnKey = S.updatePropAt ix ∘ flip Tuple value
+      updateFnVal = S.updatePropAt ix ∘ Tuple key
       classes = [ CN.formControl ]
     in
     HH.tr_
@@ -98,18 +96,18 @@ render state =
           ]
       ]
 
-eval ∷ Query ~> H.ComponentDSL MCS.State Query SettingsMessage Slam
+eval ∷ Query ~> H.ComponentDSL S.State Query SettingsMessage Slam
 eval = case _ of
   ModifyState f next → do
     H.modify f
     H.raise Modified
     pure next
   Validate k →
-    k <<< either Just (const Nothing) <<< MCS.toConfig <$> H.get
+    k <<< either Just (const Nothing) <<< MCS.vToE <<< S.toConfig <$> H.get
   Submit parent name k →
     k <$> runExceptT do
       st ← lift H.get
-      config ← except $ lmap QE.msgToQError $ MCS.toConfig st
+      config ← except $ lmap QE.msgToQError $ MCS.vToE $ S.toConfig st
       let path = parent </> dir name
       ExceptT $ API.saveMount (Left path) (QM.SparkHDFSConfig config)
       pure $ Database path


### PR DESCRIPTION
Also start introducing `V` error handling so we can annotate specific fields in the future. At the moment it mashes back down into a `Either String` to preserve the old behaviour.