### PR TITLE
Lazy load for Open card (alternative)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -53,7 +53,7 @@
     "purescript-parallel": "^3.0.0",
     "purescript-pathy": "^4.0.0",
     "purescript-profunctor-lenses": "^3.2.0",
-    "purescript-quasar": "^31.0.0",
+    "purescript-quasar": "^32.0.0",
     "purescript-rationals": "^3.1.1",
     "purescript-routing": "^5.1.0",
     "purescript-search": "^3.0.0",

--- a/src/SlamData/Quasar/FS.purs
+++ b/src/SlamData/Quasar/FS.purs
@@ -16,6 +16,7 @@ limitations under the License.
 
 module SlamData.Quasar.FS
   ( children
+  , childrenPaginated
   , getNewName
   , move
   , listing
@@ -69,8 +70,17 @@ children
   ⇒ QuasarDSL m
   ⇒ DirPath
   → m (Either QError (Array R.Resource))
-children dir = runExceptT do
-  cs ← ExceptT $ listing dir
+children dir = childrenPaginated dir Nothing
+
+childrenPaginated
+  ∷ ∀ m
+  . Monad m
+  ⇒ QuasarDSL m
+  ⇒ DirPath
+  → Maybe QF.Pagination
+  → m (Either QError (Array R.Resource))
+childrenPaginated dir pagination = runExceptT do
+  cs ← ExceptT $ listingPaginated dir pagination
   let result = (R._root .~ dir) <$> cs
   -- TODO: do this somewhere more appropriate
   -- lift $ fromAff $ memoizeCompletionStrs dir result

--- a/src/SlamData/Workspace/Card/Open/Component.purs
+++ b/src/SlamData/Workspace/Card/Open/Component.purs
@@ -31,6 +31,7 @@ import Halogen as H
 import Halogen.Component.Utils (busEventSource)
 import Halogen.HTML as HH
 import Halogen.HTML.Properties as HP
+import Quasar.Types (Pagination)
 import SlamData.FileSystem.Resource as R
 import SlamData.GlobalError as GE
 import SlamData.GlobalMenu.Bus as GMB
@@ -208,8 +209,11 @@ columnsComponent =
     , id: map R.getPath
     }
 
+makePagination ∷ Int → Pagination
+makePagination = { offset: _, limit: 25 }
+
 load ∷ AnyPath' × MCR.LoadRequest → DSL (MCR.LoadResponse AnyItem')
-load (path × { filter, requestId }) =
+load (path × { filter, requestId, offset }) =
   case path of
     Root →
       pure
@@ -231,14 +235,15 @@ load (path × { filter, requestId }) =
         , nextOffset: Nothing
         }
     Resource (Left r) → do
-      Quasar.children r >>= case _ of
+      let pagination = makePagination (fromMaybe 0 offset)
+      Quasar.childrenPaginated r (Just pagination) >>= case _ of
         Left err → handleError err $> noResult
         Right rs → do
           let filenameFilter = MCF.mkFilter filter
           pure
             { requestId
             , items: L.fromFoldable (Resource <$> A.filter (filenameFilter ∘ view R._name) rs)
-            , nextOffset: Nothing
+            , nextOffset: if A.length rs < pagination.limit then Nothing else Just $ pagination.offset + pagination.limit
             }
     Resource _ → pure noResult
     Variable v → pure noResult

--- a/src/SlamData/Workspace/Card/Open/Component.purs
+++ b/src/SlamData/Workspace/Card/Open/Component.purs
@@ -210,7 +210,7 @@ columnsComponent =
     }
 
 makePagination ∷ Int → Pagination
-makePagination = { offset: _, limit: 25 }
+makePagination = { offset: _, limit: 5 }
 
 load ∷ AnyPath' × MCR.LoadRequest → DSL (MCR.LoadResponse AnyItem')
 load (path × { filter, requestId, offset }) =

--- a/src/SlamData/Workspace/Legacy.purs
+++ b/src/SlamData/Workspace/Legacy.purs
@@ -213,7 +213,7 @@ pruneLegacyData
   ⇒ DirPath
   → m (Either QE.QError Unit)
 pruneLegacyData path = runExceptT do
-  children ← ExceptT $ liftQuasar (QF.dirMetadata path)
+  children ← ExceptT $ liftQuasar (QF.dirMetadata path Nothing)
   let
     tmpDir = path </> Pathy.dir ".tmp"
     deckDirs = flip foldMap children case _ of

--- a/src/SlamData/Workspace/MillerColumns/Column/Component.purs
+++ b/src/SlamData/Workspace/MillerColumns/Column/Component.purs
@@ -235,7 +235,8 @@ component' (ColumnOptions colSpec) colPath =
     let
       shouldLoad = case lastLoadRequest of
         Nothing → true
-        Just { filter, offset } → filter /= filterText || offset /= nextOffset
+        Just { filter, offset } →
+          nextOffset /= Nothing && (filter /= filterText || offset /= nextOffset)
     when shouldLoad do
       let
         requestId = Req.succ lastRequestId

--- a/src/SlamData/Workspace/MillerColumns/Column/Component.purs
+++ b/src/SlamData/Workspace/MillerColumns/Column/Component.purs
@@ -31,8 +31,6 @@ import Data.Array as A
 import Data.List as L
 import Data.Time.Duration (Milliseconds(..))
 import DOM.Classy.Element (scrollTop, scrollHeight, clientHeight) as DOM
-import DOM.Classy.Event (currentTarget) as DOM
-import DOM.Classy.Node (fromNode) as DOM
 import Halogen as H
 import Halogen.Component.Proxy (proxyQI)
 import Halogen.Component.Utils.Debounced (debouncedEventSource, runDebounceTrigger, cancelDebounceTrigger)
@@ -108,7 +106,8 @@ component' (ColumnOptions colSpec) colPath =
       , renderSelected selected
       , HH.div
           [ HP.class_ (HH.ClassName "sd-miller-column-items")
-          , HE.onScroll \e → H.action ∘ HandleScroll <$> DOM.fromNode (DOM.currentTarget e)
+          , HP.ref refItems
+          , HE.onScroll (HE.input_ HandleScroll)
           ]
           [ HH.ul
               [ HP.class_ (HH.ClassName "sd-miller-column-items-list") ]
@@ -116,6 +115,9 @@ component' (ColumnOptions colSpec) colPath =
                   <> (guard (state == Loading) $> loadIndicator)
           ]
       ]
+
+  refItems ∷ H.RefLabel
+  refItems = H.RefLabel "refItems"
 
   loadIndicator ∷ HTML a i o
   loadIndicator =
@@ -190,13 +192,8 @@ component' (ColumnOptions colSpec) colPath =
       H.modify (_ { filterText = text, items = L.Nil, lastLoadRequest = Nothing })
       load
       pure next
-    HandleScroll ul next → do
-      remain ← H.liftEff do
-        height <- DOM.clientHeight ul
-        scrollTop <- DOM.scrollTop ul
-        scrollHeight <- DOM.scrollHeight ul
-        pure (scrollHeight - height - scrollTop)
-      when (remain < 20.0) load
+    HandleScroll next → do
+      fill
       pure next
     HandleMessage itemId msg next → do
       case msg of
@@ -213,13 +210,24 @@ component' (ColumnOptions colSpec) colPath =
       pure next
     FulfilLoadRequest { requestId, items, nextOffset } next → do
       expectedId ← H.gets _.lastRequestId
-      when (requestId == expectedId) $
+      when (requestId == expectedId) do
         H.modify \st' → st'
           { items = st'.items <> items
           , nextOffset = nextOffset
           , state = Loaded
           }
+        fill
       pure next
+
+  fill ∷ DSL a i o Unit
+  fill =
+    H.getHTMLElementRef refItems >>= traverse_ \items → do
+      remain ← H.liftEff do
+        height <- DOM.clientHeight items
+        scrollTop <- DOM.scrollTop items
+        scrollHeight <- DOM.scrollHeight items
+        pure (scrollHeight - height - scrollTop)
+      when (remain < 20.0) load
 
   load ∷ DSL a i o Unit
   load = do

--- a/src/SlamData/Workspace/MillerColumns/Column/Component.purs
+++ b/src/SlamData/Workspace/MillerColumns/Column/Component.purs
@@ -107,11 +107,11 @@ component' (ColumnOptions colSpec) colPath =
           ]
       , renderSelected selected
       , HH.div
-          [ HP.class_ (HH.ClassName "sd-miller-column-items") ]
+          [ HP.class_ (HH.ClassName "sd-miller-column-items")
+          , HE.onScroll \e → H.action ∘ HandleScroll <$> DOM.fromNode (DOM.currentTarget e)
+          ]
           [ HH.ul
-              [ HP.class_ (HH.ClassName "sd-miller-column-items-list")
-              , HE.onScroll \e → H.action ∘ HandleScroll <$> DOM.fromNode (DOM.currentTarget e)
-              ]
+              [ HP.class_ (HH.ClassName "sd-miller-column-items-list") ]
               $ A.fromFoldable (renderItem selected <$> items)
                   <> (guard (state == Loading) $> loadIndicator)
           ]

--- a/src/SlamData/Workspace/MillerColumns/Column/Component/Query.purs
+++ b/src/SlamData/Workspace/MillerColumns/Column/Component/Query.purs
@@ -24,10 +24,7 @@ module SlamData.Workspace.MillerColumns.Column.Component.Query
 
 import SlamData.Prelude
 
-import DOM.Node.Types (Element)
-
 import Halogen.Component.Proxy (ProxyQ)
-
 import SlamData.Workspace.MillerColumns.Column.Component.Item as Item
 import SlamData.Workspace.MillerColumns.Column.Component.Request (LoadRequest, LoadResponse)
 import SlamData.Workspace.MillerColumns.Column.Component.ColumnWidth (ColumnWidth)
@@ -39,7 +36,7 @@ data Query a i o b
   | Deselect b
   | HandleFilterChange String b
   | UpdateFilter String b
-  | HandleScroll Element b
+  | HandleScroll b
   | HandleMessage i (Item.Message' a o) b
   | HandleInput (ColumnWidth × Maybe a) b
   | FulfilLoadRequest (LoadResponse a) b


### PR DESCRIPTION
Resolves #1848 

I forked your branch at the point just before you attempted to fix the "too much loading" problem. Here's my take...

There are two changes here. One is a minor tweak to the `shouldLoad` test, that fixes the thing to stop loading when it reaches the end. The other is to ensure we keep loading until the column is filled, if the limit is too short to give a filled column. This also means we need no special handling for filters.

I'd suggest we change the the `limit` to `250` or something before merging this.