### PR TITLE
Callout focus vs hover styling in FS tooltips

### DIFF
--- a/sass/_autogen-theme-variables.sass
+++ b/sass/_autogen-theme-variables.sass
@@ -131,6 +131,11 @@ $indicator-error-color: $brand-danger !default
 $filesystem-toolbar-color: $brand-primary !default
 $filesystem-toolbar-hover-color: $brand-primary !default
 
+// Tooltips in the filesystem
+$tooltip-focus-color: brighten($body-bg, 10%, 10%) !default
+$tooltip-hover-color: $brand-primary !default
+$tooltip-hover-text-color: $body-bg !default
+
 // Download Card
 $download-card-sidebar-bg: brighten($body-bg, 3.75%, 5%) !default
 $download-card-sidebar-type-active-bg: $brand-primary !default

--- a/sass/_tooltip.sass
+++ b/sass/_tooltip.sass
@@ -4,14 +4,14 @@
   // Toolip label
   &::before
     background-color: rgba(225, 225, 225, 0.8)
-    color: #fff
+    color: #fffkyy
     content: attr(aria-label)
-    padding: 0.25em 0.5em
+    padding: 0.4rem 0.6rem
     line-height: 1
     text-transform: none
     font-weight: 400
     white-space: nowrap
-    font-size: 1.2rem
+    font-size: 1.1rem
     margin-bottom: 0.5rem
 
   // Tooltip arrow
@@ -46,3 +46,11 @@
   &:hover::after
     opacity: 1
     transition: all 0.2s ease
+
+  &:hover::before
+    background-color: $brand-primary
+    color: #fff
+
+  &:hover::after
+    border-top-color: $brand-primary
+

--- a/sass/_tooltip.sass
+++ b/sass/_tooltip.sass
@@ -3,7 +3,7 @@
 
   // Toolip label
   &::before
-    background-color: rgba(225, 225, 225, 0.8)
+    background-color: $tooltip-focus-color
     color: #fffkyy
     content: attr(aria-label)
     padding: 0.4rem 0.6rem
@@ -21,7 +21,7 @@
     margin-top: -0.1rem
     border-left: 0.5rem solid transparent
     border-right: 0.5rem solid transparent
-    border-top: 0.5rem solid rgba(225, 225, 225, 0.8)
+    border-top: 0.5rem solid $tooltip-focus-color
     font-size: 0
     line-height: 0
 
@@ -48,9 +48,9 @@
     transition: all 0.2s ease
 
   &:hover::before
-    background-color: $brand-primary
-    color: #fff
+    background-color: $tooltip-hover-color
+    color: $tooltip-hover-text-color
 
   &:hover::after
-    border-top-color: $brand-primary
+    border-top-color: $tooltip-hover-color
 

--- a/sass/_tooltip.sass
+++ b/sass/_tooltip.sass
@@ -4,7 +4,7 @@
   // Toolip label
   &::before
     background-color: $tooltip-focus-color
-    color: #fffkyy
+    color: $text-color
     content: attr(aria-label)
     padding: 0.4rem 0.6rem
     line-height: 1

--- a/sass/filesystem/_item.sass
+++ b/sass/filesystem/_item.sass
@@ -20,6 +20,12 @@
     padding: 0
     margin: 0
 
+    button
+      position: relative
+
+    button:hover
+      z-index: 1
+
   &.phantom > .item-content,
   .item-content > a
     display: block

--- a/sass/filesystem/_toolbar.sass
+++ b/sass/filesystem/_toolbar.sass
@@ -28,8 +28,10 @@
     padding: 0 0.75rem
     cursor: pointer
     color: $filesystem-toolbar-color
+    position: relative
 
-    &:hover, &:focus
+    &:hover
+      z-index: 1
       color: $filesystem-toolbar-hover-color
 
   .sd-icon


### PR DESCRIPTION
Fixes #1995 

![tooltips](https://user-images.githubusercontent.com/144058/29139831-2a595b72-7cfd-11e7-9e71-19b7e237b661.gif)

@toastal I could use suggestions on which theme variables to use. I don't really like hard coding these this way.