### PR TITLE
Properly seed and transition markdown form state

### DIFF
--- a/src/SlamData/Workspace/Card/Markdown/Eval.purs
+++ b/src/SlamData/Workspace/Card/Markdown/Eval.purs
@@ -18,7 +18,7 @@ module SlamData.Workspace.Card.Markdown.Eval
 
 import SlamData.Prelude
 
-import Control.Monad.Eff.Class (class MonadEff, liftEff)
+import Control.Monad.Eff.Class (class MonadEff)
 import Control.Monad.Writer.Class (class MonadTell)
 import Data.Array as A
 import Data.HugeInt as HI
@@ -51,15 +51,15 @@ import Utils.Path (DirPath)
 
 evalMarkdownForm
   ∷ ∀ m
-  . MonadEff SlamDataEffects m
-  ⇒ Monad m
+  . Monad m
   ⇒ MD.Model
   → SD.SlamDownP Port.VarMapValue
   → Port.DataMap
   → m Port.Out
 evalMarkdownForm model doc varMap = do
-  let inputState = SDH.formStateFromDocument doc
-  thisVarMap ← liftEff $ MDS.formStateToVarMap inputState model
+  let
+    inputState = SDH.formStateFromDocument doc
+    thisVarMap = MDS.formStateToVarMap inputState model
   pure (Port.Variables × map Right thisVarMap `SM.union` varMap)
 
 evalMarkdown

--- a/src/SlamData/Workspace/Card/Model.purs
+++ b/src/SlamData/Workspace/Card/Model.purs
@@ -22,7 +22,7 @@ import Data.Argonaut ((:=), (~>), (.?))
 import Data.Argonaut as J
 import Data.Array as Array
 import Data.Codec.Argonaut as CA
-import Data.Lens (Traversal', wander, Prism', prism', (^?))
+import Data.Lens (Traversal', wander, Prism', prism')
 import Data.List as L
 import Data.Path.Pathy (fileName, runFileName)
 import Data.Rational ((%))
@@ -79,7 +79,6 @@ import SlamData.Workspace.Card.Table.Model as JT
 import SlamData.Workspace.Card.Tabs.Model as Tabs
 import SlamData.Workspace.Card.Variables.Model as Variables
 import SlamData.Workspace.Deck.DeckId (DeckId)
-import Text.Markdown.SlamDown.Halogen.Component.State as SDS
 import Test.StrongCheck.Arbitrary as SC
 import Test.StrongCheck.Gen as Gen
 import Utils (decodec)
@@ -436,7 +435,7 @@ cardModelOfType (port × varMap) = case _ of
   CT.SetupFormInput Static → SetupStatic SetupStatic.initialModel
   CT.FormInput → FormInput FormInput.initialModel
   CT.Chart → Chart Chart.emptyModel
-  CT.Markdown → Markdown $ maybe MD.emptyModel SDS.formStateFromDocument $ port ^? Port._SlamDown
+  CT.Markdown → Markdown MD.emptyModel
   CT.Table → Table JT.emptyModel
   CT.Download → Download
   CT.Variables → Variables Variables.emptyModel

--- a/src/SlamData/Workspace/Card/Model.purs
+++ b/src/SlamData/Workspace/Card/Model.purs
@@ -22,7 +22,7 @@ import Data.Argonaut ((:=), (~>), (.?))
 import Data.Argonaut as J
 import Data.Array as Array
 import Data.Codec.Argonaut as CA
-import Data.Lens (Traversal', wander, Prism', prism')
+import Data.Lens (Traversal', wander, Prism', prism', (^?))
 import Data.List as L
 import Data.Path.Pathy (fileName, runFileName)
 import Data.Rational ((%))
@@ -79,6 +79,7 @@ import SlamData.Workspace.Card.Table.Model as JT
 import SlamData.Workspace.Card.Tabs.Model as Tabs
 import SlamData.Workspace.Card.Variables.Model as Variables
 import SlamData.Workspace.Deck.DeckId (DeckId)
+import Text.Markdown.SlamDown.Halogen.Component.State as SDS
 import Test.StrongCheck.Arbitrary as SC
 import Test.StrongCheck.Gen as Gen
 import Utils (decodec)
@@ -435,7 +436,7 @@ cardModelOfType (port × varMap) = case _ of
   CT.SetupFormInput Static → SetupStatic SetupStatic.initialModel
   CT.FormInput → FormInput FormInput.initialModel
   CT.Chart → Chart Chart.emptyModel
-  CT.Markdown → Markdown MD.emptyModel
+  CT.Markdown → Markdown $ maybe MD.emptyModel SDS.formStateFromDocument $ port ^? Port._SlamDown
   CT.Table → Table JT.emptyModel
   CT.Download → Download
   CT.Variables → Variables Variables.emptyModel

--- a/test/src/Test/SlamData/Property/Workspace/Card/Markdown/Model.purs
+++ b/test/src/Test/SlamData/Property/Workspace/Card/Markdown/Model.purs
@@ -54,7 +54,7 @@ checkVarMapConstruction =
   quickCheck \(SDS.SlamDownState { document, formState }) →
     let
       inputState = SDS.formStateFromDocument document
-      varMap = unsafeRunLocale $ MDS.formStateToVarMap inputState formState
+      varMap = MDS.formStateToVarMap inputState formState
       descKeys = Set.fromFoldable $ SM.keys inputState
       stateKeys = Set.fromFoldable $ SM.keys varMap
     in


### PR DESCRIPTION
Fixes #2031 

This ensures that:
* Initially, if no default value exists for a drop-down, the first item is selected, otherwise the default value is selected. `null` is never selected unless there are no drop-down values and no default value.
* When updating drop-down/checkboxes/radio programmatically via a query, invalid selections are removed. So in the chained drop-down case, it will select a new default value if the previous selection no longer applies to the available options.
* In the chained case, if you toggle a different set of options, and then switch back, the previous selection will be preserved.