### PR TITLE
Fix loading indicator display for Miller columns

### DIFF
--- a/sass/workspace/_miller-columns.sass
+++ b/sass/workspace/_miller-columns.sass
@@ -9,3 +9,17 @@
   width: 100%
   height: 100%
   white-space: nowrap
+
+
+.sd-miller-column-loading
+
+  .sd-icon
+    display: block
+    font-size: 1.8em
+    margin: $padding-base-horizontal auto 0.4rem
+    text-align: center
+
+  span
+    display: block
+    text-align: center
+    padding-bottom: $padding-base-horizontal

--- a/sass/workspace/miller-columns/_item.sass
+++ b/sass/workspace/miller-columns/_item.sass
@@ -29,22 +29,6 @@
     background-color: $miller-column-item-selected-bg
     z-index: 2
 
-  &.sd-miller-column-loading
-    cursor: auto
-
-    &:hover
-      background: transparent
-
-    .sd-icon
-      display: block
-      font-size: 1.8em
-      margin: $padding-base-horizontal auto 0.4rem
-      text-align: center
-
-    span
-      display: block
-      text-align: center
-
 
 
 .sd-miller-column-item-inner


### PR DESCRIPTION
Resolves #1952 

This got broken when the styles were moved around and switched to using class names rather than element hierarchy, it seems. I just moved the style out, and as a bonus it no longer needs to override stuff that the items had applied now.