### PR TITLE
Fix HTML for structure viewer layout

### DIFF
--- a/src/SlamData/Workspace/Card/StructureEditor/Column/Component.purs
+++ b/src/SlamData/Workspace/Card/StructureEditor/Column/Component.purs
@@ -69,11 +69,9 @@ component' opts path =
 
   render ∷ State → HTML
   render st =
-    HH.div_
-      [ HH.div
-          [ HP.class_ (HH.ClassName "sd-structure-editor-column") ]
-          [ HH.slot unit column st (Just ∘ right ∘ H.action ∘ Raise) ]
-      ]
+    HH.div
+      [ HP.class_ (HH.ClassName "sd-structure-editor-column") ]
+      [ HH.slot unit column st (Just ∘ right ∘ H.action ∘ Raise) ]
 
   eval ∷ Query' ~> DSL
   eval = coproduct evalInner evalOuter


### PR DESCRIPTION
Resolves #1866

This was broken by CSS changes in #1861. The extra `div` wrapping will need to be re-inserted eventually, when the column has additional actions, but for now it's just getting in the way. The styling for the additional wrapping can be resolved when that goes in.