### PR TITLE
Update Couchbase mount dialog for new format

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -53,7 +53,7 @@
     "purescript-parallel": "^3.0.0",
     "purescript-pathy": "^4.0.0",
     "purescript-profunctor-lenses": "^3.2.0",
-    "purescript-quasar": "^29.0.0",
+    "purescript-quasar": "garyb/purescript-quasar#couchbase-connection-format",
     "purescript-rationals": "^3.1.1",
     "purescript-routing": "^5.1.0",
     "purescript-search": "^3.0.0",

--- a/bower.json
+++ b/bower.json
@@ -53,7 +53,7 @@
     "purescript-parallel": "^3.0.0",
     "purescript-pathy": "^4.0.0",
     "purescript-profunctor-lenses": "^3.2.0",
-    "purescript-quasar": "6c5c623aa8c8a570b9d1cd9d7708da8efe0b43fb",
+    "purescript-quasar": "^29.0.0",
     "purescript-rationals": "^3.1.1",
     "purescript-routing": "^5.1.0",
     "purescript-search": "^3.0.0",

--- a/less/dialog/mount.less
+++ b/less/dialog/mount.less
@@ -143,7 +143,46 @@
     }
   }
 
+  .mount-couchbase {
+    .sd-cb-options {
+      label {
+        width: auto;
+        span:nth-child(3) {
+          display: inline-block;
+          float: none;
+          font-weight: normal;
+        }
+      }
+      label:nth-child(2) {
+        display:block;
+        margin-left: 12rem;
+        font-weight: normal;
+        span {
+          display: inline-block;
+          float: none;
+        }
+      }
+    }
+    label {
+      span {
+        width: 12rem;
+      }
+      input.form-control {
+        width: ~"calc(100% - 12rem)";
+      }
+      input[type=number] {
+        width: 8rem;
+        display: inline-block;
+        margin-right: 0.5rem;
+      }
+      input[type=checkbox] {
+        margin-right: 0.5rem;
+      }
+    }
+  }
+
   .alert {
     min-height: 4.2rem;
+    margin-top: 1rem;
   }
 }

--- a/src/SlamData/FileSystem/Dialog/Mount/Couchbase/Component.purs
+++ b/src/SlamData/FileSystem/Dialog/Mount/Couchbase/Component.purs
@@ -18,33 +18,32 @@ module SlamData.FileSystem.Dialog.Mount.Couchbase.Component
   ( comp
   , Query
   , module SlamData.FileSystem.Dialog.Mount.Common.SettingsQuery
-  , module MCS
+  , module S
   ) where
 
 import SlamData.Prelude
 
 import Data.Path.Pathy (dir, (</>))
-
 import Halogen as H
 import Halogen.HTML as HH
+import Halogen.HTML.Events as HE
 import Halogen.HTML.Properties as HP
-
 import Quasar.Mount as QM
-
 import SlamData.FileSystem.Dialog.Mount.Common.Render as MCR
 import SlamData.FileSystem.Dialog.Mount.Common.SettingsQuery (SettingsQuery(..), SettingsMessage(..))
-import SlamData.FileSystem.Dialog.Mount.Couchbase.Component.State as MCS
+import SlamData.FileSystem.Dialog.Mount.Common.State as MCS
+import SlamData.FileSystem.Dialog.Mount.Couchbase.Component.State as S
 import SlamData.FileSystem.Resource (Mount(..))
 import SlamData.Monad (Slam)
 import SlamData.Quasar.Error as QE
 import SlamData.Quasar.Mount as API
 import SlamData.Render.ClassName as CN
 
-type Query = SettingsQuery MCS.State
+type Query = SettingsQuery S.State
 
 type HTML = H.ComponentHTML Query
 
-comp ∷ MCS.State → H.Component HH.HTML Query Unit SettingsMessage Slam
+comp ∷ S.State → H.Component HH.HTML Query Unit SettingsMessage Slam
 comp initialState =
   H.component
     { initialState: const initialState
@@ -53,32 +52,60 @@ comp initialState =
     , receiver: const Nothing
     }
 
-render ∷ MCS.State → HTML
+render ∷ S.State → HTML
 render state =
   HH.div
     [ HP.class_ CN.mountCouchbase ]
-    [ MCR.section "Server" [ MCR.host state MCS._host' ]
-    , MCR.section "Authentication"
+    [ MCR.section "Server" [ MCR.host state S._host' ]
+    , MCR.section "Bucket"
         [ HH.div
             [ HP.classes [CN.formGroup, CN.mountUserInfo] ]
-            [ MCR.label "Username" [ MCR.input state MCS._user [] ]
-            , MCR.label "Password" [ MCR.input state MCS._password [ HP.type_ HP.InputPassword ] ]
+            [ MCR.label "Bucket name" [ MCR.input state S._bucketName [] ]
+            , MCR.label "Password" [ MCR.input state S._password [ HP.type_ HP.InputPassword ] ]
+            , MCR.label "Document type" [ MCR.input state S._docTypeKey [] ]
+            ]
+        ]
+    , MCR.section "Options"
+        [ HH.div
+            [ HP.class_ (HH.ClassName "sd-cb-options") ]
+            [ HH.label_
+                [ HH.span_ [ HH.text "Query timeout" ]
+                , HH.input
+                    [ HP.class_ CN.formControl
+                    , HP.type_ HP.InputNumber
+                    , HP.enabled (isJust state.queryTimeout)
+                    , HP.value (fromMaybe "" state.queryTimeout)
+                    , HP.min 1.0
+                    ]
+                , HH.span_ [ HH.text "(seconds)" ]
+                ]
+            , HH.label_
+                [ HH.input
+                    [ HP.type_ HP.InputCheckbox
+                    , HP.checked (isJust state.queryTimeout)
+                    , HE.onChecked $ HE.input_ $ ModifyState \st →
+                        st { queryTimeout = toggleTimeout st.queryTimeout }
+                    ]
+                , HH.span_ [ HH.text "Override default" ]
+                ]
             ]
         ]
     ]
+  where
+    toggleTimeout = maybe (Just "30") (const Nothing)
 
-eval ∷ Query ~> H.ComponentDSL MCS.State Query SettingsMessage Slam
+eval ∷ Query ~> H.ComponentDSL S.State Query SettingsMessage Slam
 eval = case _ of
   ModifyState f next → do
     H.modify f
     H.raise Modified
     pure next
   Validate k →
-    k <<< either Just (const Nothing) <<< MCS.toConfig <$> H.get
+    k ∘ either Just (const Nothing) ∘ MCS.vToE ∘ S.toConfig <$> H.get
   Submit parent name k →
     k <$> runExceptT do
       st ← lift H.get
-      config ← except $ lmap QE.msgToQError $ MCS.toConfig st
+      config ← except $ lmap QE.msgToQError $ MCS.vToE $ S.toConfig st
       let path = parent </> dir name
       ExceptT $ API.saveMount (Left path) (QM.CouchbaseConfig config)
       pure $ Database path

--- a/src/SlamData/FileSystem/Dialog/Mount/Couchbase/Component/State.purs
+++ b/src/SlamData/FileSystem/Dialog/Mount/Couchbase/Component/State.purs
@@ -16,7 +16,10 @@ limitations under the License.
 
 module SlamData.FileSystem.Dialog.Mount.Couchbase.Component.State
   ( State
+  , Field(..)
   , initialState
+  , _bucketName
+  , _docTypeKey
   , fromConfig
   , toConfig
   , module MCS
@@ -24,43 +27,80 @@ module SlamData.FileSystem.Dialog.Mount.Couchbase.Component.State
 
 import SlamData.Prelude
 
+import Data.Number as Num
+import Data.String as Str
+import Data.Lens (Lens', lens)
+import Data.Time.Duration (Seconds(..))
 import Data.URI.Host as URI
-
+import Data.Validation.Semigroup as V
 import Global as Global
-
 import Quasar.Mount.Couchbase (Config)
-
 import SlamData.FileSystem.Dialog.Mount.Common.State as MCS
+
+data Field = Host | BucketName | Password | DocType | QueryTimeout
 
 type State =
   { host ∷ MCS.MountHost
-  , user ∷ String
+  , bucketName ∷ String
   , password ∷ String
+  , docTypeKey ∷ String
+  , queryTimeout ∷ Maybe String
   }
 
 initialState ∷ State
 initialState =
   { host: MCS.initialTuple
-  , user: ""
+  , bucketName: ""
   , password: ""
+  , docTypeKey: "type"
+  , queryTimeout: Nothing
   }
+
+_bucketName ∷ Lens' State String
+_bucketName = lens _.bucketName (_{bucketName = _})
+
+_docTypeKey ∷ Lens' State String
+_docTypeKey = lens _.docTypeKey (_{docTypeKey = _})
 
 fromConfig ∷ Config → State
-fromConfig { host, user, password } =
+fromConfig { host, bucketName, password, docTypeKey, queryTimeout } =
   { host: bimap URI.printHost (maybe "" show) host
-  , user: maybe "" Global.decodeURIComponent user
-  , password: maybe "" Global.decodeURIComponent password
+  , bucketName
+  , password
+  , docTypeKey
+  , queryTimeout: dropTrailingZero <<< show <<< unwrap <$> queryTimeout
   }
+  where
+    dropTrailingZero ∷ String → String
+    dropTrailingZero n = fromMaybe n $ Str.stripSuffix (Str.Pattern ".0") n
 
-toConfig ∷ State → Either String Config
-toConfig { host, user, password } = do
-  when (MCS.isEmpty (fst host)) $ Left "Please enter host"
-  host' ← lmap ("Host: " <> _) $ MCS.parseHost host
-  when (not MCS.isEmpty user || not MCS.isEmpty password) do
-    when (MCS.isEmpty user) $ Left "Please enter user name"
-    when (MCS.isEmpty password) $ Left "Please enter password"
-  pure
-    { host: host'
-    , user: Global.encodeURIComponent <$> MCS.nonEmptyString user
-    , password: Global.encodeURIComponent <$> MCS.nonEmptyString password
-    }
+toConfig ∷ State → V.V (MCS.ValidationError Field) Config
+toConfig st = do
+  { host: _, bucketName: _, password: _, docTypeKey: _, queryTimeout: _ }
+    <$> host
+    <*> bucketName
+    <*> password
+    <*> docTypeKey
+    <*> queryTimeout
+  where
+
+    host = either (MCS.invalid Host) pure do
+      when (MCS.isEmpty (fst st.host)) $ Left "Please enter a host"
+      lmap ("Host: " <> _) $ MCS.parseHost st.host
+
+    bucketName =
+      maybe (MCS.invalid BucketName "Please enter a bucket name") pure $
+        MCS.nonEmptyString st.bucketName
+
+    docTypeKey =
+      maybe (MCS.invalid DocType "Please enter a document type") pure $
+        MCS.nonEmptyString st.docTypeKey
+
+    password = pure (Global.encodeURIComponent st.password)
+
+    queryTimeout =
+      either (MCS.invalid QueryTimeout) pure $
+        for st.queryTimeout \s → do
+          n ← maybe (Left "Please enter a valid timeout in seconds") Right $ Num.fromString s
+          when (n < 0.0) $ Left "Please enter a timeout value greater than 0 seconds"
+          pure $ Seconds n

--- a/src/SlamData/FileSystem/Dialog/Mount/Couchbase/Component/State.purs
+++ b/src/SlamData/FileSystem/Dialog/Mount/Couchbase/Component/State.purs
@@ -27,15 +27,15 @@ module SlamData.FileSystem.Dialog.Mount.Couchbase.Component.State
 
 import SlamData.Prelude
 
-import Data.Number as Num
-import Data.String as Str
 import Data.Lens (Lens', lens)
+import Data.Number as Num
 import Data.Time.Duration (Seconds(..))
 import Data.URI.Host as URI
 import Data.Validation.Semigroup as V
 import Global as Global
 import Quasar.Mount.Couchbase (Config)
 import SlamData.FileSystem.Dialog.Mount.Common.State as MCS
+import Utils (showPrettyNumber)
 
 data Field = Host | BucketName | Password | DocType | QueryTimeout
 
@@ -68,11 +68,8 @@ fromConfig { host, bucketName, password, docTypeKey, queryTimeout } =
   , bucketName
   , password
   , docTypeKey
-  , queryTimeout: dropTrailingZero <<< show <<< unwrap <$> queryTimeout
+  , queryTimeout: showPrettyNumber <<< unwrap <$> queryTimeout
   }
-  where
-    dropTrailingZero ∷ String → String
-    dropTrailingZero n = fromMaybe n $ Str.stripSuffix (Str.Pattern ".0") n
 
 toConfig ∷ State → V.V (MCS.ValidationError Field) Config
 toConfig st = do

--- a/src/SlamData/Monad/Auth.purs
+++ b/src/SlamData/Monad/Auth.purs
@@ -57,7 +57,7 @@ getIdTokenSilently interactionlessSignIn idTokenRequestBus =
   signedOutBefore ∷ Aff SlamDataEffects Boolean
   signedOutBefore =
     isRight <$> LS.retrieve LSK.signedOutBefore
-  
+
   authModeSignedOutBefore ∷ AuthenticationMode.AuthenticationMode → Aff SlamDataEffects Boolean
   authModeSignedOutBefore =
     map isRight


### PR DESCRIPTION
Resolves #1794

@nicflores can I just double check that the `docTypeKey` should be free text - there's no preset enum or anything for it?

This also adds a new "Options" section to the dialog, to accomodate the optional `queryTimeout` field that was previously missing. I don't think we have any existing optional-inputs to go off, so I just did this for now:

![timeout-options](https://user-images.githubusercontent.com/693642/26979433-a367ef08-4d26-11e7-9d25-88ad503bdf3e.png)

The input is disabled when the checkbox is toggled.