### PR TITLE
Restore deleted auth_redirect

### DIFF
--- a/public/auth_redirect.html
+++ b/public/auth_redirect.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>SlamData</title>
+    <meta charset="UTF-8">
+    <script type="text/javascript" src="js/auth_redirect.js"></script>
+  </head>
+  <body>
+  </body>
+</html>


### PR DESCRIPTION
It went missing in #2112, and broke the ability to log in