### PR TITLE
Fix display of frequency hints for structure viewer

### DIFF
--- a/less/deck/structure-editor.less
+++ b/less/deck/structure-editor.less
@@ -13,10 +13,10 @@
 .sd-structure-editor-item-weight {
   position: absolute;
   left: 0;
-  top: 0.4rem;
+  top: 0.2rem;
   background: rgba(0, 0, 0, 0.05);
-  height: ~"calc(100% - 0.9rem)";
-  z-index: -1;
+  height: ~"calc(100% - 0.4rem)";
+  z-index: 1;
 }
 
 .sd-structure-editor-column {

--- a/less/workspace/miller-columns.less
+++ b/less/workspace/miller-columns.less
@@ -68,22 +68,16 @@
 
     li {
       display: block;
-      padding: 1.2rem 0.6rem;
       cursor: pointer;
       z-index: 1;
-      line-height: 1;
+      border-bottom: 0.1rem solid #ddd;
 
       &:hover {
-        background: #eee;
-      }
-
-      + li {
-        margin-top: -0.1rem;
-        border-top: 0.1rem solid #ddd;
+        background: rgba(0, 0, 0, 0.2);
       }
 
       &.selected {
-        background: #ddd;
+        background: rgba(0, 0, 0, 0.1);
         z-index: 2;
       }
 
@@ -138,6 +132,7 @@
   justify-content: space-between;
   align-items: center;
   position: relative;
+  padding: 1rem 0.6rem;
 
   .sd-icon--chevron-right-sm {
     flex: 0 0 auto;


### PR DESCRIPTION
Resolves #1907 

This is mostly a re-arrangement of moving the padding into the div wrapping the items rather than having it on the `li` directly, as it seemed to be interfering with the sizing in a way that would have made positioning and sizing the bars annoying. I've checked other instances of the columns - dimension picker, open card, etc. and they are still spaced appropriately.

Also adds a border to the bottom of each item in the column. This used to add a border only to the top, but when changing the hover/selected states to use tints rather than fixed colours it didn't work so well, as the overlap would mean the previous item's border was caught in the tint. The only disadvantage now is when scrolling to the bottom of a column there will be a double border for the last item in the list. The only way I can think of avoiding that is pretty awful: toggle a class based on whether the column is scrolling or not, which involves measuring the DOM rendered elements, etc. That or maybe have the list display as a table so border-collapse works...