### PR TITLE
Propagate constrained form state to the UI

### DIFF
--- a/src/SlamData/Workspace/Card/Eval/State.purs
+++ b/src/SlamData/Workspace/Card/Eval/State.purs
@@ -33,6 +33,7 @@ module SlamData.Workspace.Card.Eval.State
   , _PivotTable
   , _ChartOptions
   , _Geo
+  , _SlamDown
   , _Leaflet
   , _BuildLeaflet
   , _Layers
@@ -42,24 +43,21 @@ module SlamData.Workspace.Card.Eval.State
 import SlamData.Prelude
 
 import Control.Monad.Aff (Aff)
-
 import Data.Argonaut (Json)
 import Data.Array as Array
 import Data.Lens (Prism', prism', Traversal', wander, lens)
 import Data.Set as Set
-
 import ECharts.Monad (DSL)
 import ECharts.Types.Phantom (OptionI)
-
 import Leaflet.Core as LC
-
 import SlamData.Effects (SlamDataEffects)
-
 import SlamData.Workspace.Card.Chart.PivotTableRenderer.Common (PTree)
 import SlamData.Workspace.Card.Model as CM
 import SlamData.Workspace.Card.Port (Resource, PivotTablePort)
+import SlamData.Workspace.Card.Port.VarMap as VM
 import SlamData.Workspace.Card.Setups.Axis (Axes)
 import SlamData.Workspace.Card.Setups.Semantics as Sem
+import Text.Markdown.SlamDown.Halogen.Component as SDH
 
 type AnalysisR =
   { resource ∷ Resource
@@ -79,7 +77,6 @@ type TableR =
   , pageSize ∷ Int
   , size ∷ Int
   }
-
 
 type GeoR =
   { leaflet ∷ Maybe LC.Leaflet
@@ -107,6 +104,7 @@ data EvalState
   | PivotTable PivotTableR
   | ChartOptions (DSL OptionI)
   | Geo GeoR
+  | SlamDown (SDH.SlamDownFormState VM.VarMapValue)
 
 initialEvalState ∷ CM.AnyCardModel → Maybe EvalState
 initialEvalState = case _ of
@@ -174,6 +172,11 @@ _ResourceSize = wander \f s → case s of
 _Geo ∷ Prism' EvalState GeoR
 _Geo = prism' Geo case _ of
   Geo r → Just r
+  _ → Nothing
+
+_SlamDown ∷ Prism' EvalState (SDH.SlamDownFormState VM.VarMapValue)
+_SlamDown = prism' SlamDown case _ of
+  SlamDown r → Just r
   _ → Nothing
 
 _Leaflet ∷ Traversal' EvalState (Maybe LC.Leaflet)

--- a/src/SlamData/Workspace/Card/Markdown/Component.purs
+++ b/src/SlamData/Workspace/Card/Markdown/Component.purs
@@ -32,6 +32,7 @@ import SlamData.Wiring as Wiring
 import SlamData.Workspace.Card.CardId as CID
 import SlamData.Workspace.Card.CardType as CT
 import SlamData.Workspace.Card.Component as CC
+import SlamData.Workspace.Card.Eval.State as CES
 import SlamData.Workspace.Card.Markdown.Component.Query (Query(..))
 import SlamData.Workspace.Card.Markdown.Component.State (State, initialState)
 import SlamData.Workspace.Card.Model as Card
@@ -93,13 +94,14 @@ evalCard = case _ of
     pure next
   CC.ReceiveInput input _ next → do
     for_ (input ^? Port._SlamDown) \sd → do
-      state ← H.gets _.state
       void $ H.query unit $ H.action (SD.SetDocument sd)
-      void $ H.query unit $ H.action (SD.PopulateForm state)
     pure next
   CC.ReceiveOutput _ _ next →
     pure next
-  CC.ReceiveState _ next →
+  CC.ReceiveState evalState next → do
+    for_ (evalState ^? CES._SlamDown) \state → do
+      H.modify _ { state = state }
+      void $ H.query unit $ H.action (SD.PopulateForm state)
     pure next
   CC.ReceiveDimensions _ reply →
     pure $ reply LOD.High

--- a/src/SlamData/Workspace/Card/Markdown/Component/State.purs
+++ b/src/SlamData/Workspace/Card/Markdown/Component/State.purs
@@ -17,14 +17,13 @@ limitations under the License.
 module SlamData.Workspace.Card.Markdown.Component.State where
 
 import SlamData.Prelude
-import SlamData.Workspace.Card.Port.VarMap as VM
-import SlamData.Workspace.Card.Markdown.Interpret as MDI
-import Text.Markdown.SlamDown.Halogen.Component.State as SDS
 
 import Data.BrowserFeatures (BrowserFeatures)
 import Data.StrMap as SM
-
+import SlamData.Workspace.Card.Markdown.Interpret (formFieldConstrainValue)
+import SlamData.Workspace.Card.Port.VarMap as VM
 import Text.Markdown.SlamDown.Halogen.Component as SDH
+import Text.Markdown.SlamDown.Halogen.Component.State as SDS
 import Text.Markdown.SlamDown.Syntax.FormField as SDF
 
 type State =
@@ -38,35 +37,27 @@ initialState =
   , state: SM.empty
   }
 
-formStateToVarMap
+updateFormState
   ∷ SDH.SlamDownFormState VM.VarMapValue
   → SDH.SlamDownFormState VM.VarMapValue
-  → VM.VarMap
-formStateToVarMap newState oldState =
+  → SDH.SlamDownFormState VM.VarMapValue
+updateFormState newState oldState =
   SM.fold
-    (\m k v → SM.insert k (valueForKey k v) m)
+    (\m k v → SM.insert k (formFieldConstrainValue $ valueForKey k v) m)
     SM.empty
     newState
   where
-    valueForKey
-      ∷ String
-      → SDH.FormFieldValue VM.VarMapValue
-      → VM.VarMapValue
-    valueForKey k newField = case SM.lookup k oldState of
-      Nothing → MDI.formFieldDefaultValue newField
-      Just oldField → case oldField, newField of
-        SDF.DropDown oldSel _, SDF.DropDown _ newOptions →
-          MDI.formFieldDefaultValue (SDF.DropDown oldSel newOptions)
-        SDF.CheckBoxes oldSel _, SDF.CheckBoxes _ newOptions →
-          MDI.formFieldDefaultValue (SDF.CheckBoxes oldSel newOptions)
-        SDF.RadioButtons oldSel _, SDF.RadioButtons _ newOptions →
-          MDI.formFieldDefaultValue (SDF.RadioButtons oldSel newOptions)
-        SDF.TextBox oldSel, SDF.TextBox newSel → case oldSel, newSel of
-          SDF.PlainText _, SDF.PlainText _ → MDI.formFieldDefaultValue oldField
-          SDF.Numeric _, SDF.Numeric _ → MDI.formFieldDefaultValue oldField
-          SDF.Date _, SDF.Date _ → MDI.formFieldDefaultValue oldField
-          SDF.Time _ _, SDF.Time _ _ → MDI.formFieldDefaultValue oldField
-          SDF.DateTime _ _, SDF.DateTime _ _ → MDI.formFieldDefaultValue oldField
-          _, _ → MDI.formFieldDefaultValue newField
-        _, _ →
-          MDI.formFieldDefaultValue newField
+  valueForKey k newField = case SM.lookup k oldState of
+    Nothing → newField
+    Just oldField → case oldField, newField of
+      SDF.DropDown oldSel _, SDF.DropDown _ newOptions → SDF.DropDown oldSel newOptions
+      SDF.CheckBoxes oldSel _, SDF.CheckBoxes _ newOptions → SDF.CheckBoxes oldSel newOptions
+      SDF.RadioButtons oldSel _, SDF.RadioButtons _ newOptions → SDF.RadioButtons oldSel newOptions
+      SDF.TextBox oldSel, SDF.TextBox newSel → case oldSel, newSel of
+        SDF.PlainText _, SDF.PlainText _ → oldField
+        SDF.Numeric _, SDF.Numeric _ → oldField
+        SDF.Date _, SDF.Date _ → oldField
+        SDF.Time _ _, SDF.Time _ _ → oldField
+        SDF.DateTime _ _, SDF.DateTime _ _ → oldField
+        _, _ → newField
+      _, _ → newField

--- a/src/SlamData/Workspace/Card/Markdown/Component/State.purs
+++ b/src/SlamData/Workspace/Card/Markdown/Component/State.purs
@@ -47,6 +47,10 @@ updateFormState newState oldState =
     SM.empty
     newState
   where
+  valueForKey
+    ∷ String
+    → SDH.FormFieldValue VM.VarMapValue
+    → SDH.FormFieldValue VM.VarMapValue
   valueForKey k newField = case SM.lookup k oldState of
     Nothing → newField
     Just oldField → case oldField, newField of

--- a/src/SlamData/Workspace/Card/Markdown/Interpret.purs
+++ b/src/SlamData/Workspace/Card/Markdown/Interpret.purs
@@ -12,25 +12,22 @@ limitations under the License.
 -}
 
 module SlamData.Workspace.Card.Markdown.Interpret
-  ( formFieldValueToVarMapValue
+  ( formFieldValue
   , formFieldDefaultValue
+  , formFieldConstrainValue
   ) where
 
 import SlamData.Prelude
 
 import Data.DateTime as DT
 import Data.Foldable as F
+import Data.Formatter.DateTime as FD
 import Data.Identity (Identity(..))
 import Data.List as L
-import Data.Formatter.DateTime as FD
 import Data.Maybe as M
-
-import Matryoshka (embed, project)
-
-import SqlSquared as Sql
-
+import Matryoshka (project)
 import SlamData.Workspace.Card.Port.VarMap as VM
-
+import SqlSquared as Sql
 import Text.Markdown.SlamDown as SD
 import Text.Markdown.SlamDown.Halogen.Component.State as SDS
 
@@ -53,15 +50,29 @@ getLiteral (VM.VarMapValue s) = project s # case _ of
   Sql.Literal e → pure s
   _ → empty
 
+formFieldConstrainValue ∷ SDS.FormFieldValue VM.VarMapValue → SDS.FormFieldValue VM.VarMapValue
+formFieldConstrainValue formField = case formField of
+  SD.CheckBoxes (Identity sels) (Identity options) →
+    let sels' = L.mapMaybe (\sel → F.find (eq sel) options) sels
+    in SD.CheckBoxes (Identity sels') (Identity options)
+  SD.RadioButtons (Identity sel) (Identity options)
+    | F.elem sel options → formField
+    | Just sel' ← L.head options → SD.RadioButtons (Identity sel') (Identity options)
+    | otherwise → formField
+  SD.DropDown mbSel (Identity options)
+    | Just (Identity sel) ← mbSel, F.elem sel options → formField
+    | Just sel ← L.head options → SD.DropDown (Just (Identity sel)) (Identity options)
+    | otherwise → SD.DropDown Nothing (Identity options)
+  _ → formField
+
 formFieldDefaultValue ∷ SDS.FormFieldValue VM.VarMapValue → VM.VarMapValue
-formFieldDefaultValue = case _ of
-  formField@(SD.TextBox tb) → case tb of
+formFieldDefaultValue formField = case formField of
+  SD.TextBox tb → case tb of
     SD.PlainText _ → defaultValue (VM.VarMapValue $ Sql.string "") formField
     SD.Numeric _ → defaultValue (VM.VarMapValue $ Sql.int 0) formField
     _ → defaultValue (VM.VarMapValue Sql.null) formField
   SD.CheckBoxes (Identity sels) (Identity options) →
-    VM.VarMapValue $ Sql.set $
-      L.mapMaybe (\sel → unwrap <$> F.find (eq sel) options) sels
+    VM.VarMapValue $ Sql.set $ unwrap <$> sels
   SD.RadioButtons (Identity sel) (Identity options)
     | F.elem sel options → sel
     | otherwise → VM.VarMapValue $ Sql.null
@@ -69,13 +80,11 @@ formFieldDefaultValue = case _ of
     | Just (Identity sel) ← mbSel, F.elem sel options → sel
     | Just sel ← L.head options → sel
     | otherwise → VM.VarMapValue $ Sql.null
-
   where
-  defaultValue a f =
-    fromMaybe a $ formFieldValueToVarMapValue f
+  defaultValue a = fromMaybe a ∘ formFieldValue
 
-formFieldValueToVarMapValue ∷ SDS.FormFieldValue VM.VarMapValue → M.Maybe VM.VarMapValue
-formFieldValueToVarMapValue v = case v of
+formFieldValue ∷ SDS.FormFieldValue VM.VarMapValue → M.Maybe VM.VarMapValue
+formFieldValue = case _ of
   SD.TextBox tb → VM.VarMapValue <$> do
     tb' ← SD.traverseTextBox unwrap tb
     case tb' of
@@ -84,23 +93,16 @@ formFieldValueToVarMapValue v = case v of
       SD.Numeric (Identity x) →
         pure $ Sql.hugeNum x
       SD.Date (Identity x) →
-        hush
-        $ FD.formatDateTime "YYYY-MM-DD" (DT.DateTime x bottom) <#> \s →
+        hush $ FD.formatDateTime "YYYY-MM-DD" (DT.DateTime x bottom) <#> \s →
           Sql.invokeFunction "DATE" $ pure $ Sql.string s
       SD.Time _ (Identity x) →
-        hush
-        $ FD.formatDateTime "HH:mm:ss" (DT.DateTime bottom x) <#> \s →
+        hush $ FD.formatDateTime "HH:mm:ss" (DT.DateTime bottom x) <#> \s →
           Sql.invokeFunction "TIME" $ pure $ Sql.string s
       SD.DateTime _ (Identity x) →
-        hush
-        $ FD.formatDateTime "YYYY-MM-DDTHH:mm:ssZ" x <#> \s →
+        hush $ FD.formatDateTime "YYYY-MM-DDTHH:mm:ssZ" x <#> \s →
           Sql.invokeFunction "TIMESTAMP" $ pure $ Sql.string s
   SD.CheckBoxes (Identity sel) _ →
-      pure
-      $ VM.VarMapValue
-      $ embed
-      $ Sql.SetLiteral
-      $ L.mapMaybe (getLiteral) sel
+      pure $ VM.VarMapValue $ Sql.set $ L.mapMaybe (getLiteral) sel
   SD.RadioButtons (Identity x) _ →
     VM.VarMapValue <$> getLiteral x
   SD.DropDown mx _ → VM.VarMapValue <$> do

--- a/src/SlamData/Workspace/Card/Markdown/Interpret.purs
+++ b/src/SlamData/Workspace/Card/Markdown/Interpret.purs
@@ -50,6 +50,9 @@ getLiteral (VM.VarMapValue s) = project s # case _ of
   Sql.Literal e → pure s
   _ → empty
 
+-- | A sanity check for form fields. When transitioning form state, you can end up with an
+-- | invalid selection for a given set of options. This just checks that it makes sense,
+-- | otherwise it will pick a sensible default.
 formFieldConstrainValue ∷ SDS.FormFieldValue VM.VarMapValue → SDS.FormFieldValue VM.VarMapValue
 formFieldConstrainValue formField = case formField of
   SD.CheckBoxes (Identity sels) (Identity options) →

--- a/test/src/Test/SlamData/Property/Workspace/Card/Markdown/Model.purs
+++ b/test/src/Test/SlamData/Property/Workspace/Card/Markdown/Model.purs
@@ -26,6 +26,7 @@ import Data.Set as Set
 import Data.StrMap as SM
 
 import SlamData.Workspace.Card.Markdown.Model as M
+import SlamData.Workspace.Card.Markdown.Interpret (formFieldDefaultValue)
 import SlamData.Workspace.Card.Markdown.Component.State as MDS
 
 import Text.Markdown.SlamDown.Halogen.Component.State as SDS
@@ -54,7 +55,7 @@ checkVarMapConstruction =
   quickCheck \(SDS.SlamDownState { document, formState }) →
     let
       inputState = SDS.formStateFromDocument document
-      varMap = MDS.formStateToVarMap inputState formState
+      varMap = Right ∘ formFieldDefaultValue <$> MDS.updateFormState inputState formState
       descKeys = Set.fromFoldable $ SM.keys inputState
       stateKeys = Set.fromFoldable $ SM.keys varMap
     in


### PR DESCRIPTION
Fixes #2044 

The issue was that, while the form state was correctly constrained as part of eval, I was not notifying the UI of the new form state. I've added an `EvalState` constructor for SlamDown forms so that the UI can react to this change.