### PR TITLE
transformed measure axis is measure axis

### DIFF
--- a/src/SlamData/Workspace/Card/Setups/Dimension.purs
+++ b/src/SlamData/Workspace/Card/Setups/Dimension.purs
@@ -236,7 +236,9 @@ axisType d axes = fromMaybe Ax.Category do
     -- If axis is transformed then we should use category
     -- i.e. date_part("year", datetime) isn't continuous
     -- and round(measure, 2) isn't continous too
-    | Just _ ← t = Ax.Category
+    -- But we know, that applying transformation to measure axis
+    -- produce measure axis.
+    | isJust t ∧ (not $ Set.member c axes.value) = Ax.Category
     | Set.member c axes.value = Ax.Measure
     | Set.member c axes.time = Ax.Time
     | Set.member c axes.date = Ax.Date

--- a/src/SlamData/Workspace/Card/Setups/Dimension.purs
+++ b/src/SlamData/Workspace/Card/Setups/Dimension.purs
@@ -238,7 +238,7 @@ axisType d axes = fromMaybe Ax.Category do
     -- and round(measure, 2) isn't continous too
     -- But we know, that applying transformation to measure axis
     -- produce measure axis.
-    | isJust t ∧ (not $ Set.member c axes.value) = Ax.Category
+    | isJust t && not (Set.member c axes.value) = Ax.Category
     | Set.member c axes.value = Ax.Measure
     | Set.member c axes.time = Ax.Time
     | Set.member c axes.date = Ax.Date


### PR DESCRIPTION
Fixes #2076 

@kRITZCREEK Please review. 

The idea is following: when we bucket something using `ROUND|FLOOR|CEIL` we shouldn't transform measure axis to categorical, because its data still _is_ numeric. 

It isn't continuous though, and I'm a bit worrying about situation where no datapoints for some buckets provided. That leads to automatically calculated things on line chart. 

Other solution is modifying sorting function, but I don't like this approach. Because data is analyzed and axis type is the way of judging if we're going to compare points as numbers or strings. ¯\_(ツ)_/¯