### PR TITLE
Bump sql-squared

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -57,7 +57,7 @@
     "purescript-rationals": "^3.1.1",
     "purescript-routing": "^5.1.0",
     "purescript-search": "^3.0.0",
-    "purescript-sqlsquare": "^0.4.1",
+    "purescript-sqlsquare": "^0.6.2",
     "purescript-these": "^3.0.0",
     "purescript-tuples": "^4.0.0",
     "purescript-type-equality": "^2.1.0",


### PR DESCRIPTION
Fixes #1891 

This technically introduces a _slight_ breaking change. Version `0.4` of sql-squared has a bug in the parser of let statements. It _however_ would reprint it correctly.

```sql
:foo := 41;
SELECT foo
```

Notice that it required `:foo` in the binding. If we'd reprint this parse, it would print as:

```sql
foo := 41;
SELECT foo
```

Which is what Quasar expects. So our users could have been writing incorrect SQL^2, but it still pass through.