### PR TITLE
Prevent scrolling within columns in structure viewer

### DIFF
--- a/sass/deck/_structure-editor.sass
+++ b/sass/deck/_structure-editor.sass
@@ -2,19 +2,17 @@
   height: 100%
 
 
-.sd-structure-editor-item
-  position: relative
-
-  .sd-icon
-    opacity: 0.5
-
-
 .sd-structure-editor-item-weight
   position: absolute
   left: 0
   top: 0.4rem
   background: rgba(0, 0, 0, 0.05)
   height: calc(100% - 0.9rem)
+
+
+.sd-structure-editor-item-label
+  overflow: hidden
+  text-overflow: ellipsis
 
 
 .sd-structure-editor-column

--- a/sass/workspace/miller-columns/_item.sass
+++ b/sass/workspace/miller-columns/_item.sass
@@ -48,6 +48,8 @@
 
 .sd-miller-column-item-inner
   padding: $padding-base-horizontal
+  overflow: hidden
+  text-overflow: ellipsis
 
 
 

--- a/src/SlamData/Workspace/Card/StructureEditor/Item/Component.purs
+++ b/src/SlamData/Workspace/Card/StructureEditor/Item/Component.purs
@@ -97,10 +97,9 @@ renderItem ci =
         , HCSS.style $ CSS.width (CSS.pct (unwrap (columnItemWeight ci) * 100.0))
         ]
         []
-    , HH.div_
-        [ HH.span_
-            [ columnItemIcon ci
-            , HH.text (columnItemLabel ci)
-            ]
+    , HH.div
+        [ HP.class_ (H.ClassName "sd-structure-editor-item-label") ]
+        [ columnItemIcon ci
+        , HH.text (columnItemLabel ci)
         ]
     ]


### PR DESCRIPTION
Resolves #1955 

Also ensures any Miller column items will truncate rather than scroll. The `text-overflow: ellipsis` only works for "naked" labels though, so needs reapplying in some cases, hence the change being echoed in a style for the structure viewer.