### PR TITLE
License notice per license type

### DIFF
--- a/src/SlamData/Dialog/License.purs
+++ b/src/SlamData/Dialog/License.purs
@@ -97,7 +97,7 @@ licenseInvalid =
                     [ H.text
                         $ "Try double checking your license information and "
                         <> howToFix App
-                        <> ". If you are still experiencing problems with your license after trying this please contact support." ]
+                        <> " before restarting SlamData. If you are still experiencing problems with your license after trying this please contact support." ]
               ]
         , DR.modalFooter
             [ H.a

--- a/src/SlamData/Dialog/License.purs
+++ b/src/SlamData/Dialog/License.purs
@@ -1,0 +1,134 @@
+{-
+Copyright 2017 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
+module SlamData.Dialog.License where
+
+import SlamData.Prelude
+
+import Halogen.HTML as H
+import Halogen.HTML.Properties as HP
+
+import SlamData.Render.ClassName as CN
+import SlamData.Dialog.Render as DR
+
+data LaunchedBy = App | Other
+
+advancedLicenseExpired ∷ ∀ f p. H.HTML p (f Unit)
+advancedLicenseExpired =
+  H.div
+    [ HP.classes [ H.ClassName "deck-dialog", H.ClassName "license-dialog" ] ]
+    [ H.div_
+        [ H.img [ HP.src "img/features.png" ]
+        , DR.modalHeader "Your license has expired"
+        , DR.modalBody
+            $ H.div_
+                [ H.p_
+                    [ H.text "Thanks for using SlamData Advanced!" ]
+                , H.p_
+                    [ H.text
+                        $ "Get in touch with us today to renew your "
+                        <> "license or to purchase training for your team, "
+                        <> "configuration and optimization assistance and support with queries, "
+                        <> "sharing and distribution."
+                    ]
+              ]
+        , DR.modalFooter
+            [ H.a
+                [ HP.classes [ CN.btn, CN.btnPrimary ]
+                , HP.href "https://slamdata.com/contact-us/"
+                ]
+                [ H.text "Contact SlamData" ]
+            , H.a
+                [ HP.classes [ CN.btn, CN.btnDefault ]
+                , HP.href "https://slamdata.com/slamdata-jump-start/"
+                ]
+                [ H.text "Request training" ]
+            ]
+        ]
+  ]
+
+advancedTrialLicenseExpired ∷ ∀ f p. H.HTML p (f Unit)
+advancedTrialLicenseExpired =
+  H.div
+    [ HP.classes [ H.ClassName "deck-dialog", H.ClassName "license-dialog" ] ]
+    [ H.div_
+        [ H.img [ HP.src "img/features.png" ]
+        , DR.modalHeader "Your trial has expired"
+        , DR.modalBody
+            $ H.div_
+                [ H.p_
+                    [ H.text "Thanks for trying SlamData Advanced!" ]
+                , H.p_
+                    [ H.text
+                        $ "Get in touch with us today to purchase SlamData Advanced "
+                        <> "or an extended trial period with kick-off training for your team, "
+                        <> "configuration and optimization assistance and support with queries, "
+                        <> "sharing and distribution."
+                    ]
+              ]
+        , DR.modalFooter
+            [ H.a
+                [ HP.classes [ CN.btn, CN.btnPrimary ]
+                , HP.href "https://slamdata.com/contact-us/"
+                ]
+                [ H.text "Contact SlamData" ]
+            , H.a
+                [ HP.classes [ CN.btn, CN.btnDefault ]
+                , HP.href "https://slamdata.com/slamdata-jump-start/"
+                ]
+                [ H.text "Get a kick start" ]
+            ]
+        ]
+  ]
+
+licenseInvalid ∷ ∀ f p. H.HTML p (f Unit)
+licenseInvalid =
+  H.div
+    [ HP.classes [ H.ClassName "deck-dialog", H.ClassName "license-dialog" ] ]
+    [ H.div_
+        [ H.img [ HP.src "img/features.png" ]
+        , DR.modalHeader "Your license is invalid"
+        , DR.modalBody
+            $ H.div_
+                [ H.p_
+                    [ H.text
+                        $ "Try double checking your license information "
+                        <> "and " <> howToFix App <> " "
+                        <> "before starting SlamData again. If you are "
+                        <> "still experiencing problems with your "
+                        <> "license after trying this please do get in touch."
+                    ]
+              ]
+        , DR.modalFooter
+            [ H.a
+                [ HP.classes [ CN.btn, CN.btnPrimary ]
+                , HP.href "https://slamdata.com/contact-us/"
+                ]
+                [ H.text "Contact SlamData" ]
+            , H.a
+                [ HP.classes [ CN.btn, CN.btnDefault ]
+                , HP.href "https://slamdata.com/slamdata-jump-start/"
+                ]
+                [ H.text "Get a kick start" ]
+            ]
+        ]
+    ]
+  where
+  howToFix ∷ LaunchedBy → String
+  howToFix = case _ of
+    App → "reinstalling"
+    Other → "providing your Java system properties"
+

--- a/src/SlamData/Dialog/License.purs
+++ b/src/SlamData/Dialog/License.purs
@@ -74,7 +74,7 @@ advancedTrialLicenseExpired =
                 , H.p_
                     [ H.text
                         $ "Get in touch with us today to purchase SlamData Advanced "
-                        <> "or an extended trial period with kick-off training for your team, "
+                        <> "or an extended trial period with training for your team, "
                         <> "configuration and optimization assistance and support with queries, "
                         <> "sharing and distribution."
                     ]
@@ -89,7 +89,7 @@ advancedTrialLicenseExpired =
                 [ HP.classes [ CN.btn, CN.btnDefault ]
                 , HP.href "https://slamdata.com/slamdata-jump-start/"
                 ]
-                [ H.text "Get a kick start" ]
+                [ H.text "Request training" ]
             ]
         ]
   ]
@@ -122,7 +122,7 @@ licenseInvalid =
                 [ HP.classes [ CN.btn, CN.btnDefault ]
                 , HP.href "https://slamdata.com/slamdata-jump-start/"
                 ]
-                [ H.text "Get a kick start" ]
+                [ H.text "Request training" ]
             ]
         ]
     ]

--- a/src/SlamData/Dialog/License.purs
+++ b/src/SlamData/Dialog/License.purs
@@ -38,12 +38,7 @@ advancedLicenseExpired =
                 [ H.p_
                     [ H.text "Thanks for using SlamData Advanced!" ]
                 , H.p_
-                    [ H.text
-                        $ "Get in touch with us today to renew your "
-                        <> "license or to purchase training for your team, "
-                        <> "configuration and optimization assistance and support with queries, "
-                        <> "sharing and distribution."
-                    ]
+                    [ H.text "Get in touch with us today to purchase SlamData Advanced or an extended trial period with raining for your team, configuration and optimization assistance and support ith queries, sharing and distribution." ]
               ]
         , DR.modalFooter
             [ H.a
@@ -72,12 +67,7 @@ advancedTrialLicenseExpired =
                 [ H.p_
                     [ H.text "Thanks for trying SlamData Advanced!" ]
                 , H.p_
-                    [ H.text
-                        $ "Get in touch with us today to purchase SlamData Advanced "
-                        <> "or an extended trial period with training for your team, "
-                        <> "configuration and optimization assistance and support with queries, "
-                        <> "sharing and distribution."
-                    ]
+                    [ H.text "Get in touch with us today to purchase a SlamData license or an extended trial period with training for your team, configuration, query optimization and support." ]
               ]
         , DR.modalFooter
             [ H.a
@@ -104,13 +94,7 @@ licenseInvalid =
         , DR.modalBody
             $ H.div_
                 [ H.p_
-                    [ H.text
-                        $ "Try double checking your license information "
-                        <> "and " <> howToFix App <> " "
-                        <> "before starting SlamData again. If you are "
-                        <> "still experiencing problems with your "
-                        <> "license after trying this please do get in touch."
-                    ]
+                    [ H.text "Try double checking your license information and reinstalling. If you are still experiencing problems with your license after trying this please contact support." ]
               ]
         , DR.modalFooter
             [ H.a

--- a/src/SlamData/Dialog/License.purs
+++ b/src/SlamData/Dialog/License.purs
@@ -94,7 +94,10 @@ licenseInvalid =
         , DR.modalBody
             $ H.div_
                 [ H.p_
-                    [ H.text "Try double checking your license information and reinstalling. If you are still experiencing problems with your license after trying this please contact support." ]
+                    [ H.text
+                        $ "Try double checking your license information and "
+                        <> howToFix App
+                        <> ". If you are still experiencing problems with your license after trying this please contact support." ]
               ]
         , DR.modalFooter
             [ H.a

--- a/src/SlamData/Dialog/Render.purs
+++ b/src/SlamData/Dialog/Render.purs
@@ -19,9 +19,7 @@ module SlamData.Dialog.Render where
 import SlamData.Prelude
 
 import Halogen.HTML as H
-import Halogen.HTML.Properties as HP
 
-import SlamData.Render.ClassName as CN
 import SlamData.Render.Common (classedDiv)
 
 modalDialog :: forall f p. Array (H.HTML p (f Unit)) -> H.HTML p (f Unit)
@@ -41,68 +39,3 @@ modalBody = classedDiv (H.ClassName "deck-dialog-body") <<< pure
 
 modalFooter :: forall f p. Array (H.HTML p (f Unit)) -> H.HTML p (f Unit)
 modalFooter = classedDiv (H.ClassName "deck-dialog-footer")
-
-licenseExpired ∷ ∀ f p. H.HTML p (f Unit)
-licenseExpired =
-  H.div
-    [ HP.classes [ H.ClassName "deck-dialog", H.ClassName "license-dialog" ] ]
-    [ H.div_
-        [ H.img [ HP.src "img/murray.png" ]
-        , modalHeader "Your license has expired"
-        , modalBody
-            $ H.div_
-                [ H.p_
-                    [ H.text "Thanks for using SlamData Advanced!" ]
-                , H.p_
-                    [ H.text
-                        $ "Get in touch with us today to purchase SlamData Advanced "
-                        <> "or an extended trial period with kick-off training for your team, "
-                        <> "configuration and optimization assistance and support with queries, "
-                        <> "sharing and distribution."
-                    ]
-              ]
-        , modalFooter
-            [ H.a
-                [ HP.classes [ CN.btn, CN.btnPrimary ]
-                , HP.href "https://slamdata.com/contact-us/"
-                ]
-                [ H.text "Contact SlamData" ]
-            , H.a
-                [ HP.classes [ CN.btn, CN.btnDefault ]
-                , HP.href "https://slamdata.com/slamdata-jump-start/"
-                ]
-                [ H.text "Get a kick start" ]
-            ]
-        ]
-  ]
-licenseInvalid ∷ ∀ f p. H.HTML p (f Unit)
-licenseInvalid =
-  H.div
-    [ HP.classes [ H.ClassName "deck-dialog", H.ClassName "license-dialog" ] ]
-    [ H.div_
-        [ H.img [ HP.src "img/murray.png" ]
-        , modalHeader "Your license is invalid"
-        , modalBody
-            $ H.div_
-                [ H.p_
-                    [ H.text
-                        $ "Try double checking your license information and "
-                        <> "reinstalling or providing your Java system properties "
-                        <> "again. If you are still experiencing problems with your "
-                        <> "license after trying this please do get in touch."
-                    ]
-              ]
-        , modalFooter
-            [ H.a
-                [ HP.classes [ CN.btn, CN.btnPrimary ]
-                , HP.href "https://slamdata.com/contact-us/"
-                ]
-                [ H.text "Contact SlamData" ]
-            , H.a
-                [ HP.classes [ CN.btn, CN.btnDefault ]
-                , HP.href "https://slamdata.com/slamdata-jump-start/"
-                ]
-                [ H.text "Get a kick start" ]
-            ]
-        ]
-    ]

--- a/src/SlamData/FileSystem/Dialog/Component.purs
+++ b/src/SlamData/FileSystem/Dialog/Component.purs
@@ -29,8 +29,10 @@ import Halogen.HTML.Properties.ARIA as ARIA
 
 import Network.HTTP.RequestHeader (RequestHeader)
 
+import Quasar.Advanced.Types as QAT
+
 import SlamData.Dialog.Error.Component as Error
-import SlamData.Dialog.Render (licenseExpired, licenseInvalid)
+import SlamData.Dialog.License (advancedLicenseExpired, advancedTrialLicenseExpired, licenseInvalid)
 import SlamData.FileSystem.Dialog.Component.Message (Message(..))
 import SlamData.FileSystem.Dialog.Download.Component as Download
 import SlamData.FileSystem.Dialog.Mount.Component as Mount
@@ -105,8 +107,10 @@ render state =
       HH.slot' CP.cp4 unit Download.component { resource, headers } (HE.input HandleChild)
     Mount input →
       HH.slot' CP.cp5 unit Mount.component input (HE.input HandleChild)
-    LicenseProblem License.Expired →
-      licenseExpired
+    LicenseProblem (License.Expired licenseType) →
+      case licenseType of
+        QAT.Advanced → advancedLicenseExpired
+        QAT.AdvancedTrial → advancedTrialLicenseExpired
     LicenseProblem License.Invalid →
       licenseInvalid
 

--- a/src/SlamData/License.purs
+++ b/src/SlamData/License.purs
@@ -16,4 +16,6 @@ limitations under the License.
 
 module SlamData.License where
 
-data LicenseProblem = Invalid | Expired
+import Quasar.Advanced.Types (LicenseType)
+
+data LicenseProblem = Invalid | Expired LicenseType

--- a/src/SlamData/Workspace/Dialog/Component.purs
+++ b/src/SlamData/Workspace/Dialog/Component.purs
@@ -28,18 +28,19 @@ import Halogen.Component.ChildPath as CP
 import Halogen.HTML as HH
 import Halogen.HTML.Events as HE
 import Halogen.HTML.Properties as HP
+import Quasar.Advanced.Types as QAT
 import SlamData.Dialog.Error.Component as Error
-import SlamData.Dialog.Render (licenseExpired, licenseInvalid)
-import SlamData.Monad (Slam)
-import SlamData.Workspace.Deck.Options (DeckOptions)
+import SlamData.License as License
 import SlamData.Workspace.Dialog.Confirm.Component as Confirm
 import SlamData.Workspace.Dialog.Export.Component as Export
 import SlamData.Workspace.Dialog.Reason.Component as Reason
 import SlamData.Workspace.Dialog.Rename.Component as Rename
 import SlamData.Workspace.Dialog.Share.Component as Share
-import SlamData.Workspace.Dialog.Types (Dialog(..))
 import SlamData.Workspace.Dialog.Unshare.Component as Unshare
-import SlamData.License as License
+import SlamData.Dialog.License (advancedLicenseExpired, advancedTrialLicenseExpired, licenseInvalid)
+import SlamData.Monad (Slam)
+import SlamData.Workspace.Deck.Options (DeckOptions)
+import SlamData.Workspace.Dialog.Types (Dialog(..))
 
 type State = Maybe Dialog
 
@@ -161,8 +162,10 @@ render = case _ of
         }
         \Reason.Dismiss → Just $ H.action $ Raise Dismissed
 
-    LicenseProblem License.Expired →
-      licenseExpired
+    LicenseProblem (License.Expired licenseType) →
+      case licenseType of
+        QAT.Advanced → advancedLicenseExpired
+        QAT.AdvancedTrial → advancedTrialLicenseExpired
 
     LicenseProblem License.Invalid →
       licenseInvalid


### PR DESCRIPTION
This provides one license notice per license type. The key change here is

https://github.com/slamdata/slamdata/compare/master...beckyconning:license-type-notices?diff=unified&expand=1&name=license-type-notices#diff-073decef3cbbe4b7c738b6078b4c835dL19

I'm pretty sure there are parts of this which could be tidied up but I'm not 100% sure of the preferable ways of doing this.